### PR TITLE
Début de test de bout en bout des fonctions du map reduce algo2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ dbmongo/export/mongo_dump
 rsignauxfaibles_*.tar.gz
 script/archive/*
 dbmongo/lib/engine/jsFunctions.go
+dbmongo/js/test/test_data_algo2

--- a/dbmongo/js/test/test_map_reduce_algo2.js
+++ b/dbmongo/js/test/test_map_reduce_algo2.js
@@ -2,3 +2,5 @@ function map(entrepriseData){
 
   return entrepriseData;
 }
+
+debug("hello");

--- a/dbmongo/js/test/test_map_reduce_algo2.js
+++ b/dbmongo/js/test/test_map_reduce_algo2.js
@@ -1,10 +1,11 @@
 
 
 const notreMap = (testData) => {
-  const results = [];
-  emit = (result) => results.push(result);
-  map(testData); // will call emit an inderminate number of times
+  const results = {};
+  emit = (key, value) => results[key] = value;
+  map.call(testData); // will call emit an inderminate number of times
+  // testData contains _id and value properties. testData is passed as this
   return results;
 };
 
-debug(JSON.stringify(notreMap(testData), null, 2));
+debug(JSON.stringify(notreMap(testData[0]), null, 2));

--- a/dbmongo/js/test/test_map_reduce_algo2.js
+++ b/dbmongo/js/test/test_map_reduce_algo2.js
@@ -10,9 +10,9 @@ offset_effectif = 2
 const notreMap = (testData) => {
   const results = [];
   emit = (key, value) => results.push({"_id": key, value});
-  map.call(testData); // will call emit an inderminate number of times
+  testData.forEach(entrepriseOuEtablissement => map.call(entrepriseOuEtablissement)); // will call emit an inderminate number of times
   // testData contains _id and value properties. testData is passed as this
   return results;
 };
 
-print(JSON.stringify(notreMap(testData[0]), null, 2));
+print(JSON.stringify(notreMap(testData), null, 2));

--- a/dbmongo/js/test/test_map_reduce_algo2.js
+++ b/dbmongo/js/test/test_map_reduce_algo2.js
@@ -1,0 +1,4 @@
+function map(entrepriseData){
+
+  return entrepriseData;
+}

--- a/dbmongo/js/test/test_map_reduce_algo2.js
+++ b/dbmongo/js/test/test_map_reduce_algo2.js
@@ -1,11 +1,18 @@
 
+f = this;
+actual_batch = "2002_1";
+date_debut = new Date("2014-01-01")
+date_fin = new Date("2016-01-01")
+serie_periode = f.generatePeriodSerie(date_debut, date_fin);
+includes = {"all": true}
+offset_effectif = 2
 
 const notreMap = (testData) => {
-  const results = {};
-  emit = (key, value) => results[key] = value;
+  const results = [];
+  emit = (key, value) => results.push({"_id": key, value});
   map.call(testData); // will call emit an inderminate number of times
   // testData contains _id and value properties. testData is passed as this
   return results;
 };
 
-debug(JSON.stringify(notreMap(testData[0]), null, 2));
+print(JSON.stringify(notreMap(testData[0]), null, 2));

--- a/dbmongo/js/test/test_map_reduce_algo2.js
+++ b/dbmongo/js/test/test_map_reduce_algo2.js
@@ -1,7 +1,10 @@
-function map(entrepriseData){
 
 
-  return entrepriseData;
-}
+const notreMap = (testData) => {
+  const results = [];
+  emit = (result) => results.push(result);
+  map(testData); // will call emit an inderminate number of times
+  return results;
+};
 
-debug(JSON.stringify(map(testData), null, 2));
+debug(JSON.stringify(notreMap(testData), null, 2));

--- a/dbmongo/js/test/test_map_reduce_algo2.js
+++ b/dbmongo/js/test/test_map_reduce_algo2.js
@@ -1,6 +1,7 @@
 function map(entrepriseData){
 
+
   return entrepriseData;
 }
 
-debug("hello");
+debug(JSON.stringify(map(testData), null, 2));

--- a/dbmongo/js/test/test_map_reduce_algo2.sh
+++ b/dbmongo/js/test/test_map_reduce_algo2.sh
@@ -1,0 +1,4 @@
+mkdir ./test_data_algo2
+scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_data_algo2/
+# Tests here
+rm -rf ./test_data_algo2

--- a/dbmongo/js/test/test_map_reduce_algo2.sh
+++ b/dbmongo/js/test/test_map_reduce_algo2.sh
@@ -1,4 +1,10 @@
-mkdir ./test_data_algo2
-scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_data_algo2/
+# mkdir ./test_data_algo2
+# scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_data_algo2/
+
 # Tests here
-rm -rf ./test_data_algo2
+cat ../reduce.algo2/*.js >./test_data_algo2/jsFunctions.js
+cat ../common/*.js >>./test_data_algo2/jsFunctions.js
+jsc ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js
+
+# Clean up
+# rm -rf ./test_data_algo2

--- a/dbmongo/js/test/test_map_reduce_algo2.sh
+++ b/dbmongo/js/test/test_map_reduce_algo2.sh
@@ -1,10 +1,12 @@
-# mkdir ./test_data_algo2
-# scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_data_algo2/
+mkdir ./test_data_algo2
+scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_data_algo2/
 
 # Tests here
+
+echo "ISODate = (dateString) => new Date(dateString); NumberInt = (int) => int; testData = $(cat ./test_data_algo2/reduce_test_data.json)" > ./test_data_algo2/reduce_test_data.js
 cat ../reduce.algo2/*.js >./test_data_algo2/jsFunctions.js
 cat ../common/*.js >>./test_data_algo2/jsFunctions.js
-jsc ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js
+jsc ./test_data_algo2/reduce_test_data.js ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js
 
 # Clean up
 # rm -rf ./test_data_algo2

--- a/dbmongo/js/test/test_map_reduce_algo2.sh
+++ b/dbmongo/js/test/test_map_reduce_algo2.sh
@@ -6,7 +6,7 @@ scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_
 echo "ISODate = (dateString) => new Date(dateString); NumberInt = (int) => int; testData = $(cat ./test_data_algo2/reduce_test_data.json)" > ./test_data_algo2/reduce_test_data.js
 cat ../reduce.algo2/*.js >./test_data_algo2/jsFunctions.js
 cat ../common/*.js >>./test_data_algo2/jsFunctions.js
-jsc ./test_data_algo2/reduce_test_data.js ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js
+jsc ./test_data_algo2/reduce_test_data.js ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js > ./test_data_algo2/stdout.log
 
 # Clean up
 # rm -rf ./test_data_algo2

--- a/dbmongo/js/test/test_map_reduce_algo2.sh
+++ b/dbmongo/js/test/test_map_reduce_algo2.sh
@@ -4,9 +4,9 @@ scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_
 # Tests here
 
 echo "ISODate = (dateString) => new Date(dateString); NumberInt = (int) => int; testData = $(cat ./test_data_algo2/reduce_test_data.json)" > ./test_data_algo2/reduce_test_data.js
-cat ../reduce.algo2/*.js >./test_data_algo2/jsFunctions.js
-cat ../common/*.js >>./test_data_algo2/jsFunctions.js
-jsc ./test_data_algo2/reduce_test_data.js ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js 2> ./test_data_algo2/stdout.log
+cat ../common/*.js >./test_data_algo2/jsFunctions.js
+cat ../reduce.algo2/*.js >>./test_data_algo2/jsFunctions.js
+jsc ./test_data_algo2/reduce_test_data.js ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js > ./test_data_algo2/stdout.log
 
 # Clean up
 # rm -rf ./test_data_algo2

--- a/dbmongo/js/test/test_map_reduce_algo2.sh
+++ b/dbmongo/js/test/test_map_reduce_algo2.sh
@@ -6,7 +6,7 @@ scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_
 echo "ISODate = (dateString) => new Date(dateString); NumberInt = (int) => int; testData = $(cat ./test_data_algo2/reduce_test_data.json)" > ./test_data_algo2/reduce_test_data.js
 cat ../reduce.algo2/*.js >./test_data_algo2/jsFunctions.js
 cat ../common/*.js >>./test_data_algo2/jsFunctions.js
-jsc ./test_data_algo2/reduce_test_data.js ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js > ./test_data_algo2/stdout.log
+jsc ./test_data_algo2/reduce_test_data.js ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js 2> ./test_data_algo2/stdout.log
 
 # Clean up
 # rm -rf ./test_data_algo2


### PR DESCRIPTION
Début de test de bout en bout des fonctions du map reduce algo2. 
Le test nécessite l'accès à des données anonymisées mais confidentielles.  

TODO: 
- Refacto: définir toutes les fonctions de substitution (ISODate, NumberInt) dans le fichier js. 
- Refacto: Retirer les appels à "cat" et faire un one liner "jsc"
- Fix: jsc retourne "Invalid Date" sous MacOSX à la commande: 
`new Date("2016-03-01T00:00:00.000+0000")`

