### PR TITLE
tests: Transpiler les fichiers TypeScript lors de l'exécution des tests JS

### DIFF
--- a/dbmongo/js_test.go
+++ b/dbmongo/js_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/engine"
 )
 
 const SKIP_ON_CI = "SKIP_ON_CI"
@@ -21,7 +23,7 @@ var update = flag.Bool("update", false, "Update the expected test values in gold
 // TestMain sera exécuté avant les tests
 func TestMain(m *testing.M) {
 	fmt.Println("Transpilation des fonctions JS depuis TypeScript...")
-	// typescript.TranspileTsFunctions()
+	engine.TranspileTsFunctions()
 	code := m.Run()
 	os.Exit(code)
 }

--- a/dbmongo/js_test.go
+++ b/dbmongo/js_test.go
@@ -18,6 +18,14 @@ const SKIP_ON_CI = "SKIP_ON_CI"
 
 var update = flag.Bool("update", false, "Update the expected test values in golden file")
 
+// TestMain sera exécuté avant les tests
+func TestMain(m *testing.M) {
+	fmt.Println("Transpilation des fonctions JS depuis TypeScript...")
+	// typescript.TranspileTsFunctions()
+	code := m.Run()
+	os.Exit(code)
+}
+
 func Test_js(t *testing.T) {
 
 	scriptNameRegex, _ := regexp.Compile(".*[.]sh")

--- a/dbmongo/js_test.go
+++ b/dbmongo/js_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"syscall"
@@ -23,7 +24,8 @@ var update = flag.Bool("update", false, "Update the expected test values in gold
 // TestMain sera exécuté avant les tests
 func TestMain(m *testing.M) {
 	fmt.Println("Transpilation des fonctions JS depuis TypeScript...")
-	engine.TranspileTsFunctions()
+	jsRootDir := filepath.Join("js") // chemin vers les fichiers TS et JS (sous-répertoire)
+	engine.TranspileTsFunctions(jsRootDir)
 	code := m.Run()
 	os.Exit(code)
 }

--- a/dbmongo/lib/engine/js/loadJS.go
+++ b/dbmongo/lib/engine/js/loadJS.go
@@ -5,9 +5,10 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/engine"
 )
 
 // Reads all .js files in the current folder
@@ -56,18 +57,7 @@ func bundleJsFunctions() {
 	out.Write([]byte("}\n"))
 }
 
-func transpileTsFunctions() {
-	// TODO: also transpile any other TS files
-	cmd := exec.Command("npx", "typescript", "../../js/common/raison_sociale.ts") // output: dbmongo/js/common/raison_sociale.js
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
 func main() {
-	transpileTsFunctions() // convert *.ts files to .js
-	bundleJsFunctions()    // bundle *.js files to jsFunctions.go
+	engine.TranspileTsFunctions() // convert *.ts files to .js
+	bundleJsFunctions()           // bundle *.js files to jsFunctions.go
 }

--- a/dbmongo/lib/engine/js/loadJS.go
+++ b/dbmongo/lib/engine/js/loadJS.go
@@ -13,8 +13,7 @@ import (
 
 // Reads all .js files in the current folder
 // and encodes them as strings maps in jsFunctions.go
-func bundleJsFunctions() {
-	jsRootDir := filepath.Join("..", "..", "js")
+func bundleJsFunctions(jsRootDir string) {
 	folders, err := ioutil.ReadDir(jsRootDir)
 	if err != nil {
 		log.Fatal(err)
@@ -58,6 +57,7 @@ func bundleJsFunctions() {
 }
 
 func main() {
-	engine.TranspileTsFunctions() // convert *.ts files to .js
-	bundleJsFunctions()           // bundle *.js files to jsFunctions.go
+	jsRootDir := filepath.Join("..", "..", "js")
+	engine.TranspileTsFunctions(jsRootDir) // convert *.ts files to .js
+	bundleJsFunctions(jsRootDir)           // bundle *.js files to jsFunctions.go
 }

--- a/dbmongo/lib/engine/typescript.go
+++ b/dbmongo/lib/engine/typescript.go
@@ -6,9 +6,9 @@ import (
 	"os/exec"
 )
 
-func TranspileTsFunctions() {
+func TranspileTsFunctions(jsRootDir string) {
 	// TODO: also transpile any other TS files
-	cmd := exec.Command("npx", "typescript", "../../js/common/raison_sociale.ts") // output: dbmongo/js/common/raison_sociale.js
+	cmd := exec.Command("npx", "typescript", jsRootDir+"/common/raison_sociale.ts") // output: dbmongo/js/common/raison_sociale.js
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()

--- a/dbmongo/lib/engine/typescript.go
+++ b/dbmongo/lib/engine/typescript.go
@@ -1,0 +1,18 @@
+package engine
+
+import (
+	"log"
+	"os"
+	"os/exec"
+)
+
+func TranspileTsFunctions() {
+	// TODO: also transpile any other TS files
+	cmd := exec.Command("npx", "typescript", "../../js/common/raison_sociale.ts") // output: dbmongo/js/common/raison_sociale.js
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
Problème: le développeur pourrait croire à tort que ses modifs sur les fichiers `.ts` fonctionnent si les tests passent, alors qu'il a oublié d'exécuter `go generate` pour les transpiler...

Solution proposée: `go test` lancera systématiquement la transpilation.