### PR TITLE
fix(TS): Passage de fraisFinancier.js en TypeScript + test

### DIFF
--- a/dbmongo/js/reduce.algo2/apart.js
+++ b/dbmongo/js/reduce.algo2/apart.js
@@ -1,5 +1,5 @@
-"use strict";
 function apart (apconso, apdemande) {
+  "use strict";
 
   var output_apart = {}
 

--- a/dbmongo/js/reduce.algo2/finalize_test.js
+++ b/dbmongo/js/reduce.algo2/finalize_test.js
@@ -10,9 +10,6 @@
 // Please execute ../test/test_finalize_algo2.sh
 // to fill these requirements and run the tests.
 
-// Allow f.*() function calls to resolve to globally-defined functions
-const f = this;
-
 // Define global parameters that are required by JS functions
 const jsParams = this; // => all properties of this object will become global. TODO: remove this when merging namespace (https://github.com/signaux-faibles/opensignauxfaibles/pull/40)
 jsParams.actual_batch = "2002_1";

--- a/dbmongo/js/reduce.algo2/fraisFinancier.js
+++ b/dbmongo/js/reduce.algo2/fraisFinancier.js
@@ -1,19 +1,19 @@
-function fraisFinancier(diane){
-  "use strict";
-  if (("interets" in diane) && (diane["interets"] !== null) &&
-    ("excedent_brut_d_exploitation" in diane) && (diane["excedent_brut_d_exploitation"] !== null) &&
-    ("produits_financiers" in diane) && (diane["produits_financiers"] !== null) &&
-    ("charges_financieres" in diane) && (diane["charges_financieres"] !== null) &&
-    ("charge_exceptionnelle" in  diane) && (diane["charge_exceptionnelle"] !== null) &&
-    ("produit_exceptionnel" in diane) && (diane["produit_exceptionnel"] !== null) &&
-    diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] - diane["charge_exceptionnelle"] - diane["charges_financieres"] != 0 ){
-    return diane["interets"] / (diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] -
-      diane["charge_exceptionnelle"] - diane["charges_financieres"] ) * 100
-  } else {
-    return null
-  }
+"use strict";
+exports.__esModule = true;
+function fraisFinancier(diane) {
+    "use strict";
+    if (("interets" in diane) && (diane["interets"] !== null) &&
+        ("excedent_brut_d_exploitation" in diane) && (diane["excedent_brut_d_exploitation"] !== null) &&
+        ("produits_financiers" in diane) && (diane["produits_financiers"] !== null) &&
+        ("charges_financieres" in diane) && (diane["charges_financieres"] !== null) &&
+        ("charge_exceptionnelle" in diane) && (diane["charge_exceptionnelle"] !== null) &&
+        ("produit_exceptionnel" in diane) && (diane["produit_exceptionnel"] !== null) &&
+        diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] - diane["charge_exceptionnelle"] - diane["charges_financieres"] != 0) {
+        return diane["interets"] / (diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] -
+            diane["charge_exceptionnelle"] - diane["charges_financieres"]) * 100;
+    }
+    else {
+        return null;
+    }
 }
-
-try {
-  module.exports.fraisFinancier = fraisFinancier
-} catch (err) {}
+exports.fraisFinancier = fraisFinancier;

--- a/dbmongo/js/reduce.algo2/fraisFinancier.js
+++ b/dbmongo/js/reduce.algo2/fraisFinancier.js
@@ -13,3 +13,7 @@ function fraisFinancier(diane){
     return null
   }
 }
+
+try {
+  module.exports.fraisFinancier = fraisFinancier
+} catch (err) {}

--- a/dbmongo/js/reduce.algo2/fraisFinancier.js
+++ b/dbmongo/js/reduce.algo2/fraisFinancier.js
@@ -1,4 +1,3 @@
-"use strict";
 exports.__esModule = true;
 function fraisFinancier(diane) {
     "use strict";

--- a/dbmongo/js/reduce.algo2/fraisFinancier.ts
+++ b/dbmongo/js/reduce.algo2/fraisFinancier.ts
@@ -1,0 +1,15 @@
+export function fraisFinancier(diane){
+  "use strict";
+  if (("interets" in diane) && (diane["interets"] !== null) &&
+    ("excedent_brut_d_exploitation" in diane) && (diane["excedent_brut_d_exploitation"] !== null) &&
+    ("produits_financiers" in diane) && (diane["produits_financiers"] !== null) &&
+    ("charges_financieres" in diane) && (diane["charges_financieres"] !== null) &&
+    ("charge_exceptionnelle" in  diane) && (diane["charge_exceptionnelle"] !== null) &&
+    ("produit_exceptionnel" in diane) && (diane["produit_exceptionnel"] !== null) &&
+    diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] - diane["charge_exceptionnelle"] - diane["charges_financieres"] != 0 ){
+    return diane["interets"] / (diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] -
+      diane["charge_exceptionnelle"] - diane["charges_financieres"] ) * 100
+  } else {
+    return null
+  }
+}

