### PR TITLE
fix(refactor): Restructuration du parseur Diane et simplification de gestion d'erreurs

### DIFF
--- a/dbmongo/lib/diane/main.go
+++ b/dbmongo/lib/diane/main.go
@@ -403,10 +403,9 @@ func parseDianeFile(path string, outputChannel chan engine.Tuple, event engine.E
 	reader.LazyQuotes = true
 	_, err = reader.Read() // Discard header
 	if err != nil {
-		contextualizedErr := errors.New("echec de lecture de l'en-tête du fichier en sortie du script: " + err.Error())
-		tracker.Error(contextualizedErr)
-		event.Critical(tracker.Report("fatalError"))
-		return contextualizedErr
+		errMsg := "echec de lecture de l'en-tête du fichier en sortie du script: " + err.Error()
+		event.Critical(errMsg)
+		return errors.New(errMsg)
 	}
 	for {
 		row, err := reader.Read()

--- a/dbmongo/lib/diane/main.go
+++ b/dbmongo/lib/diane/main.go
@@ -407,7 +407,7 @@ func parseDianeFile(path string, outputChannel chan engine.Tuple, event engine.E
 
 	// process rows of data
 	var row = []string{}
-	var readErr = (error)(nil)
+	var readErr error
 	for {
 		row, readErr = reader.Read()
 		if readErr != nil {

--- a/dbmongo/lib/diane/main.go
+++ b/dbmongo/lib/diane/main.go
@@ -406,7 +406,7 @@ func parseDianeFile(path string, outputChannel chan engine.Tuple, event engine.E
 		engine.TrackerReports)
 
 	// process rows of data
-	var row = []string{}
+	var row []string
 	var readErr error
 	for {
 		row, readErr = reader.Read()

--- a/dbmongo/lib/diane/main.go
+++ b/dbmongo/lib/diane/main.go
@@ -356,10 +356,6 @@ func parseDianeRow(row []string) (diane Diane) {
 
 // parseDianeRow génère des objets Diane à partir d'un fichier
 func parseDianeFile(path string, outputChannel chan engine.Tuple, event engine.Event) error {
-	tracker := gournal.NewTracker(
-		map[string]string{"path": path},
-		engine.TrackerReports)
-
 	event.Debug(path + ": ouverture")
 
 	cmdPath := []string{filepath.Join(viper.GetString("SCRIPTDIANE_DIR"), "convert_diane.sh"), viper.GetString("APP_DATA") + path}
@@ -397,7 +393,7 @@ func parseDianeFile(path string, outputChannel chan engine.Tuple, event engine.E
 		}
 	}()
 
-	// process rows of data
+	// init csv reader and skip header
 	reader := csv.NewReader(stdout)
 	reader.Comma = ';'
 	reader.LazyQuotes = true
@@ -407,6 +403,13 @@ func parseDianeFile(path string, outputChannel chan engine.Tuple, event engine.E
 		event.Critical(errMsg)
 		return errors.New(errMsg)
 	}
+
+	// init tracker to keep track and report parsing errors
+	tracker := gournal.NewTracker(
+		map[string]string{"path": path},
+		engine.TrackerReports)
+
+	// process rows of data
 	for {
 		row, err := reader.Read()
 		if err == io.EOF {


### PR DESCRIPTION
Suite à discussion avec Christophe, concernant l'usage de `event` et `tracker` dans [parseur diane](https://github.com/signaux-faibles/opensignauxfaibles/pull/20):
- utiliser `tracker` seulement pour les erreurs qui arrivent en cours de progression (afin de bénéficier d'un rapport standardisé de parsing). pour les autres erreurs: `event.Critical("")` suffit
- laisser l'appelant décider si on `abort` ou pas => remplacer `return true` par `return error("")`
