### PR TITLE
fix(tests): Libérer la goroutine d'affichage d'évènements

### DIFF
--- a/dbmongo/lib/marshal/testing.go
+++ b/dbmongo/lib/marshal/testing.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -79,7 +80,11 @@ func TestParserTupleOutput(
 	var firstCriticalEvent *engine.Event = nil
 
 	// intercepter et afficher les évènements pendant l'importation
+	var wg sync.WaitGroup
+	wg.Add(1)
+	defer wg.Wait() // pour éviter "panic: Log in goroutine after TestEffectif has completed"
 	go func() {
+		defer wg.Done()
 		for event := range events {
 			t.Logf("[%s] event: %v", event.Priority, event.Comment)
 			if event.Priority == engine.Critical && firstCriticalEvent == nil {


### PR DESCRIPTION
## Problème

Une erreur `panic: Log in goroutine after TestEffectif has completed` fait échouer les tests en CI, sur la branche `master`:

![image](https://user-images.githubusercontent.com/531781/80594255-f90b2600-8a22-11ea-851f-dd98e89fba0f.png)

Exemple: https://github.com/signaux-faibles/opensignauxfaibles/runs/629288009

```
panic: Log in goroutine after TestEffectif has completed

goroutine 13 [running]:
testing.(*common).logDepth(0xc000312b40, 0xc00000ab00, 0xf4, 0x3)
	/opt/hostedtoolcache/go/1.14.2/x64/src/testing/testing.go:680 +0x4d3
testing.(*common).log(...)
	/opt/hostedtoolcache/go/1.14.2/x64/src/testing/testing.go:662
testing.(*common).Logf(0xc000312b40, 0xba115d, 0xe, 0xc000055f28, 0x2, 0x2)
	/opt/hostedtoolcache/go/1.14.2/x64/src/testing/testing.go:701 +0x7e
github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/marshal.TestParserTupleOutput.func1(0xc000310540, 0xc000312b40, 0xc000010098)
	/home/runner/work/opensignauxfaibles/opensignauxfaibles/dbmongo/lib/marshal/testing.go:84 +0x170
created by github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/marshal.TestParserTupleOutput
	/home/runner/work/opensignauxfaibles/opensignauxfaibles/dbmongo/lib/marshal/testing.go:82 +0x1bf
FAIL	github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/urssaf	0.016s
FAIL
##[error]Process completed with exit code 1.
```

## Solution proposée

Permettre à la goroutine en cause de finir de traiter les logs puis de clore le canal une fois que le test a fini de s'exécuter.