--- a/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
+++ b/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
@@ -5,3 +5,24 @@ test(`fraisFinancier est nul si "interets" n'est pas disponible dans Diane`, t =
   const diane = {}
   t.is(fraisFinancier(diane), null)
 })
+
+test(`fraisFinancier est calculé selon la formule:
+ interets / (
+  excedent_brut_d_exploitation +
+  produits_financiers +
+  produit_exceptionnel -
+  charge_exceptionnelle -
+  charges_financieres ) * 100`, t => {
+  const diane = {
+    interets: 50,
+    excedent_brut_d_exploitation: 1000,
+    produits_financiers: 100,
+    produit_exceptionnel: 120,
+    charge_exceptionnelle: 450,
+    charges_financieres: 160 
+  }
+  const resultat = diane["interets"] / (diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] - diane["charge_exceptionnelle"] - diane["charges_financieres"] ) * 100
+  t.is(fraisFinancier(diane), resultat)
+})
+
+// $ node_modules/.bin/ava-ts ./reduce.algo2/fraisFinancier_tests.ts

--- a/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
+++ b/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
@@ -1,11 +1,6 @@
 import test from 'ava'
 import { fraisFinancier } from './fraisFinancier.js'
 
-test(`fraisFinancier est nul si "interets" n'est pas disponible dans Diane`, t => {
-  const diane = {}
-  t.is(fraisFinancier(diane), null)
-})
-
 test(`fraisFinancier est calculé selon la formule:
  interets / (
   excedent_brut_d_exploitation +
@@ -19,10 +14,22 @@ test(`fraisFinancier est calculé selon la formule:
     produits_financiers: 100,
     produit_exceptionnel: 120,
     charge_exceptionnelle: 450,
-    charges_financieres: 160 
+    charges_financieres: 160
   }
-  const resultat = diane["interets"] / (diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] - diane["charge_exceptionnelle"] - diane["charges_financieres"] ) * 100
+  const resultat = diane.interets / (diane.excedent_brut_d_exploitation +
+    diane.produits_financiers + diane.produit_exceptionnel -
+    diane.charge_exceptionnelle - diane.charges_financieres) * 100
   t.is(fraisFinancier(diane), resultat)
 })
+
+const proprietes = ["interets", "excedent_brut_d_exploitation", "produits_financiers", "produit_exceptionnel", "charge_exceptionnelle", "charges_financieres"]
+proprietes.forEach((propriete) =>
+  test(`fraisFinancier est nul si "${propriete}" n'est pas disponible dans Diane`, t => {
+    const diane = {}
+    t.is(fraisFinancier(diane), null)
+  })
+)
+
+
 
 // $ node_modules/.bin/ava-ts ./reduce.algo2/fraisFinancier_tests.ts

--- a/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
+++ b/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
@@ -1,5 +1,5 @@
 import test from 'ava'
