### PR TITLE
fix: Erreur de génération de parseur 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Solution logicielle pour la détection anticipée d'entreprises en difficulté
 ```bash
 $ go get -v -d -u github.com/signaux-faibles/opensignauxfaibles/dbmongo
 $ cd $(go env GOPATH)/src/github.com/signaux-faibles/opensignauxfaibles/dbmongo
-$ cd lib/engine
-$ go generate # pour générer jsFunctions
-$ cd -
+$ go generate ./...
 $ go build
 ```
 

--- a/dbmongo/lib/marshal/generateParser.go
+++ b/dbmongo/lib/marshal/generateParser.go
@@ -23,15 +23,16 @@ func main() {
 	for _, file := range files {
 		po := marshal.ParserOptions{}
 		wd, _ := os.Getwd()
-		err := po.ReadOptions(filepath.Join(wd, folderName, file.Name()))
+		fileName := filepath.Join(wd, folderName, file.Name())
+		err := po.ReadOptions(fileName)
 		if err != nil {
-			log.Fatal("File could not be read: ", err.Error())
+			log.Fatal("File could not be read: ", fileName, "\n", err.Error())
 		}
 		dirName := strings.TrimSuffix(file.Name(), filepath.Ext(file.Name()))
 
 		err = os.MkdirAll(dirName, os.ModePerm)
 		if err != nil {
-			log.Fatal("Could not create directory: " + err.Error())
+			log.Fatal("Could not create directory: ", dirName, err.Error())
 		}
 		// GenerateParser(po, filepath.Join(dirName, dirName+"Parser.go"))
 	}

--- a/dbmongo/lib/marshal/parserSpecs/apdemande.yaml
+++ b/dbmongo/lib/marshal/parserSpecs/apdemande.yaml
@@ -16,7 +16,7 @@ fields:
   - go_name: Siret
     csv_name: ETAB_SIRET
     csv_col: 0
-    json_name: -
+    json_name: "-"
     parser: ParseString
     if_empty: fatal
     if_invalid: sfregexp.RegexpDict["siret"]
@@ -109,5 +109,3 @@ fields:
     if_empty: fatal
     if_invalid: fatal
     validity_regex: nil `json:"effectif_consomme" bson:"effectif_consomme"
-
-

--- a/dbmongo/lib/marshal/parserSpecs/apdemande.yaml
+++ b/dbmongo/lib/marshal/parserSpecs/apdemande.yaml
@@ -47,7 +47,7 @@ fields:
     validity_regex: nil `json:"date_statut" bson:"date_statut"
   - go_name: Periode
     csv_name:
-    csv_col: 0hta
+    csv_col: 0
     json_name:
     parser: Parsemisc.Periode hta
     if_empty: fatal


### PR DESCRIPTION
Problème réglé par cette PR:

```
$ cd dbmongo
$ go generate -x ./...
[...]
go run generateParser.go
2020/04/28 11:41:55 File could not be read: yaml: line 19: block sequence entries are not allowed in this context
exit status 1
lib/marshal/readOptions.go:14: running "go": exit status 1
```