### PR TITLE
fix: Rapport d'erreurs de convert_diane.sh

### DIFF
--- a/dbmongo/lib/diane/main.go
+++ b/dbmongo/lib/diane/main.go
@@ -390,7 +390,7 @@ func parseDianeFile(path string, outputChannel chan engine.Tuple, event engine.E
 	cmd.Start()
 	defer func() {
 		if err := cmd.Wait(); err != nil {
-			tracker.Error(errors.New("[convert_diane.sh] failed with " + err.Error()))
+			event.Debug("[convert_diane.sh] failed with " + err.Error())
 		}
 	}()
 

--- a/dbmongo/lib/diane/main.go
+++ b/dbmongo/lib/diane/main.go
@@ -2,6 +2,7 @@ package diane
 
 import (
 	"encoding/csv"
+	"errors"
 	"io"
 	"io/ioutil"
 	"log"
@@ -115,7 +116,303 @@ func (diane Diane) Scope() string {
 	return "entreprise"
 }
 
-// Parser produit les données Diane
+func parseDianeFile(path string, outputChannel chan engine.Tuple, event engine.Event) (abort bool, err error) {
+	tracker := gournal.NewTracker(
+		map[string]string{"path": path},
+		engine.TrackerReports)
+
+	cmdPath := []string{filepath.Join(viper.GetString("SCRIPTDIANE_DIR"), "convert_diane.sh"), viper.GetString("APP_DATA") + path}
+	cmd := exec.Command("/bin/bash", cmdPath...)
+
+	stdout, err := cmd.StdoutPipe()
+	defer stdout.Close()
+	if err != nil {
+		event.Critical(path + ": erreur à l'ouverture, abandon")
+		return false, errors.New(path + ": erreur à l'ouverture, abandon")
+	}
+	event.Debug(path + ": ouverture")
+
+	stderr, err := cmd.StderrPipe()
+	defer stderr.Close()
+	if err != nil {
+		event.Critical(path + ": erreur à l'ouverture, abandon")
+		return false, errors.New(path + ": erreur à l'ouverture, abandon")
+	}
+	event.Debug(path + ": ouverture")
+
+	reader := csv.NewReader(stdout)
+	reader.Comma = ';'
+	reader.LazyQuotes = true
+	cmd.Start()
+	defer func() {
+		slurp, _ := ioutil.ReadAll(stderr)
+		if err := cmd.Wait(); err != nil {
+			log.Printf("Preprocessing script failed with %v:\n%s\n", err, slurp)
+		}
+	}()
+
+	_, err = reader.Read() // Discard header
+	if err != nil {
+		event.Critical(tracker.Report("fatalError"))
+		return true, errors.New("fatalError: lecture depuis la sortie du script")
+	}
+	for {
+		row, err := reader.Read()
+		tracker.Error(err)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			event.Critical(tracker.Report("fatalError"))
+			break
+		}
+		diane := Diane{}
+
+		if len(row) >= 83 {
+
+			if i, err := strconv.Atoi(row[0]); err == nil {
+				diane.Annee = &i
+			}
+			diane.NomEntreprise = row[2]
+			diane.NumeroSiren = row[3]
+			diane.StatutJuridique = row[4]
+			diane.ProcedureCollective = (row[5] == "Oui")
+
+			if i, err := strconv.Atoi(row[6]); err == nil {
+				diane.EffectifConsolide = &i
+			}
+			if i, err := strconv.ParseFloat(row[7], 64); err == nil {
+				diane.DetteFiscaleEtSociale = &i
+			}
+			if i, err := strconv.ParseFloat(row[8], 64); err == nil {
+				diane.FraisDeRetD = &i
+			}
+			if i, err := strconv.ParseFloat(row[9], 64); err == nil {
+				diane.ConcesBrevEtDroitsSim = &i
+			}
+			if i, err := strconv.Atoi(row[10]); err == nil {
+				diane.NombreEtabSecondaire = &i
+			}
+			if i, err := strconv.Atoi(row[11]); err == nil {
+				diane.NombreFiliale = &i
+			}
+			if i, err := strconv.Atoi(row[12]); err == nil {
+				diane.TailleCompoGroupe = &i
+			}
+			if i, err := time.Parse("02/01/2006", row[14]); err == nil {
+				diane.ArreteBilan = i
+			}
+			if i, err := strconv.Atoi(row[15]); err == nil {
+				diane.NombreMois = &i
+			}
+			if i, err := strconv.ParseFloat(row[16], 64); err == nil {
+				diane.ConcoursBancaireCourant = &i
+			}
+			if i, err := strconv.ParseFloat(row[17], 64); err == nil {
+				diane.EquilibreFinancier = &i
+			}
+			if i, err := strconv.ParseFloat(row[18], 64); err == nil {
+				diane.IndependanceFinanciere = &i
+			}
+			if i, err := strconv.ParseFloat(row[19], 64); err == nil {
+				diane.Endettement = &i
+			}
+			if i, err := strconv.ParseFloat(row[20], 64); err == nil {
+				diane.AutonomieFinanciere = &i
+			}
+			if i, err := strconv.ParseFloat(row[21], 64); err == nil {
+				diane.DegreImmoCorporelle = &i
+			}
+			if i, err := strconv.ParseFloat(row[22], 64); err == nil {
+				diane.FinancementActifCirculant = &i
+			}
+			if i, err := strconv.ParseFloat(row[23], 64); err == nil {
+				diane.LiquiditeGenerale = &i
+			}
+			if i, err := strconv.ParseFloat(row[24], 64); err == nil {
+				diane.LiquiditeReduite = &i
+			}
+			if i, err := strconv.ParseFloat(row[25], 64); err == nil {
+				diane.RotationStocks = &i
+			}
+			if i, err := strconv.ParseFloat(row[26], 64); err == nil {
+				diane.CreditClient = &i
+			}
+			if i, err := strconv.ParseFloat(row[27], 64); err == nil {
+				diane.CreditFournisseur = &i
+			}
+			if i, err := strconv.ParseFloat(row[28], 64); err == nil {
+				diane.CAparEffectif = &i
+			}
+			if i, err := strconv.ParseFloat(row[29], 64); err == nil {
+				diane.TauxInteretFinancier = &i
+			}
+			if i, err := strconv.ParseFloat(row[30], 64); err == nil {
+				diane.TauxInteretSurCA = &i
+			}
+			if i, err := strconv.ParseFloat(row[31], 64); err == nil {
+				diane.EndettementGlobal = &i
+			}
+			if i, err := strconv.ParseFloat(row[32], 64); err == nil {
+				diane.TauxEndettement = &i
+			}
+			if i, err := strconv.ParseFloat(row[33], 64); err == nil {
+				diane.CapaciteRemboursement = &i
+			}
+			if i, err := strconv.ParseFloat(row[34], 64); err == nil {
+				diane.CapaciteAutofinancement = &i
+			}
+			if i, err := strconv.ParseFloat(row[35], 64); err == nil {
+				diane.CouvertureCaFdr = &i
+			}
+			if i, err := strconv.ParseFloat(row[36], 64); err == nil {
+				diane.CouvertureCaBesoinFdr = &i
+			}
+			if i, err := strconv.ParseFloat(row[37], 64); err == nil {
+				diane.PoidsBFRExploitation = &i
+			}
+			if i, err := strconv.ParseFloat(row[38], 64); err == nil {
+				diane.Exportation = &i
+			}
+			if i, err := strconv.ParseFloat(row[39], 64); err == nil {
+				diane.EfficaciteEconomique = &i
+			}
+			if i, err := strconv.ParseFloat(row[40], 64); err == nil {
+				diane.ProductivitePotentielProduction = &i
+			}
+			if i, err := strconv.ParseFloat(row[41], 64); err == nil {
+				diane.ProductiviteCapitalFinancier = &i
+			}
+			if i, err := strconv.ParseFloat(row[42], 64); err == nil {
+				diane.ProductiviteCapitalInvesti = &i
+			}
+			if i, err := strconv.ParseFloat(row[43], 64); err == nil {
+				diane.TauxDInvestissementProductif = &i
+			}
+			if i, err := strconv.ParseFloat(row[44], 64); err == nil {
+				diane.RentabiliteEconomique = &i
+			}
+			if i, err := strconv.ParseFloat(row[45], 64); err == nil {
+				diane.Performance = &i
+			}
+			if i, err := strconv.ParseFloat(row[46], 64); err == nil {
+				diane.RendementBrutFondsPropres = &i
+			}
+			if i, err := strconv.ParseFloat(row[47], 64); err == nil {
+				diane.RentabiliteNette = &i
+			}
+			if i, err := strconv.ParseFloat(row[48], 64); err == nil {
+				diane.RendementCapitauxPropres = &i
+			}
+			if i, err := strconv.ParseFloat(row[49], 64); err == nil {
+				diane.RendementRessourcesDurables = &i
+			}
+			if i, err := strconv.ParseFloat(row[50], 64); err == nil {
+				diane.TauxMargeCommerciale = &i
+			}
+			if i, err := strconv.ParseFloat(row[51], 64); err == nil {
+				diane.TauxValeurAjoutee = &i
+			}
+			if i, err := strconv.ParseFloat(row[52], 64); err == nil {
+				diane.PartSalaries = &i
+			}
+			if i, err := strconv.ParseFloat(row[53], 64); err == nil {
+				diane.PartEtat = &i
+			}
+			if i, err := strconv.ParseFloat(row[54], 64); err == nil {
+				diane.PartPreteur = &i
+			}
+			if i, err := strconv.ParseFloat(row[55], 64); err == nil {
+				diane.PartAutofinancement = &i
+			}
+			if i, err := strconv.ParseFloat(row[56], 64); err == nil {
+				diane.CA = &i
+			}
+			if i, err := strconv.ParseFloat(row[57], 64); err == nil {
+				diane.CAExportation = &i
+			}
+			if i, err := strconv.ParseFloat(row[58], 64); err == nil {
+				diane.AchatMarchandises = &i
+			}
+			if i, err := strconv.ParseFloat(row[60], 64); err == nil {
+				diane.AchatMatieresPremieres = &i
+			}
+			if i, err := strconv.ParseFloat(row[61], 64); err == nil {
+				diane.Production = &i
+			}
+			if i, err := strconv.ParseFloat(row[62], 64); err == nil {
+				diane.MargeCommerciale = &i
+			}
+			if i, err := strconv.ParseFloat(row[63], 64); err == nil {
+				diane.Consommation = &i
+			}
+			if i, err := strconv.ParseFloat(row[64], 64); err == nil {
+				diane.AutresAchatsChargesExternes = &i
+			}
+			if i, err := strconv.ParseFloat(row[65], 64); err == nil {
+				diane.ValeurAjoutee = &i
+			}
+			if i, err := strconv.ParseFloat(row[66], 64); err == nil {
+				diane.ChargePersonnel = &i
+			}
+			if i, err := strconv.ParseFloat(row[67], 64); err == nil {
+				diane.ImpotsTaxes = &i
+			}
+			if i, err := strconv.ParseFloat(row[68], 64); err == nil {
+				diane.SubventionsDExploitation = &i
+			}
+			if i, err := strconv.ParseFloat(row[69], 64); err == nil {
+				diane.ExcedentBrutDExploitation = &i
+			}
+			if i, err := strconv.ParseFloat(row[70], 64); err == nil {
+				diane.AutresProduitsChargesReprises = &i
+			}
+			if i, err := strconv.ParseFloat(row[71], 64); err == nil {
+				diane.DotationAmortissement = &i
+			}
+			if i, err := strconv.ParseFloat(row[72], 64); err == nil {
+				diane.ResultatExpl = &i
+			}
+			if i, err := strconv.ParseFloat(row[73], 64); err == nil {
+				diane.OperationsCommun = &i
+			}
+			if i, err := strconv.ParseFloat(row[74], 64); err == nil {
+				diane.ProduitsFinanciers = &i
+			}
+			if i, err := strconv.ParseFloat(row[75], 64); err == nil {
+				diane.ChargesFinancieres = &i
+			}
+			if i, err := strconv.ParseFloat(row[76], 64); err == nil {
+				diane.Interets = &i
+			}
+			if i, err := strconv.ParseFloat(row[77], 64); err == nil {
+				diane.ResultatAvantImpot = &i
+			}
+			if i, err := strconv.ParseFloat(row[78], 64); err == nil {
+				diane.ProduitExceptionnel = &i
+			}
+			if i, err := strconv.ParseFloat(row[79], 64); err == nil {
+				diane.ChargeExceptionnelle = &i
+			}
+			if i, err := strconv.ParseFloat(row[80], 64); err == nil {
+				diane.ParticipationSalaries = &i
+			}
+			if i, err := strconv.ParseFloat(row[81], 64); err == nil {
+				diane.ImpotBenefice = &i
+			}
+			if i, err := strconv.ParseFloat(row[82], 64); err == nil {
+				diane.BeneficeOuPerte = &i
+			}
+			outputChannel <- diane
+		} else {
+			event.Critical("Ligne invalide. Abandon !")
+		}
+		tracker.Next()
+	} // end of "for" loop
+	event.Debug(tracker.Report("abstract"))
+	return false, nil
+}
+
+// Parser produit les données Diane listées dans un batch
 func Parser(cache engine.Cache, batch *engine.AdminBatch) (chan engine.Tuple, chan engine.Event) {
 	outputChannel := make(chan engine.Tuple)
 	eventChannel := make(chan engine.Event)
@@ -126,301 +423,10 @@ func Parser(cache engine.Cache, batch *engine.AdminBatch) (chan engine.Tuple, ch
 
 	go func() {
 		for _, path := range batch.Files["diane"] {
-			tracker := gournal.NewTracker(
-				map[string]string{"path": path},
-				engine.TrackerReports)
-
-			cmdPath := []string{filepath.Join(viper.GetString("SCRIPTDIANE_DIR"), "convert_diane.sh"), viper.GetString("APP_DATA") + path}
-			cmd := exec.Command("/bin/bash", cmdPath...)
-
-			stdout, err := cmd.StdoutPipe()
-			defer stdout.Close()
-			if err != nil {
-				event.Critical(path + ": erreur à l'ouverture, abandon")
-				continue
-			} else {
-				event.Debug(path + ": ouverture")
-			}
-
-			stderr, err := cmd.StderrPipe()
-			defer stderr.Close()
-			if err != nil {
-				event.Critical(path + ": erreur à l'ouverture, abandon")
-				continue
-			} else {
-				event.Debug(path + ": ouverture")
-			}
-
-			reader := csv.NewReader(stdout)
-			reader.Comma = ';'
-			reader.LazyQuotes = true
-			cmd.Start()
-			defer func() {
-				slurp, _ := ioutil.ReadAll(stderr)
-				if err := cmd.Wait(); err != nil {
-					log.Printf("Preprocessing script failed with %v:\n%s\n", err, slurp)
-				}
-			}()
-
-			_, err = reader.Read() // Discard header
-			if err != nil {
-				event.Critical(tracker.Report("fatalError"))
+			abort, _ := parseDianeFile(path, outputChannel, event)
+			if abort == true {
 				break
 			}
-			for {
-				row, err := reader.Read()
-				tracker.Error(err)
-				if err == io.EOF {
-					break
-				} else if err != nil {
-					event.Critical(tracker.Report("fatalError"))
-					break
-				}
-				diane := Diane{}
-
-				if len(row) >= 83 {
-
-					if i, err := strconv.Atoi(row[0]); err == nil {
-						diane.Annee = &i
-					}
-					diane.NomEntreprise = row[2]
-					diane.NumeroSiren = row[3]
-					diane.StatutJuridique = row[4]
-					diane.ProcedureCollective = (row[5] == "Oui")
-
-					if i, err := strconv.Atoi(row[6]); err == nil {
-						diane.EffectifConsolide = &i
-					}
-					if i, err := strconv.ParseFloat(row[7], 64); err == nil {
-						diane.DetteFiscaleEtSociale = &i
-					}
-					if i, err := strconv.ParseFloat(row[8], 64); err == nil {
-						diane.FraisDeRetD = &i
-					}
-					if i, err := strconv.ParseFloat(row[9], 64); err == nil {
-						diane.ConcesBrevEtDroitsSim = &i
-					}
-					if i, err := strconv.Atoi(row[10]); err == nil {
-						diane.NombreEtabSecondaire = &i
-					}
-					if i, err := strconv.Atoi(row[11]); err == nil {
-						diane.NombreFiliale = &i
-					}
-					if i, err := strconv.Atoi(row[12]); err == nil {
-						diane.TailleCompoGroupe = &i
-					}
-					if i, err := time.Parse("02/01/2006", row[14]); err == nil {
-						diane.ArreteBilan = i
-					}
-					if i, err := strconv.Atoi(row[15]); err == nil {
-						diane.NombreMois = &i
-					}
-					if i, err := strconv.ParseFloat(row[16], 64); err == nil {
-						diane.ConcoursBancaireCourant = &i
-					}
-					if i, err := strconv.ParseFloat(row[17], 64); err == nil {
-						diane.EquilibreFinancier = &i
-					}
-					if i, err := strconv.ParseFloat(row[18], 64); err == nil {
-						diane.IndependanceFinanciere = &i
-					}
-					if i, err := strconv.ParseFloat(row[19], 64); err == nil {
-						diane.Endettement = &i
-					}
-					if i, err := strconv.ParseFloat(row[20], 64); err == nil {
-						diane.AutonomieFinanciere = &i
-					}
-					if i, err := strconv.ParseFloat(row[21], 64); err == nil {
-						diane.DegreImmoCorporelle = &i
-					}
-					if i, err := strconv.ParseFloat(row[22], 64); err == nil {
-						diane.FinancementActifCirculant = &i
-					}
-					if i, err := strconv.ParseFloat(row[23], 64); err == nil {
-						diane.LiquiditeGenerale = &i
-					}
-					if i, err := strconv.ParseFloat(row[24], 64); err == nil {
-						diane.LiquiditeReduite = &i
-					}
-					if i, err := strconv.ParseFloat(row[25], 64); err == nil {
-						diane.RotationStocks = &i
-					}
-					if i, err := strconv.ParseFloat(row[26], 64); err == nil {
-						diane.CreditClient = &i
-					}
-					if i, err := strconv.ParseFloat(row[27], 64); err == nil {
-						diane.CreditFournisseur = &i
-					}
-					if i, err := strconv.ParseFloat(row[28], 64); err == nil {
-						diane.CAparEffectif = &i
-					}
-					if i, err := strconv.ParseFloat(row[29], 64); err == nil {
-						diane.TauxInteretFinancier = &i
-					}
-					if i, err := strconv.ParseFloat(row[30], 64); err == nil {
-						diane.TauxInteretSurCA = &i
-					}
-					if i, err := strconv.ParseFloat(row[31], 64); err == nil {
-						diane.EndettementGlobal = &i
-					}
-					if i, err := strconv.ParseFloat(row[32], 64); err == nil {
-						diane.TauxEndettement = &i
-					}
-					if i, err := strconv.ParseFloat(row[33], 64); err == nil {
-						diane.CapaciteRemboursement = &i
-					}
-					if i, err := strconv.ParseFloat(row[34], 64); err == nil {
-						diane.CapaciteAutofinancement = &i
-					}
-					if i, err := strconv.ParseFloat(row[35], 64); err == nil {
-						diane.CouvertureCaFdr = &i
-					}
-					if i, err := strconv.ParseFloat(row[36], 64); err == nil {
-						diane.CouvertureCaBesoinFdr = &i
-					}
-					if i, err := strconv.ParseFloat(row[37], 64); err == nil {
-						diane.PoidsBFRExploitation = &i
-					}
-					if i, err := strconv.ParseFloat(row[38], 64); err == nil {
-						diane.Exportation = &i
-					}
-					if i, err := strconv.ParseFloat(row[39], 64); err == nil {
-						diane.EfficaciteEconomique = &i
-					}
-					if i, err := strconv.ParseFloat(row[40], 64); err == nil {
-						diane.ProductivitePotentielProduction = &i
-					}
-					if i, err := strconv.ParseFloat(row[41], 64); err == nil {
-						diane.ProductiviteCapitalFinancier = &i
-					}
-					if i, err := strconv.ParseFloat(row[42], 64); err == nil {
-						diane.ProductiviteCapitalInvesti = &i
-					}
-					if i, err := strconv.ParseFloat(row[43], 64); err == nil {
-						diane.TauxDInvestissementProductif = &i
-					}
-					if i, err := strconv.ParseFloat(row[44], 64); err == nil {
-						diane.RentabiliteEconomique = &i
-					}
-					if i, err := strconv.ParseFloat(row[45], 64); err == nil {
-						diane.Performance = &i
-					}
-					if i, err := strconv.ParseFloat(row[46], 64); err == nil {
-						diane.RendementBrutFondsPropres = &i
-					}
-					if i, err := strconv.ParseFloat(row[47], 64); err == nil {
-						diane.RentabiliteNette = &i
-					}
-					if i, err := strconv.ParseFloat(row[48], 64); err == nil {
-						diane.RendementCapitauxPropres = &i
-					}
-					if i, err := strconv.ParseFloat(row[49], 64); err == nil {
-						diane.RendementRessourcesDurables = &i
-					}
-					if i, err := strconv.ParseFloat(row[50], 64); err == nil {
-						diane.TauxMargeCommerciale = &i
-					}
-					if i, err := strconv.ParseFloat(row[51], 64); err == nil {
-						diane.TauxValeurAjoutee = &i
-					}
-					if i, err := strconv.ParseFloat(row[52], 64); err == nil {
-						diane.PartSalaries = &i
-					}
-					if i, err := strconv.ParseFloat(row[53], 64); err == nil {
-						diane.PartEtat = &i
-					}
-					if i, err := strconv.ParseFloat(row[54], 64); err == nil {
-						diane.PartPreteur = &i
-					}
-					if i, err := strconv.ParseFloat(row[55], 64); err == nil {
-						diane.PartAutofinancement = &i
-					}
-					if i, err := strconv.ParseFloat(row[56], 64); err == nil {
-						diane.CA = &i
-					}
-					if i, err := strconv.ParseFloat(row[57], 64); err == nil {
-						diane.CAExportation = &i
-					}
-					if i, err := strconv.ParseFloat(row[58], 64); err == nil {
-						diane.AchatMarchandises = &i
-					}
-					if i, err := strconv.ParseFloat(row[60], 64); err == nil {
-						diane.AchatMatieresPremieres = &i
-					}
-					if i, err := strconv.ParseFloat(row[61], 64); err == nil {
-						diane.Production = &i
-					}
-					if i, err := strconv.ParseFloat(row[62], 64); err == nil {
-						diane.MargeCommerciale = &i
-					}
-					if i, err := strconv.ParseFloat(row[63], 64); err == nil {
-						diane.Consommation = &i
-					}
-					if i, err := strconv.ParseFloat(row[64], 64); err == nil {
-						diane.AutresAchatsChargesExternes = &i
-					}
-					if i, err := strconv.ParseFloat(row[65], 64); err == nil {
-						diane.ValeurAjoutee = &i
-					}
-					if i, err := strconv.ParseFloat(row[66], 64); err == nil {
-						diane.ChargePersonnel = &i
-					}
-					if i, err := strconv.ParseFloat(row[67], 64); err == nil {
-						diane.ImpotsTaxes = &i
-					}
-					if i, err := strconv.ParseFloat(row[68], 64); err == nil {
-						diane.SubventionsDExploitation = &i
-					}
-					if i, err := strconv.ParseFloat(row[69], 64); err == nil {
-						diane.ExcedentBrutDExploitation = &i
-					}
-					if i, err := strconv.ParseFloat(row[70], 64); err == nil {
-						diane.AutresProduitsChargesReprises = &i
-					}
-					if i, err := strconv.ParseFloat(row[71], 64); err == nil {
-						diane.DotationAmortissement = &i
-					}
-					if i, err := strconv.ParseFloat(row[72], 64); err == nil {
-						diane.ResultatExpl = &i
-					}
-					if i, err := strconv.ParseFloat(row[73], 64); err == nil {
-						diane.OperationsCommun = &i
-					}
-					if i, err := strconv.ParseFloat(row[74], 64); err == nil {
-						diane.ProduitsFinanciers = &i
-					}
-					if i, err := strconv.ParseFloat(row[75], 64); err == nil {
-						diane.ChargesFinancieres = &i
-					}
-					if i, err := strconv.ParseFloat(row[76], 64); err == nil {
-						diane.Interets = &i
-					}
-					if i, err := strconv.ParseFloat(row[77], 64); err == nil {
-						diane.ResultatAvantImpot = &i
-					}
-					if i, err := strconv.ParseFloat(row[78], 64); err == nil {
-						diane.ProduitExceptionnel = &i
-					}
-					if i, err := strconv.ParseFloat(row[79], 64); err == nil {
-						diane.ChargeExceptionnelle = &i
-					}
-					if i, err := strconv.ParseFloat(row[80], 64); err == nil {
-						diane.ParticipationSalaries = &i
-					}
-					if i, err := strconv.ParseFloat(row[81], 64); err == nil {
-						diane.ImpotBenefice = &i
-					}
-					if i, err := strconv.ParseFloat(row[82], 64); err == nil {
-						diane.BeneficeOuPerte = &i
-					}
-					outputChannel <- diane
-				} else {
-					event.Critical("Ligne invalide. Abandon !")
-				}
-				tracker.Next()
-			} // end of "for" loop
-			event.Debug(tracker.Report("abstract"))
-
 		}
 		close(eventChannel)
 		close(outputChannel)

--- a/dbmongo/lib/diane/main.go
+++ b/dbmongo/lib/diane/main.go
@@ -116,6 +116,245 @@ func (diane Diane) Scope() string {
 	return "entreprise"
 }
 
+// parseDianeRow construit un objet Diane à partir d'une ligne de valeurs récupérée depuis un fichier
+func parseDianeRow(row []string) (diane Diane) {
+	if i, err := strconv.Atoi(row[0]); err == nil {
+		diane.Annee = &i
+	}
+	diane.NomEntreprise = row[2]
+	diane.NumeroSiren = row[3]
+	diane.StatutJuridique = row[4]
+	diane.ProcedureCollective = (row[5] == "Oui")
+
+	if i, err := strconv.Atoi(row[6]); err == nil {
+		diane.EffectifConsolide = &i
+	}
+	if i, err := strconv.ParseFloat(row[7], 64); err == nil {
+		diane.DetteFiscaleEtSociale = &i
+	}
+	if i, err := strconv.ParseFloat(row[8], 64); err == nil {
+		diane.FraisDeRetD = &i
+	}
+	if i, err := strconv.ParseFloat(row[9], 64); err == nil {
+		diane.ConcesBrevEtDroitsSim = &i
+	}
+	if i, err := strconv.Atoi(row[10]); err == nil {
+		diane.NombreEtabSecondaire = &i
+	}
+	if i, err := strconv.Atoi(row[11]); err == nil {
+		diane.NombreFiliale = &i
+	}
+	if i, err := strconv.Atoi(row[12]); err == nil {
+		diane.TailleCompoGroupe = &i
+	}
+	if i, err := time.Parse("02/01/2006", row[14]); err == nil {
+		diane.ArreteBilan = i
+	}
+	if i, err := strconv.Atoi(row[15]); err == nil {
+		diane.NombreMois = &i
+	}
+	if i, err := strconv.ParseFloat(row[16], 64); err == nil {
+		diane.ConcoursBancaireCourant = &i
+	}
+	if i, err := strconv.ParseFloat(row[17], 64); err == nil {
+		diane.EquilibreFinancier = &i
+	}
+	if i, err := strconv.ParseFloat(row[18], 64); err == nil {
+		diane.IndependanceFinanciere = &i
+	}
+	if i, err := strconv.ParseFloat(row[19], 64); err == nil {
+		diane.Endettement = &i
+	}
+	if i, err := strconv.ParseFloat(row[20], 64); err == nil {
+		diane.AutonomieFinanciere = &i
+	}
+	if i, err := strconv.ParseFloat(row[21], 64); err == nil {
+		diane.DegreImmoCorporelle = &i
+	}
+	if i, err := strconv.ParseFloat(row[22], 64); err == nil {
+		diane.FinancementActifCirculant = &i
+	}
+	if i, err := strconv.ParseFloat(row[23], 64); err == nil {
+		diane.LiquiditeGenerale = &i
+	}
+	if i, err := strconv.ParseFloat(row[24], 64); err == nil {
+		diane.LiquiditeReduite = &i
+	}
+	if i, err := strconv.ParseFloat(row[25], 64); err == nil {
+		diane.RotationStocks = &i
+	}
+	if i, err := strconv.ParseFloat(row[26], 64); err == nil {
+		diane.CreditClient = &i
+	}
+	if i, err := strconv.ParseFloat(row[27], 64); err == nil {
+		diane.CreditFournisseur = &i
+	}
+	if i, err := strconv.ParseFloat(row[28], 64); err == nil {
+		diane.CAparEffectif = &i
+	}
+	if i, err := strconv.ParseFloat(row[29], 64); err == nil {
+		diane.TauxInteretFinancier = &i
+	}
+	if i, err := strconv.ParseFloat(row[30], 64); err == nil {
+		diane.TauxInteretSurCA = &i
+	}
+	if i, err := strconv.ParseFloat(row[31], 64); err == nil {
+		diane.EndettementGlobal = &i
+	}
+	if i, err := strconv.ParseFloat(row[32], 64); err == nil {
+		diane.TauxEndettement = &i
+	}
+	if i, err := strconv.ParseFloat(row[33], 64); err == nil {
+		diane.CapaciteRemboursement = &i
+	}
+	if i, err := strconv.ParseFloat(row[34], 64); err == nil {
+		diane.CapaciteAutofinancement = &i
+	}
+	if i, err := strconv.ParseFloat(row[35], 64); err == nil {
+		diane.CouvertureCaFdr = &i
+	}
+	if i, err := strconv.ParseFloat(row[36], 64); err == nil {
+		diane.CouvertureCaBesoinFdr = &i
+	}
+	if i, err := strconv.ParseFloat(row[37], 64); err == nil {
+		diane.PoidsBFRExploitation = &i
+	}
+	if i, err := strconv.ParseFloat(row[38], 64); err == nil {
+		diane.Exportation = &i
+	}
+	if i, err := strconv.ParseFloat(row[39], 64); err == nil {
+		diane.EfficaciteEconomique = &i
+	}
+	if i, err := strconv.ParseFloat(row[40], 64); err == nil {
+		diane.ProductivitePotentielProduction = &i
+	}
+	if i, err := strconv.ParseFloat(row[41], 64); err == nil {
+		diane.ProductiviteCapitalFinancier = &i
+	}
+	if i, err := strconv.ParseFloat(row[42], 64); err == nil {
+		diane.ProductiviteCapitalInvesti = &i
+	}
+	if i, err := strconv.ParseFloat(row[43], 64); err == nil {
+		diane.TauxDInvestissementProductif = &i
+	}
+	if i, err := strconv.ParseFloat(row[44], 64); err == nil {
+		diane.RentabiliteEconomique = &i
+	}
+	if i, err := strconv.ParseFloat(row[45], 64); err == nil {
+		diane.Performance = &i
+	}
+	if i, err := strconv.ParseFloat(row[46], 64); err == nil {
+		diane.RendementBrutFondsPropres = &i
+	}
+	if i, err := strconv.ParseFloat(row[47], 64); err == nil {
+		diane.RentabiliteNette = &i
+	}
+	if i, err := strconv.ParseFloat(row[48], 64); err == nil {
+		diane.RendementCapitauxPropres = &i
+	}
+	if i, err := strconv.ParseFloat(row[49], 64); err == nil {
+		diane.RendementRessourcesDurables = &i
+	}
+	if i, err := strconv.ParseFloat(row[50], 64); err == nil {
+		diane.TauxMargeCommerciale = &i
+	}
+	if i, err := strconv.ParseFloat(row[51], 64); err == nil {
+		diane.TauxValeurAjoutee = &i
+	}
+	if i, err := strconv.ParseFloat(row[52], 64); err == nil {
+		diane.PartSalaries = &i
+	}
+	if i, err := strconv.ParseFloat(row[53], 64); err == nil {
+		diane.PartEtat = &i
+	}
+	if i, err := strconv.ParseFloat(row[54], 64); err == nil {
+		diane.PartPreteur = &i
+	}
+	if i, err := strconv.ParseFloat(row[55], 64); err == nil {
+		diane.PartAutofinancement = &i
+	}
+	if i, err := strconv.ParseFloat(row[56], 64); err == nil {
+		diane.CA = &i
+	}
+	if i, err := strconv.ParseFloat(row[57], 64); err == nil {
+		diane.CAExportation = &i
+	}
+	if i, err := strconv.ParseFloat(row[58], 64); err == nil {
+		diane.AchatMarchandises = &i
+	}
+	if i, err := strconv.ParseFloat(row[60], 64); err == nil {
+		diane.AchatMatieresPremieres = &i
+	}
+	if i, err := strconv.ParseFloat(row[61], 64); err == nil {
+		diane.Production = &i
+	}
+	if i, err := strconv.ParseFloat(row[62], 64); err == nil {
+		diane.MargeCommerciale = &i
+	}
+	if i, err := strconv.ParseFloat(row[63], 64); err == nil {
+		diane.Consommation = &i
+	}
+	if i, err := strconv.ParseFloat(row[64], 64); err == nil {
+		diane.AutresAchatsChargesExternes = &i
+	}
+	if i, err := strconv.ParseFloat(row[65], 64); err == nil {
+		diane.ValeurAjoutee = &i
+	}
+	if i, err := strconv.ParseFloat(row[66], 64); err == nil {
+		diane.ChargePersonnel = &i
+	}
+	if i, err := strconv.ParseFloat(row[67], 64); err == nil {
+		diane.ImpotsTaxes = &i
+	}
+	if i, err := strconv.ParseFloat(row[68], 64); err == nil {
+		diane.SubventionsDExploitation = &i
+	}
+	if i, err := strconv.ParseFloat(row[69], 64); err == nil {
+		diane.ExcedentBrutDExploitation = &i
+	}
+	if i, err := strconv.ParseFloat(row[70], 64); err == nil {
+		diane.AutresProduitsChargesReprises = &i
+	}
+	if i, err := strconv.ParseFloat(row[71], 64); err == nil {
+		diane.DotationAmortissement = &i
+	}
+	if i, err := strconv.ParseFloat(row[72], 64); err == nil {
+		diane.ResultatExpl = &i
+	}
+	if i, err := strconv.ParseFloat(row[73], 64); err == nil {
+		diane.OperationsCommun = &i
+	}
+	if i, err := strconv.ParseFloat(row[74], 64); err == nil {
+		diane.ProduitsFinanciers = &i
+	}
+	if i, err := strconv.ParseFloat(row[75], 64); err == nil {
+		diane.ChargesFinancieres = &i
+	}
+	if i, err := strconv.ParseFloat(row[76], 64); err == nil {
+		diane.Interets = &i
+	}
+	if i, err := strconv.ParseFloat(row[77], 64); err == nil {
+		diane.ResultatAvantImpot = &i
+	}
+	if i, err := strconv.ParseFloat(row[78], 64); err == nil {
+		diane.ProduitExceptionnel = &i
+	}
+	if i, err := strconv.ParseFloat(row[79], 64); err == nil {
+		diane.ChargeExceptionnelle = &i
+	}
+	if i, err := strconv.ParseFloat(row[80], 64); err == nil {
+		diane.ParticipationSalaries = &i
+	}
+	if i, err := strconv.ParseFloat(row[81], 64); err == nil {
+		diane.ImpotBenefice = &i
+	}
+	if i, err := strconv.ParseFloat(row[82], 64); err == nil {
+		diane.BeneficeOuPerte = &i
+	}
+	return diane
+}
+
+// parseDianeRow génère des objets Diane à partir d'un fichier
 func parseDianeFile(path string, outputChannel chan engine.Tuple, event engine.Event) (abort bool, err error) {
 	tracker := gournal.NewTracker(
 		map[string]string{"path": path},
@@ -165,244 +404,9 @@ func parseDianeFile(path string, outputChannel chan engine.Tuple, event engine.E
 			event.Critical(tracker.Report("fatalError"))
 			break
 		}
-		diane := Diane{}
 
 		if len(row) >= 83 {
-
-			if i, err := strconv.Atoi(row[0]); err == nil {
-				diane.Annee = &i
-			}
-			diane.NomEntreprise = row[2]
-			diane.NumeroSiren = row[3]
-			diane.StatutJuridique = row[4]
-			diane.ProcedureCollective = (row[5] == "Oui")
-
-			if i, err := strconv.Atoi(row[6]); err == nil {
-				diane.EffectifConsolide = &i
-			}
-			if i, err := strconv.ParseFloat(row[7], 64); err == nil {
-				diane.DetteFiscaleEtSociale = &i
-			}
-			if i, err := strconv.ParseFloat(row[8], 64); err == nil {
-				diane.FraisDeRetD = &i
-			}
-			if i, err := strconv.ParseFloat(row[9], 64); err == nil {
-				diane.ConcesBrevEtDroitsSim = &i
-			}
-			if i, err := strconv.Atoi(row[10]); err == nil {
-				diane.NombreEtabSecondaire = &i
-			}
-			if i, err := strconv.Atoi(row[11]); err == nil {
-				diane.NombreFiliale = &i
-			}
-			if i, err := strconv.Atoi(row[12]); err == nil {
-				diane.TailleCompoGroupe = &i
-			}
-			if i, err := time.Parse("02/01/2006", row[14]); err == nil {
-				diane.ArreteBilan = i
-			}
-			if i, err := strconv.Atoi(row[15]); err == nil {
-				diane.NombreMois = &i
-			}
-			if i, err := strconv.ParseFloat(row[16], 64); err == nil {
-				diane.ConcoursBancaireCourant = &i
-			}
-			if i, err := strconv.ParseFloat(row[17], 64); err == nil {
-				diane.EquilibreFinancier = &i
-			}
-			if i, err := strconv.ParseFloat(row[18], 64); err == nil {
-				diane.IndependanceFinanciere = &i
-			}
-			if i, err := strconv.ParseFloat(row[19], 64); err == nil {
-				diane.Endettement = &i
-			}
-			if i, err := strconv.ParseFloat(row[20], 64); err == nil {
-				diane.AutonomieFinanciere = &i
-			}
-			if i, err := strconv.ParseFloat(row[21], 64); err == nil {
-				diane.DegreImmoCorporelle = &i
-			}
-			if i, err := strconv.ParseFloat(row[22], 64); err == nil {
-				diane.FinancementActifCirculant = &i
-			}
-			if i, err := strconv.ParseFloat(row[23], 64); err == nil {
-				diane.LiquiditeGenerale = &i
-			}
-			if i, err := strconv.ParseFloat(row[24], 64); err == nil {
-				diane.LiquiditeReduite = &i
-			}
-			if i, err := strconv.ParseFloat(row[25], 64); err == nil {
-				diane.RotationStocks = &i
-			}
-			if i, err := strconv.ParseFloat(row[26], 64); err == nil {
-				diane.CreditClient = &i
-			}
-			if i, err := strconv.ParseFloat(row[27], 64); err == nil {
-				diane.CreditFournisseur = &i
-			}
-			if i, err := strconv.ParseFloat(row[28], 64); err == nil {
-				diane.CAparEffectif = &i
-			}
-			if i, err := strconv.ParseFloat(row[29], 64); err == nil {
-				diane.TauxInteretFinancier = &i
-			}
-			if i, err := strconv.ParseFloat(row[30], 64); err == nil {
-				diane.TauxInteretSurCA = &i
-			}
-			if i, err := strconv.ParseFloat(row[31], 64); err == nil {
-				diane.EndettementGlobal = &i
-			}
-			if i, err := strconv.ParseFloat(row[32], 64); err == nil {
-				diane.TauxEndettement = &i
-			}
-			if i, err := strconv.ParseFloat(row[33], 64); err == nil {
-				diane.CapaciteRemboursement = &i
-			}
-			if i, err := strconv.ParseFloat(row[34], 64); err == nil {
-				diane.CapaciteAutofinancement = &i
-			}
-			if i, err := strconv.ParseFloat(row[35], 64); err == nil {
-				diane.CouvertureCaFdr = &i
-			}
-			if i, err := strconv.ParseFloat(row[36], 64); err == nil {
-				diane.CouvertureCaBesoinFdr = &i
-			}
-			if i, err := strconv.ParseFloat(row[37], 64); err == nil {
-				diane.PoidsBFRExploitation = &i
-			}
-			if i, err := strconv.ParseFloat(row[38], 64); err == nil {
-				diane.Exportation = &i
-			}
-			if i, err := strconv.ParseFloat(row[39], 64); err == nil {
-				diane.EfficaciteEconomique = &i
-			}
-			if i, err := strconv.ParseFloat(row[40], 64); err == nil {
-				diane.ProductivitePotentielProduction = &i
-			}
-			if i, err := strconv.ParseFloat(row[41], 64); err == nil {
-				diane.ProductiviteCapitalFinancier = &i
-			}
-			if i, err := strconv.ParseFloat(row[42], 64); err == nil {
-				diane.ProductiviteCapitalInvesti = &i
-			}
-			if i, err := strconv.ParseFloat(row[43], 64); err == nil {
-				diane.TauxDInvestissementProductif = &i
-			}
-			if i, err := strconv.ParseFloat(row[44], 64); err == nil {
-				diane.RentabiliteEconomique = &i
-			}
-			if i, err := strconv.ParseFloat(row[45], 64); err == nil {
-				diane.Performance = &i
-			}
-			if i, err := strconv.ParseFloat(row[46], 64); err == nil {
-				diane.RendementBrutFondsPropres = &i
-			}
-			if i, err := strconv.ParseFloat(row[47], 64); err == nil {
-				diane.RentabiliteNette = &i
-			}
-			if i, err := strconv.ParseFloat(row[48], 64); err == nil {
-				diane.RendementCapitauxPropres = &i
-			}
-			if i, err := strconv.ParseFloat(row[49], 64); err == nil {
-				diane.RendementRessourcesDurables = &i
-			}
-			if i, err := strconv.ParseFloat(row[50], 64); err == nil {
-				diane.TauxMargeCommerciale = &i
-			}
-			if i, err := strconv.ParseFloat(row[51], 64); err == nil {
-				diane.TauxValeurAjoutee = &i
-			}
-			if i, err := strconv.ParseFloat(row[52], 64); err == nil {
-				diane.PartSalaries = &i
-			}
-			if i, err := strconv.ParseFloat(row[53], 64); err == nil {
-				diane.PartEtat = &i
-			}
-			if i, err := strconv.ParseFloat(row[54], 64); err == nil {
-				diane.PartPreteur = &i
-			}
-			if i, err := strconv.ParseFloat(row[55], 64); err == nil {
-				diane.PartAutofinancement = &i
-			}
-			if i, err := strconv.ParseFloat(row[56], 64); err == nil {
-				diane.CA = &i
-			}
-			if i, err := strconv.ParseFloat(row[57], 64); err == nil {
-				diane.CAExportation = &i
-			}
-			if i, err := strconv.ParseFloat(row[58], 64); err == nil {
-				diane.AchatMarchandises = &i
-			}
-			if i, err := strconv.ParseFloat(row[60], 64); err == nil {
-				diane.AchatMatieresPremieres = &i
-			}
-			if i, err := strconv.ParseFloat(row[61], 64); err == nil {
-				diane.Production = &i
-			}
-			if i, err := strconv.ParseFloat(row[62], 64); err == nil {
-				diane.MargeCommerciale = &i
-			}
-			if i, err := strconv.ParseFloat(row[63], 64); err == nil {
-				diane.Consommation = &i
-			}
-			if i, err := strconv.ParseFloat(row[64], 64); err == nil {
-				diane.AutresAchatsChargesExternes = &i
-			}
-			if i, err := strconv.ParseFloat(row[65], 64); err == nil {
-				diane.ValeurAjoutee = &i
-			}
-			if i, err := strconv.ParseFloat(row[66], 64); err == nil {
-				diane.ChargePersonnel = &i
-			}
-			if i, err := strconv.ParseFloat(row[67], 64); err == nil {
-				diane.ImpotsTaxes = &i
-			}
-			if i, err := strconv.ParseFloat(row[68], 64); err == nil {
-				diane.SubventionsDExploitation = &i
-			}
-			if i, err := strconv.ParseFloat(row[69], 64); err == nil {
-				diane.ExcedentBrutDExploitation = &i
-			}
-			if i, err := strconv.ParseFloat(row[70], 64); err == nil {
-				diane.AutresProduitsChargesReprises = &i
-			}
-			if i, err := strconv.ParseFloat(row[71], 64); err == nil {
-				diane.DotationAmortissement = &i
-			}
-			if i, err := strconv.ParseFloat(row[72], 64); err == nil {
-				diane.ResultatExpl = &i
-			}
-			if i, err := strconv.ParseFloat(row[73], 64); err == nil {
-				diane.OperationsCommun = &i
-			}
-			if i, err := strconv.ParseFloat(row[74], 64); err == nil {
-				diane.ProduitsFinanciers = &i
-			}
-			if i, err := strconv.ParseFloat(row[75], 64); err == nil {
-				diane.ChargesFinancieres = &i
-			}
-			if i, err := strconv.ParseFloat(row[76], 64); err == nil {
-				diane.Interets = &i
-			}
-			if i, err := strconv.ParseFloat(row[77], 64); err == nil {
-				diane.ResultatAvantImpot = &i
-			}
-			if i, err := strconv.ParseFloat(row[78], 64); err == nil {
-				diane.ProduitExceptionnel = &i
-			}
-			if i, err := strconv.ParseFloat(row[79], 64); err == nil {
-				diane.ChargeExceptionnelle = &i
-			}
-			if i, err := strconv.ParseFloat(row[80], 64); err == nil {
-				diane.ParticipationSalaries = &i
-			}
-			if i, err := strconv.ParseFloat(row[81], 64); err == nil {
-				diane.ImpotBenefice = &i
-			}
-			if i, err := strconv.ParseFloat(row[82], 64); err == nil {
-				diane.BeneficeOuPerte = &i
-			}
-			outputChannel <- diane
+			outputChannel <- parseDianeRow(row)
 		} else {
 			event.Critical("Ligne invalide. Abandon !")
 		}


### PR DESCRIPTION
Fixes #11.

## Problème

Les erreurs de syntaxe du script `awk` de `convert_diane.sh` ne sont pas remontées lors de l'exécution des tests du parseur Diane.

Exemple d'erreur non rapportée (cas réel: https://github.com/signaux-faibles/opensignauxfaibles/issues/11#issuecomment-620060414):

```
$ sh convert_diane.sh testData/dianeTestData.txt
awk: line 15: syntax error at or near ,
```

## Changements proposés

- refactorisation du parseur Diane pour rendre sa logique plus lisible et clarifier la gestion d'erreurs
- créer des évènements `debug` pour chaque ligne retournée par `convert_diane.sh` dans la sortie standard d'erreurs
- le test consomme et affiche les évènements produits par le parseur
- le teste échoue si une erreur critique a été interceptée

## Comment tester le rapport d'erreurs sans exit code

1. Dans `convert_diane.sh`, ajouter une ligne `fai{l` juste avant le `BEGIN {` de `AWK_SCRIPT`
2. Executer `go test` depuis `dbmongo/lib/diane/`, vous devriez alors obtenir:

```
$ go test
--- FAIL: TestDiane (0.04s)
    testing.go:84: [debug] event: testData/dianeTestData.txt: ouverture
    testing.go:84: [debug] event: [convert_diane.sh stderr] awk: ligne de commande:3: BEGIN { # Semi-column separated csv as input and output
    testing.go:84: [debug] event: [convert_diane.sh stderr] awk: ligne de commande:3: ^ syntax error
    testing.go:84: [debug] event: [convert_diane.sh stderr] awk: ligne de commande:7: FNR==1 { # Change field names
    testing.go:84: [debug] event: [convert_diane.sh stderr] awk: ligne de commande:7:        ^ syntax error
    testing.go:84: [debug] event: [convert_diane.sh stderr] awk: ligne de commande:29: FNR>1 && $1 !~ "Marquée" {
    testing.go:84: [debug] event: [convert_diane.sh stderr] awk: ligne de commande:29:                           ^ syntax error
    testing.go:84: [debug] event: [convert_diane.sh stderr] awk: ligne de commande:48: }
    testing.go:84: [debug] event: [convert_diane.sh stderr] awk: ligne de commande:48:  ^ fin de chaîne ou passage à la ligne inattendu
    testing.go:84: [critical] event: map[report:Erreur fatale, abandon: echec de lecture de l'en-tête du fichier en sortie du script: EOF]
    testing.go:112: 
                Error Trace:    testing.go:112
                Error:          Caught Critical event: 
                Test:           TestDiane
                Messages:       map[report:Erreur fatale, abandon: echec de lecture de l'en-tête du fichier en sortie du script: EOF]
FAIL
exit status 1
FAIL    github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/diane 0.056s
```

## Comment tester le rapport d'erreurs avec exit code non-nul

1. Tout au début de `convert_diane.sh`, ajouter une ligne `>&2 echo "echec"; exit 1;`
2. Executer `go test` depuis `dbmongo/lib/diane/`, vous devriez alors obtenir:

```
$ go test
--- FAIL: TestDiane (0.00s)
    testing.go:84: [debug] event: testData/dianeTestData.txt: ouverture
    testing.go:84: [debug] event: [convert_diane.sh stderr] echec
    testing.go:84: [critical] event: map[report:Erreur fatale, abandon: echec de lecture de l'en-tête du fichier en sortie du script: EOF]
    testing.go:84: [debug] event: [convert_diane.sh] failed with exit status 1
    testing.go:112: 
                Error Trace:    testing.go:112
                Error:          Caught Critical event: 
                Test:           TestDiane
                Messages:       [convert_diane.sh] failed with exit status 1
FAIL
exit status 1
FAIL    github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/diane 0.022s
```