-import { fraisFinancier } from './fraisFinancier.js'
+import { fraisFinancier } from './fraisFinancier'
 
 const fakeDiane = () => ({
   interets: 50,

--- a/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
+++ b/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
@@ -1,6 +1,15 @@
 import test from 'ava'
 import { fraisFinancier } from './fraisFinancier.js'
 
+const fakeDiane = () => ({
+  interets: 50,
+  excedent_brut_d_exploitation: 1000,
+  produits_financiers: 100,
+  produit_exceptionnel: 120,
+  charge_exceptionnelle: 450,
+  charges_financieres: 160
+})
+
 test(`fraisFinancier est calculé selon la formule:
  interets / (
   excedent_brut_d_exploitation +
@@ -8,14 +17,7 @@ test(`fraisFinancier est calculé selon la formule:
   produit_exceptionnel -
   charge_exceptionnelle -
   charges_financieres ) * 100`, t => {
-  const diane = {
-    interets: 50,
-    excedent_brut_d_exploitation: 1000,
-    produits_financiers: 100,
-    produit_exceptionnel: 120,
-    charge_exceptionnelle: 450,
-    charges_financieres: 160
-  }
+  const diane = fakeDiane()
   const resultat = diane.interets / (diane.excedent_brut_d_exploitation +
     diane.produits_financiers + diane.produit_exceptionnel -
     diane.charge_exceptionnelle - diane.charges_financieres) * 100
@@ -25,14 +27,7 @@ test(`fraisFinancier est calculé selon la formule:
 const proprietes = ["interets", "excedent_brut_d_exploitation", "produits_financiers", "produit_exceptionnel", "charge_exceptionnelle", "charges_financieres"]
 proprietes.forEach((propriete) =>
   test(`fraisFinancier est nul si "${propriete}" n'est pas disponible dans Diane`, t => {
-    const diane = {
-      interets: 50,
-      excedent_brut_d_exploitation: 1000,
-      produits_financiers: 100,
-      produit_exceptionnel: 120,
-      charge_exceptionnelle: 450,
-      charges_financieres: 160
-    }
+    const diane = fakeDiane()
     diane[propriete] = null
     t.is(fraisFinancier(diane), null)
   })

--- a/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
+++ b/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
@@ -30,6 +30,8 @@ proprietes.forEach((propriete) =>
     const diane = fakeDiane()
     diane[propriete] = null
     t.is(fraisFinancier(diane), null)
+    delete diane[propriete]
+    t.is(fraisFinancier(diane), null)
   })
 )
 

--- a/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
+++ b/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
@@ -25,11 +25,17 @@ test(`fraisFinancier est calculé selon la formule:
 const proprietes = ["interets", "excedent_brut_d_exploitation", "produits_financiers", "produit_exceptionnel", "charge_exceptionnelle", "charges_financieres"]
 proprietes.forEach((propriete) =>
   test(`fraisFinancier est nul si "${propriete}" n'est pas disponible dans Diane`, t => {
-    const diane = {}
+    const diane = {
+      interets: 50,
+      excedent_brut_d_exploitation: 1000,
+      produits_financiers: 100,
+      produit_exceptionnel: 120,
+      charge_exceptionnelle: 450,
+      charges_financieres: 160
+    }
+    diane[propriete] = null
     t.is(fraisFinancier(diane), null)
   })
 )
-
-
 
 // $ node_modules/.bin/ava-ts ./reduce.algo2/fraisFinancier_tests.ts

--- a/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
+++ b/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
@@ -1,0 +1,7 @@
+import test from 'ava'
+import { fraisFinancier } from './fraisFinancier.js'
+
+test(`fraisFinancier est nul si "interets" n'est pas disponible dans Diane`, t => {
+  const diane = {}
+  t.is(fraisFinancier(diane), null)
+})

--- a/dbmongo/js/reduce.algo2/map.js
+++ b/dbmongo/js/reduce.algo2/map.js
@@ -261,6 +261,4 @@ function map () {
   }
 }
 
-try {
-  module.exports.map = map
-} catch (err) {}
+exports.map = map

--- a/dbmongo/js/reduce.algo2/map_test.js
+++ b/dbmongo/js/reduce.algo2/map_test.js
@@ -10,9 +10,6 @@
 // Please execute ../test/test_map_algo2.sh to fill these requirements and
 // run the tests.
 
-// Allow f.*() function calls to resolve to globally-defined functions 
-const f = this;
-
 // Define global parameters that are required by JS functions
 const jsParams = this; // => all properties of this object will become global. TODO: remove this when merging namespace (https://github.com/signaux-faibles/opensignauxfaibles/pull/40)
 jsParams.actual_batch = "2002_1";

--- a/dbmongo/js/test/helpers/fakes.js
+++ b/dbmongo/js/test/helpers/fakes.js
@@ -38,6 +38,8 @@ const f = this /* = {
   ...
 }*/
 
