### PR TITLE
fix(test): Corrige les valeurs `null` de `effectifs`, sur macos

### DIFF
--- a/dbmongo/js/test/test_map_reduce_algo2.js
+++ b/dbmongo/js/test/test_map_reduce_algo2.js
@@ -13,11 +13,11 @@ f = this;
 
 // Define global parameters that are required by JS functions
 actual_batch = "2002_1";
-date_debut = new Date("2014-01-01")
-date_fin = new Date("2016-01-01")
+date_debut = new Date("2014-01-01");
+date_fin = new Date("2016-01-01");
 serie_periode = f.generatePeriodSerie(date_debut, date_fin);
-includes = {"all": true}
-offset_effectif = 2
+includes = { "all": true };
+offset_effectif = 2;
 
 // Run a map() function designed for MongoDB, i.e. that calls emit() an
 // inderminate number of times, instead of returning one value per iteration.

--- a/dbmongo/js/test/test_map_reduce_algo2.js
+++ b/dbmongo/js/test/test_map_reduce_algo2.js
@@ -15,4 +15,10 @@ const notreMap = (testData) => {
   return results;
 };
 
+// Generate a realistic test data set
+const testData = makeTestData({
+  ISODate: (dateString) => new Date(dateString),
+  NumberInt: (int) => int,
+});
+
 print(JSON.stringify(notreMap(testData), null, 2));

