### PR TITLE
feat(ci): Dépendances téléchargées à la demande

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,10 +22,6 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-
     - name: Check that jsFunctions.go is up to date
       working-directory: dbmongo/lib/engine
       run: |


### PR DESCRIPTION
Nous avons vu récemment qu'il n'était plus nécéssaire d'exécuter `go get` pour récupérer les dépendances depuis que dbmongo est un Go Module.

Cette PR propose de retirer cette étape de notre workflow d'intégration continue, dans l'espoir de l'accélérer un peu.

Cf https://github.com/signaux-faibles/opensignauxfaibles/actions pour comparer les durées.