+const exports = {}
+
 function reducer(array, reduce) {
   if (array.length == 1) {
     return array[0]

--- a/dbmongo/js/test/test_algo2.sh
+++ b/dbmongo/js/test/test_algo2.sh
@@ -42,9 +42,9 @@ if [ "$result_cibleApprentissage" != 'true' ]; then
 fi
 
 result_mapreduce=$(jsc \
+  helpers/fakes.js \
   ../reduce.algo2/!(*_test).js \
   ../common/!(*_test).js \
-  helpers/fakes.js \
   helpers/fake_emit_for_algo2.js \
   data/naf.js \
   data/objects.js \

--- a/dbmongo/js/test/test_finalize_algo2.sh
+++ b/dbmongo/js/test/test_finalize_algo2.sh
@@ -26,6 +26,7 @@ echo "makeTestData = ({ ISODate, NumberInt }) => (${JSON_TEST_DATASET});" \
 
 # Run tests
 jsc \
+  ./helpers/fakes.js \
   ../common/!(*_test).js \
   ${TMP_PATH}/reduce_test_data.js \
   ./data/naf.js \

--- a/dbmongo/js/test/test_map_algo2.sh
+++ b/dbmongo/js/test/test_map_algo2.sh
@@ -26,6 +26,7 @@ echo "makeTestData = ({ ISODate, NumberInt }) => (${JSON_TEST_DATASET});" \
 
 # Run tests
 jsc \
+  ./helpers/fakes.js \
   ../common/!(*_test).js \
   ${TMP_PATH}/reduce_test_data.js \
   ./data/naf.js \

--- a/dbmongo/lib/engine/js/loadJS.go
+++ b/dbmongo/lib/engine/js/loadJS.go
@@ -50,10 +50,18 @@ func bundleJsFunctions(jsRootDir string) {
 					if err != nil {
 						log.Fatal(err)
 					}
+					stringFunction := string(function)
+					useStrictRegex := regexp.MustCompile(`^"use strict";?\n`)
+					stringFunction = useStrictRegex.ReplaceAllLiteralString(stringFunction, "")
+					exportRegex := regexp.MustCompile(`^exports.__esModule = true;?\n`)
+					stringFunction = exportRegex.ReplaceAllLiteralString(stringFunction, "")
 					moduleRegex := regexp.MustCompile(`(?ms)^\}.*^try.*module.exports.*`)
-					cleanFunction := moduleRegex.ReplaceAllLiteralString(string(function), "}")
+					stringFunction = moduleRegex.ReplaceAllLiteralString(stringFunction, "}")
+					finalExportRegex := regexp.MustCompile(`(?ms)^exports\..*`)
+					stringFunction = finalExportRegex.ReplaceAllLiteralString(stringFunction, "")
+					stringFunction = strings.Trim(stringFunction, "\n")
 
-					out.Write([]byte(cleanFunction))
+					out.Write([]byte(stringFunction))
 					out.Write([]byte("`,\n"))
 				}
 			}

--- a/dbmongo/lib/engine/js/loadJS.go
+++ b/dbmongo/lib/engine/js/loadJS.go
@@ -51,9 +51,7 @@ func bundleJsFunctions(jsRootDir string) {
 						log.Fatal(err)
 					}
 					stringFunction := string(function)
-					exportRegex := regexp.MustCompile(`^exports.__esModule = true;?\n`)
-					stringFunction = exportRegex.ReplaceAllLiteralString(stringFunction, "")
-					finalExportRegex := regexp.MustCompile(`(?ms)^exports\..*`)
+					finalExportRegex := regexp.MustCompile(`(?m)^exports..*$`)
 					stringFunction = finalExportRegex.ReplaceAllLiteralString(stringFunction, "")
 					stringFunction = strings.Trim(stringFunction, "\n")
 

--- a/dbmongo/lib/engine/js/loadJS.go
+++ b/dbmongo/lib/engine/js/loadJS.go
@@ -50,8 +50,8 @@ func bundleJsFunctions(jsRootDir string) {
 					if err != nil {
 						log.Fatal(err)
 					}
-					moduleRegex := regexp.MustCompile(`(?ms)^\}.*^try.*module.exports.map =.*`)
-					cleanFunction := moduleRegex.ReplaceAllLiteralString(string(function), "}\n")
+					moduleRegex := regexp.MustCompile(`(?ms)^\}.*^try.*module.exports.*`)
+					cleanFunction := moduleRegex.ReplaceAllLiteralString(string(function), "}")
 
 					out.Write([]byte(cleanFunction))
 					out.Write([]byte("`,\n"))

--- a/dbmongo/lib/engine/js/loadJS.go
+++ b/dbmongo/lib/engine/js/loadJS.go
@@ -51,8 +51,6 @@ func bundleJsFunctions(jsRootDir string) {
 						log.Fatal(err)
 					}
 					stringFunction := string(function)
-					useStrictRegex := regexp.MustCompile(`^"use strict";?\n`)
-					stringFunction = useStrictRegex.ReplaceAllLiteralString(stringFunction, "")
 					exportRegex := regexp.MustCompile(`^exports.__esModule = true;?\n`)
 					stringFunction = exportRegex.ReplaceAllLiteralString(stringFunction, "")
 					moduleRegex := regexp.MustCompile(`(?ms)^\}.*^try.*module.exports.*`)

--- a/dbmongo/lib/engine/js/loadJS.go
+++ b/dbmongo/lib/engine/js/loadJS.go
@@ -53,8 +53,6 @@ func bundleJsFunctions(jsRootDir string) {
 					stringFunction := string(function)
 					exportRegex := regexp.MustCompile(`^exports.__esModule = true;?\n`)
 					stringFunction = exportRegex.ReplaceAllLiteralString(stringFunction, "")
-					moduleRegex := regexp.MustCompile(`(?ms)^\}.*^try.*module.exports.*`)
-					stringFunction = moduleRegex.ReplaceAllLiteralString(stringFunction, "}")
 					finalExportRegex := regexp.MustCompile(`(?ms)^exports\..*`)
 					stringFunction = finalExportRegex.ReplaceAllLiteralString(stringFunction, "")
 					stringFunction = strings.Trim(stringFunction, "\n")

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1893,8 +1893,7 @@ function map () {
       })
     }
   }
-}
-`,
+}`,
 "outputs": `function outputs (v, serie_periode) {
   "use strict";
   var output_array = serie_periode.map(function (e) {

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -59,8 +59,7 @@ package engine
             (prenom4_unite_legale || "") +
             " ").trim() + "/";
     return raison_sociale;
-}
-`,
+}`,
 "region": `function region(departement){
   "use strict";
   var reg = ""
@@ -189,8 +188,7 @@ package engine
       break
   }
   return(reg)