--- a/dbmongo/js/test/test_map_reduce_algo2.js
+++ b/dbmongo/js/test/test_map_reduce_algo2.js
@@ -30,7 +30,7 @@ function runMongoMap (testData, mapFct) {
 
 // Generate a realistic test data set
 const testData = makeTestData({
-  ISODate: (dateString) => new Date(dateString),
+  ISODate: (dateString) => new Date(dateString.replace('+0000', '+00:00')), // make sure that timezone format complies with the spec
   NumberInt: (int) => int,
 });
 

--- a/dbmongo/js/test/test_map_reduce_algo2.js
+++ b/dbmongo/js/test/test_map_reduce_algo2.js
@@ -35,4 +35,4 @@ const testData = makeTestData({
 });
 
 // Print the output of the global map() function
-print(JSON.stringify(runMongoMap(testData, mapFct), null, 2));
+print(JSON.stringify(runMongoMap(testData, map), null, 2));

--- a/dbmongo/js/test/test_map_reduce_algo2.sh
+++ b/dbmongo/js/test/test_map_reduce_algo2.sh
@@ -1,13 +1,17 @@
+# This golden-file-based test runner was designed to prevent
+# regressions on the JS functions (common + algo2) used to compute the
+# "Features" collection from the "RawData" collection.
+
 # Download realistic data set
 mkdir ./test_data_algo2
 scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_data_algo2/
 
 # Run tests
 echo "makeTestData = ({ ISODate, NumberInt }) => ($(cat ./test_data_algo2/reduce_test_data.json));" > ./test_data_algo2/reduce_test_data.js
-cat ../common/*.js >./test_data_algo2/jsFunctions.js
-cat ../reduce.algo2/*.js >>./test_data_algo2/jsFunctions.js
-jsc ./test_data_algo2/reduce_test_data.js ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js > ./test_data_algo2/stdout.log
+jsc ./test_data_algo2/reduce_test_data.js ../common/*.js ../reduce.algo2/*.js ./test_map_reduce_algo2.js > ./test_data_algo2/stdout.log
 cat ./test_data_algo2/stdout.log
+
+# TODO: compare stdout.log with golden file, return non-zero exit code if any difference is found
 
 # Clean up
 rm -rf ./test_data_algo2

--- a/dbmongo/js/test/test_map_reduce_algo2.sh
+++ b/dbmongo/js/test/test_map_reduce_algo2.sh
@@ -3,15 +3,21 @@
 # "Features" collection from the "RawData" collection.
 
 # Download realistic data set
-mkdir ./test_data_algo2
-scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_data_algo2/
+TMP_PATH="./test_data_algo2"
+mkdir ${TMP_PATH}
+scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ${TMP_PATH}/
+
+# Prepare test data set
+JSON_TEST_DATASET="$(cat ./test_data_algo2/reduce_test_data.json)"
+echo "makeTestData = ({ ISODate, NumberInt }) => (${JSON_TEST_DATASET});" \
+  > ${TMP_PATH}/reduce_test_data.js
 
 # Run tests
-echo "makeTestData = ({ ISODate, NumberInt }) => ($(cat ./test_data_algo2/reduce_test_data.json));" > ./test_data_algo2/reduce_test_data.js
-jsc ./test_data_algo2/reduce_test_data.js ../common/*.js ../reduce.algo2/*.js ./test_map_reduce_algo2.js > ./test_data_algo2/stdout.log
-cat ./test_data_algo2/stdout.log
+jsc ${TMP_PATH}/reduce_test_data.js ../common/*.js ../reduce.algo2/*.js ./test_map_reduce_algo2.js \
+  > ${TMP_PATH}/stdout.log
+cat ${TMP_PATH}/stdout.log
 
 # TODO: compare stdout.log with golden file, return non-zero exit code if any difference is found
 
 # Clean up
-rm -rf ./test_data_algo2
+rm -rf ${TMP_PATH}

--- a/dbmongo/js/test/test_map_reduce_algo2.sh
+++ b/dbmongo/js/test/test_map_reduce_algo2.sh
@@ -1,12 +1,12 @@
+# Download realistic data set
 mkdir ./test_data_algo2
 scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_data_algo2/
 
-# Tests here
-
+# Run tests
 echo "ISODate = (dateString) => new Date(dateString); NumberInt = (int) => int; testData = $(cat ./test_data_algo2/reduce_test_data.json)" > ./test_data_algo2/reduce_test_data.js
 cat ../common/*.js >./test_data_algo2/jsFunctions.js
 cat ../reduce.algo2/*.js >>./test_data_algo2/jsFunctions.js
 jsc ./test_data_algo2/reduce_test_data.js ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js > ./test_data_algo2/stdout.log
 
 # Clean up
-# rm -rf ./test_data_algo2
+rm -rf ./test_data_algo2

--- a/dbmongo/js/test/test_map_reduce_algo2.sh
+++ b/dbmongo/js/test/test_map_reduce_algo2.sh
@@ -3,10 +3,11 @@ mkdir ./test_data_algo2
 scp stockage:/home/centos/opensignauxfaibles_tests/reduce_test_data.json ./test_data_algo2/
 
 # Run tests
-echo "ISODate = (dateString) => new Date(dateString); NumberInt = (int) => int; testData = $(cat ./test_data_algo2/reduce_test_data.json)" > ./test_data_algo2/reduce_test_data.js
+echo "makeTestData = ({ ISODate, NumberInt }) => ($(cat ./test_data_algo2/reduce_test_data.json));" > ./test_data_algo2/reduce_test_data.js
 cat ../common/*.js >./test_data_algo2/jsFunctions.js
 cat ../reduce.algo2/*.js >>./test_data_algo2/jsFunctions.js
 jsc ./test_data_algo2/reduce_test_data.js ./test_data_algo2/jsFunctions.js ./test_map_reduce_algo2.js > ./test_data_algo2/stdout.log
+cat ./test_data_algo2/stdout.log
 
 # Clean up
 rm -rf ./test_data_algo2


### PR DESCRIPTION
Adresse les TODOs listés dans PR #4: 

- [x] Refacto: définir toutes les fonctions de substitution (`ISODate`, `NumberInt`) dans le fichier js. 
- [x] Refacto: Retirer les appels à `cat` et faire un one liner `jsc`
- [x] Fix: jsc retourne `Invalid Date` sous MacOSX à la commande: 
`new Date("2016-03-01T00:00:00.000+0000")`