-}
-`,
+}`,
 },
 "compact":{
 "complete_reporder": `function complete_reporder(key, object){
@@ -221,8 +219,7 @@ package engine
     object.batch[lastBatch].reporder = reporder_obj
   })
   return(object)
-}
-`,
+}`,
 "currentState": `function currentState(batches){
   "use strict";
   var currentState = batches.reduce((m, batch) => {
@@ -247,8 +244,7 @@ package engine
   }, {} )
 
   return(currentState)
-}
-`,
+}`,
 "finalize": `function finalize(k, o) {
   "use strict";
   o.index = {"algo1":false,
@@ -271,8 +267,7 @@ package engine
     o = f.complete_reporder(k, o)
   }
   return(o)
-}
-`,
+}`,
 "map": `function map() {      
   "use strict";
   try{
@@ -282,8 +277,7 @@ package engine
   } catch(error) {
     print(this.value.key)
   }
-}
-`,
+}`,
 "reduce": `function reduce(key, values) {
   "use strict";
 
@@ -488,8 +482,7 @@ package engine
   })
 
   return(reduced_value)
-}
-`,
+}`,
 },
 "crossComputation":{
 "apart": `{
@@ -506,8 +499,7 @@ package engine
       ]
     }
   }
-}
-`,
+}`,
 },
 "migrations":{
 "agg_change_index_Features": `// db.getCollection("Features").aggregate(
@@ -548,9 +540,7 @@ db.getCollection("Features").createIndex({
     "_id.periode" : 1,
     "value.effectif" : 1,
     "_id.siret" : 1
-})
-
-`,
+})`,
 },
 "public":{
 "apconso": `function apconso(apconso) {
@@ -602,8 +592,7 @@ db.getCollection("Features").createIndex({
   })
 
   return(output_cotisation)
-}
-`,
+}`,
 "dateAddDay": `function dateAddDay(date, nbMonth) {
   "use strict";
   var result = new Date(date.getTime())
@@ -634,8 +623,7 @@ db.getCollection("Features").createIndex({
   },[]).sort(
     (a,b) => {return(a.date_procol.getTime() > b.date_procol.getTime())}
   )
-}
-`,
+}`,
 "debits": `function debits(vdebit) {
   "use strict";
 
@@ -722,8 +710,7 @@ db.getCollection("Features").createIndex({
   })
 
   return(output_dette)
-}
-`,
+}`,
 "delai": `function delai(delai) {
   "use strict";
   return f.iterable(delai)
@@ -777,8 +764,7 @@ db.getCollection("Features").createIndex({
     }, { "key": v.key, scope: v.scope })
 
   return(res)
-}
-`,
+}`,
 "idEntreprise": `function idEntreprise(idEtablissement) {
   "use strict";
   return {
@@ -796,8 +782,7 @@ db.getCollection("Features").createIndex({
   } catch(error) {
     return []
   }
-}
-`,
+}`,
 "map": `function map() {
   "use strict";
   var value = f.flatten(this.value, actual_batch)
@@ -847,8 +832,7 @@ db.getCollection("Features").createIndex({
       emit("entreprise_" + this.value.key, v)
     }
   }
-}
-`,
+}`,
 "procolToHuman": `function procolToHuman (action, stade) {
   "use strict";
   var res = null;
@@ -899,8 +883,7 @@ db.getCollection("Features").createIndex({
   }
   // With a merge at the end, sending a new object, even empty, is compulsary
     emit(this._id, this.value)
-}
-`,
+}`,
 "reduce": `function reduce(key, values) {
     "use strict";
     return values
@@ -918,10 +901,9 @@ db.getCollection("Features").createIndex({
       // )
     }
   })
-}
-`,
-"apart": `"use strict";
-function apart (apconso, apdemande) {
+}`,
+"apart": `function apart (apconso, apdemande) {
+  "use strict";
 
   var output_apart = {}
 
@@ -995,8 +977,7 @@ function apart (apconso, apdemande) {
   //  }
   //})
   return(output_apart)
-}
-`,
+}`,
 "ccsf": `function ccsf(v, output_array){
   "use strict";
 
@@ -1019,8 +1000,7 @@ function apart (apconso, apdemande) {
       val.date_ccsf = optccsf.date_traitement
     }
   })
-}
-`,
+}`,
 "cibleApprentissage": `function cibleApprentissage(output_indexed, n_months) {
   "use strict";
 
@@ -1055,8 +1035,7 @@ function apart (apconso, apdemande) {
   }, {})
 
   return output_cible
-}
-`,
+}`,
 "compareDebit": `function compareDebit (a,b) {
   "use strict";
   if (a.numero_historique < b.numero_historique) return -1
@@ -1076,8 +1055,7 @@ function apart (apconso, apdemande) {
   })
 
   return output_compte
-}
-`,
+}`,
 "cotisation": `function cotisation(output_indexed, output_array) {
   "use strict";
   // calcul de cotisation_moyenne sur 12 mois
@@ -1129,8 +1107,7 @@ function apart (apconso, apdemande) {
     } else
       counter = 0
   })
-}
-`,
+}`,
 "cotisationsdettes": `function cotisationsdettes(v, periodes) {
   "use strict";
 
@@ -1285,8 +1262,7 @@ function apart (apconso, apdemande) {
   })
 
   return(output_cotisationsdettes)
-}
-`,
+}`,
 "dateAddMonth": `function dateAddMonth(date, nbMonth) {
   "use strict";
   var result = new Date(date.getTime())
@@ -1326,8 +1302,7 @@ function apart (apconso, apdemande) {
       })
     }
   )
-}
-`,
+}`,
 "defaillances": `function defaillances (v, output_indexed) {
   "use strict";
   f.dealWithProcols(v.altares, "altares", output_indexed)
@@ -1364,8 +1339,7 @@ function apart (apconso, apdemande) {
       )
     }
   )
-}
-`,
+}`,
 "detteFiscale": `function detteFiscale (diane){
   "use strict";
   if  (("dette_fiscale_et_sociale" in diane) && (diane["dette_fiscale_et_sociale"] !== null) &&
@@ -1436,8 +1410,7 @@ function apart (apconso, apdemande) {
     }
   })
   return(output_effectif)
-}
-`,
+}`,
 "finalize": `function finalize(k, v) {
   "use strict";
   const maxBsonSize = 16777216;
@@ -1503,8 +1476,7 @@ function apart (apconso, apdemande) {
       return {"incomplete": true}
     }
   }
-}
-`,
+}`,
 "financierCourtTerme": `function financierCourtTerme(diane) {
   "use strict";
   if  (("concours_bancaire_courant" in diane) && (diane["concours_bancaire_courant"] !== null) &&
@@ -1543,22 +1515,22 @@ function apart (apconso, apdemande) {
     }, { "key": v.key, scope: v.scope })
 
   return(res)
-}
-`,
-"fraisFinancier": `function fraisFinancier(diane){
-  "use strict";
-  if (("interets" in diane) && (diane["interets"] !== null) &&
-    ("excedent_brut_d_exploitation" in diane) && (diane["excedent_brut_d_exploitation"] !== null) &&
-    ("produits_financiers" in diane) && (diane["produits_financiers"] !== null) &&
-    ("charges_financieres" in diane) && (diane["charges_financieres"] !== null) &&
-    ("charge_exceptionnelle" in  diane) && (diane["charge_exceptionnelle"] !== null) &&
-    ("produit_exceptionnel" in diane) && (diane["produit_exceptionnel"] !== null) &&
-    diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] - diane["charge_exceptionnelle"] - diane["charges_financieres"] != 0 ){
-    return diane["interets"] / (diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] -
-      diane["charge_exceptionnelle"] - diane["charges_financieres"] ) * 100
-  } else {
-    return null
-  }
+}`,
+"fraisFinancier": `function fraisFinancier(diane) {
+    "use strict";
+    if (("interets" in diane) && (diane["interets"] !== null) &&
+        ("excedent_brut_d_exploitation" in diane) && (diane["excedent_brut_d_exploitation"] !== null) &&
+        ("produits_financiers" in diane) && (diane["produits_financiers"] !== null) &&
+        ("charges_financieres" in diane) && (diane["charges_financieres"] !== null) &&
+        ("charge_exceptionnelle" in diane) && (diane["charge_exceptionnelle"] !== null) &&
+        ("produit_exceptionnel" in diane) && (diane["produit_exceptionnel"] !== null) &&
+        diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] - diane["charge_exceptionnelle"] - diane["charges_financieres"] != 0) {
+        return diane["interets"] / (diane["excedent_brut_d_exploitation"] + diane["produits_financiers"] + diane["produit_exceptionnel"] -
+            diane["charge_exceptionnelle"] - diane["charges_financieres"]) * 100;
+    }
+    else {
+        return null;
+    }
 }`,
 "interim": `function interim (interim, output_indexed) {
   "use strict";
@@ -1594,8 +1566,7 @@ function apart (apconso, apdemande) {
   })
 
   return output_interim
-}
-`,
+}`,
 "lookAhead": `function lookAhead(data, attr_name, n_months, past) {
   "use strict";
   // Est-ce que l'évènement se répercute dans le passé (past = true on pourra se
@@ -1630,10 +1601,8 @@ function apart (apconso, apdemande) {
   }, {})
 
   return output
-}
-`,
-"map": `
-function map () {
+}`,
+"map": `function map () {
   "use strict";
   let v = f.flatten(this.value, actual_batch)
 
@@ -1913,8 +1882,7 @@ function map () {
   }, {})
 
   return [output_array, output_indexed]
-}
-`,
+}`,
 "poidsFrng": `function poidsFrng(diane){
   "use strict";
   if  (("couverture_ca_fdr" in diane) && (diane["couverture_ca_fdr"] !== null)){
@@ -1939,8 +1907,7 @@ function map () {
       output_indexed[k].libelle_ape5 = naf.n5[code_ape]
     }
   })
-}
-`,
+}`,
 "procolToHuman": `function procolToHuman (action, stade) {
   "use strict";
   var res = null;
@@ -1963,8 +1930,7 @@ function map () {
   return values.reduce((val, accu) => {
     return Object.assign(accu, val)
   }, {})
-}
-`,
+}`,
 "repeatable": `function repeatable(rep){
   "use strict";
   let output_repeatable = {}
@@ -1977,10 +1943,7 @@ function map () {
 
   return(output_repeatable)
 
-}
-
-
-`,
+}`,
 "sirene": `function sirene (v, output_array) {
   "use strict";
   var sireneHashes = Object.keys(v.sirene || {})
@@ -2010,9 +1973,7 @@ function map () {
       val.age = (sirene.date_creation && sirene.date_creation >= new Date("1901/01/01")) ? val.periode.getFullYear() - val.date_creation_etablissement : null
     }
   })
-}
-
-`,
+}`,
 "sirene_ul": `function sirene_ul(v, output_array) {
   "use strict";
   var sireneHashes = Object.keys(v.sirene_ul || {})
@@ -2034,8 +1995,7 @@ function map () {
       val.age_entreprise = (sirene.date_creation && sirene.date_creation >= new Date("1901/01/01")) ? val.periode.getFullYear() - val.date_creation_entreprise : null
     }
   })
-}
-`,
+}`,
 "tauxMarge": `function tauxMarge(diane) {
   "use strict";
   if  (("excedent_brut_d_exploitation" in diane) && (diane["excedent_brut_d_exploitation"] !== null) &&

--- a/dbmongo/lib/engine/typescript.go
+++ b/dbmongo/lib/engine/typescript.go
@@ -12,7 +12,7 @@ func TranspileTsFunctions(jsRootDir string) {
 		jsRootDir + "/common/raison_sociale.ts",
 		jsRootDir + "/reduce.algo2/fraisFinancier.ts",
 	}
-	cmd := exec.Command("npx", append([]string{"typescript", "--listFiles", "--lib", "es5", "--skipLibCheck"}, tsFiles...)...) // output: .js files
+	cmd := exec.Command("npx", append([]string{"typescript", "--listFiles", "--lib", "es5", "--skipLibCheck", "--noImplicitUseStrict"}, tsFiles...)...) // output: .js files
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()

--- a/dbmongo/lib/engine/typescript.go
+++ b/dbmongo/lib/engine/typescript.go
@@ -15,4 +15,11 @@ func TranspileTsFunctions(jsRootDir string) {
 	if err != nil {
 		log.Fatal(err)
 	}
+	cmd = exec.Command("npx", "typescript", jsRootDir+"/reduce.algo2/fraisFinancier.ts") // output: dbmongo/js/common/raison_sociale.js
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/dbmongo/lib/engine/typescript.go
+++ b/dbmongo/lib/engine/typescript.go
@@ -8,17 +8,14 @@ import (
 
 func TranspileTsFunctions(jsRootDir string) {
 	// TODO: also transpile any other TS files
-	cmd := exec.Command("npx", "typescript", jsRootDir+"/common/raison_sociale.ts") // output: dbmongo/js/common/raison_sociale.js
+	tsFiles := []string{
+		jsRootDir + "/common/raison_sociale.ts",
+		jsRootDir + "/reduce.algo2/fraisFinancier.ts",
+	}
+	cmd := exec.Command("npx", append([]string{"typescript", "--listFiles"}, tsFiles...)...) // output: .js files
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
-	if err != nil {
-		log.Fatal(err)
-	}
-	cmd = exec.Command("npx", "typescript", jsRootDir+"/reduce.algo2/fraisFinancier.ts") // output: dbmongo/js/common/raison_sociale.js
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err = cmd.Run()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/dbmongo/lib/engine/typescript.go
+++ b/dbmongo/lib/engine/typescript.go
@@ -12,7 +12,7 @@ func TranspileTsFunctions(jsRootDir string) {
 		jsRootDir + "/common/raison_sociale.ts",
 		jsRootDir + "/reduce.algo2/fraisFinancier.ts",
 	}
-	cmd := exec.Command("npx", append([]string{"typescript", "--listFiles"}, tsFiles...)...) // output: .js files
+	cmd := exec.Command("npx", append([]string{"typescript", "--listFiles", "--lib", "es5", "--skipLibCheck"}, tsFiles...)...) // output: .js files
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()

--- a/dbmongo/lib/engine/typescript.go
+++ b/dbmongo/lib/engine/typescript.go
@@ -4,13 +4,14 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 func TranspileTsFunctions(jsRootDir string) {
 	// TODO: also transpile any other TS files
 	tsFiles := []string{
-		jsRootDir + "/common/raison_sociale.ts",
-		jsRootDir + "/reduce.algo2/fraisFinancier.ts",
+		filepath.Join(jsRootDir, "common", "raison_sociale.ts"),
+		filepath.Join(jsRootDir, "reduce.algo2", "fraisFinancier.ts"),
 	}
 	cmd := exec.Command("npx", append([]string{"typescript", "--listFiles", "--lib", "es5", "--skipLibCheck", "--noImplicitUseStrict"}, tsFiles...)...) // output: .js files
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Travail effectué avec Pierre:

- Écriture de deux test unitaires exprimés en français (pour servir de documentation des fonctions de calcul) pour `fraisFinancier.js`
- Conversion de `fraisFinancier.js` au format TypeScript
- Harmonisation de la manière d'exporter les modules JS, et d'ignorer cette exportation depuis `jsLoad.go`
- Harmonisation du formatage de `jsFunctions.go`
- Laisser `fakes.js` initialiser les variables globales `f` et `exports`
- Déplacement du `"use strict"` dans `apart.js`, pour éviter erreur à l'exécution par mongodb
