### PR TITLE
fix(tests): Formatage JSON dans tests de bout en bout

### DIFF
--- a/test-api.golden-master.txt
+++ b/test-api.golden-master.txt
@@ -1,25 +1,1845 @@
 // Documents from db.RawData, after call to /api/data/compact:
-{ "_id" : "01234567891011", "value" : { "batch" : { "1910" : { "reporder" : { "Wed Jan 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-01-01T00:00:00Z"), "siret" : "01234567891011" }, "Sat Feb 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-02-01T00:00:00Z"), "siret" : "01234567891011" }, "Sat Mar 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-03-01T00:00:00Z"), "siret" : "01234567891011" }, "Tue Apr 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-04-01T00:00:00Z"), "siret" : "01234567891011" }, "Thu May 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-05-01T00:00:00Z"), "siret" : "01234567891011" }, "Sun Jun 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-06-01T00:00:00Z"), "siret" : "01234567891011" }, "Tue Jul 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-07-01T00:00:00Z"), "siret" : "01234567891011" }, "Fri Aug 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-08-01T00:00:00Z"), "siret" : "01234567891011" }, "Mon Sep 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-09-01T00:00:00Z"), "siret" : "01234567891011" }, "Wed Oct 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-10-01T00:00:00Z"), "siret" : "01234567891011" }, "Sat Nov 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-11-01T00:00:00Z"), "siret" : "01234567891011" }, "Mon Dec 01 2014 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2014-12-01T00:00:00Z"), "siret" : "01234567891011" }, "Thu Jan 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-01-01T00:00:00Z"), "siret" : "01234567891011" }, "Sun Feb 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-02-01T00:00:00Z"), "siret" : "01234567891011" }, "Sun Mar 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-03-01T00:00:00Z"), "siret" : "01234567891011" }, "Wed Apr 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-04-01T00:00:00Z"), "siret" : "01234567891011" }, "Fri May 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-05-01T00:00:00Z"), "siret" : "01234567891011" }, "Mon Jun 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-06-01T00:00:00Z"), "siret" : "01234567891011" }, "Wed Jul 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-07-01T00:00:00Z"), "siret" : "01234567891011" }, "Sat Aug 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-08-01T00:00:00Z"), "siret" : "01234567891011" }, "Tue Sep 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-09-01T00:00:00Z"), "siret" : "01234567891011" }, "Thu Oct 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-10-01T00:00:00Z"), "siret" : "01234567891011" }, "Sun Nov 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-11-01T00:00:00Z"), "siret" : "01234567891011" }, "Tue Dec 01 2015 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2015-12-01T00:00:00Z"), "siret" : "01234567891011" }, "Fri Jan 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-01-01T00:00:00Z"), "siret" : "01234567891011" }, "Mon Feb 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-02-01T00:00:00Z"), "siret" : "01234567891011" }, "Tue Mar 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-03-01T00:00:00Z"), "siret" : "01234567891011" }, "Fri Apr 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-04-01T00:00:00Z"), "siret" : "01234567891011" }, "Sun May 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-05-01T00:00:00Z"), "siret" : "01234567891011" }, "Wed Jun 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-06-01T00:00:00Z"), "siret" : "01234567891011" }, "Fri Jul 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-07-01T00:00:00Z"), "siret" : "01234567891011" }, "Mon Aug 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-08-01T00:00:00Z"), "siret" : "01234567891011" }, "Thu Sep 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-09-01T00:00:00Z"), "siret" : "01234567891011" }, "Sat Oct 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-10-01T00:00:00Z"), "siret" : "01234567891011" }, "Tue Nov 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-11-01T00:00:00Z"), "siret" : "01234567891011" }, "Thu Dec 01 2016 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2016-12-01T00:00:00Z"), "siret" : "01234567891011" }, "Sun Jan 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-01-01T00:00:00Z"), "siret" : "01234567891011" }, "Wed Feb 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-02-01T00:00:00Z"), "siret" : "01234567891011" }, "Wed Mar 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-03-01T00:00:00Z"), "siret" : "01234567891011" }, "Sat Apr 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-04-01T00:00:00Z"), "siret" : "01234567891011" }, "Mon May 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-05-01T00:00:00Z"), "siret" : "01234567891011" }, "Thu Jun 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-06-01T00:00:00Z"), "siret" : "01234567891011" }, "Sat Jul 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-07-01T00:00:00Z"), "siret" : "01234567891011" }, "Tue Aug 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-08-01T00:00:00Z"), "siret" : "01234567891011" }, "Fri Sep 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-09-01T00:00:00Z"), "siret" : "01234567891011" }, "Sun Oct 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-10-01T00:00:00Z"), "siret" : "01234567891011" }, "Wed Nov 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-11-01T00:00:00Z"), "siret" : "01234567891011" }, "Fri Dec 01 2017 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2017-12-01T00:00:00Z"), "siret" : "01234567891011" }, "Mon Jan 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-01-01T00:00:00Z"), "siret" : "01234567891011" }, "Thu Feb 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-02-01T00:00:00Z"), "siret" : "01234567891011" }, "Thu Mar 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-03-01T00:00:00Z"), "siret" : "01234567891011" }, "Sun Apr 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-04-01T00:00:00Z"), "siret" : "01234567891011" }, "Tue May 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-05-01T00:00:00Z"), "siret" : "01234567891011" }, "Fri Jun 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-06-01T00:00:00Z"), "siret" : "01234567891011" }, "Sun Jul 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-07-01T00:00:00Z"), "siret" : "01234567891011" }, "Wed Aug 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-08-01T00:00:00Z"), "siret" : "01234567891011" }, "Sat Sep 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-09-01T00:00:00Z"), "siret" : "01234567891011" }, "Mon Oct 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-10-01T00:00:00Z"), "siret" : "01234567891011" }, "Thu Nov 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-11-01T00:00:00Z"), "siret" : "01234567891011" }, "Sat Dec 01 2018 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2018-12-01T00:00:00Z"), "siret" : "01234567891011" }, "Tue Jan 01 2019 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2019-01-01T00:00:00Z"), "siret" : "01234567891011" }, "Fri Feb 01 2019 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2019-02-01T00:00:00Z"), "siret" : "01234567891011" }, "Fri Mar 01 2019 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2019-03-01T00:00:00Z"), "siret" : "01234567891011" }, "Mon Apr 01 2019 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2019-04-01T00:00:00Z"), "siret" : "01234567891011" }, "Wed May 01 2019 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2019-05-01T00:00:00Z"), "siret" : "01234567891011" }, "Sat Jun 01 2019 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2019-06-01T00:00:00Z"), "siret" : "01234567891011" }, "Mon Jul 01 2019 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2019-07-01T00:00:00Z"), "siret" : "01234567891011" }, "Thu Aug 01 2019 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2019-08-01T00:00:00Z"), "siret" : "01234567891011" }, "Sun Sep 01 2019 00:00:00 GMT+0000 (UTC)" : { "periode" : ISODate("2019-09-01T00:00:00Z"), "siret" : "01234567891011" } } } }, "scope" : "etablissement", "index" : { "algo1" : false, "algo2" : false }, "key" : "01234567891011" } }
+[
+	{
+		"_id" : "01234567891011",
+		"value" : {
+			"batch" : {
+				"1910" : {
+					"reporder" : {
+						"Wed Jan 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-01-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sat Feb 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-02-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sat Mar 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-03-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Tue Apr 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-04-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Thu May 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-05-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sun Jun 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-06-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Tue Jul 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-07-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Fri Aug 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-08-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Mon Sep 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-09-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Wed Oct 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-10-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sat Nov 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-11-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Mon Dec 01 2014 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2014-12-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Thu Jan 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-01-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sun Feb 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-02-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sun Mar 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-03-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Wed Apr 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-04-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Fri May 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-05-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Mon Jun 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-06-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Wed Jul 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-07-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sat Aug 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-08-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Tue Sep 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-09-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Thu Oct 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-10-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sun Nov 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-11-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Tue Dec 01 2015 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2015-12-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Fri Jan 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-01-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Mon Feb 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-02-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Tue Mar 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-03-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Fri Apr 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-04-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sun May 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-05-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Wed Jun 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-06-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Fri Jul 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-07-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Mon Aug 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-08-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Thu Sep 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-09-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sat Oct 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-10-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Tue Nov 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-11-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Thu Dec 01 2016 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2016-12-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sun Jan 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-01-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Wed Feb 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-02-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Wed Mar 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-03-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sat Apr 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-04-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Mon May 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-05-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Thu Jun 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-06-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sat Jul 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-07-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Tue Aug 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-08-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Fri Sep 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-09-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sun Oct 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-10-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Wed Nov 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-11-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Fri Dec 01 2017 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2017-12-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Mon Jan 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-01-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Thu Feb 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-02-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Thu Mar 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-03-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sun Apr 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-04-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Tue May 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-05-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Fri Jun 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-06-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sun Jul 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-07-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Wed Aug 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-08-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sat Sep 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-09-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Mon Oct 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-10-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Thu Nov 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-11-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sat Dec 01 2018 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2018-12-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Tue Jan 01 2019 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2019-01-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Fri Feb 01 2019 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2019-02-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Fri Mar 01 2019 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2019-03-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Mon Apr 01 2019 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2019-04-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Wed May 01 2019 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2019-05-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sat Jun 01 2019 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2019-06-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Mon Jul 01 2019 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2019-07-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Thu Aug 01 2019 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2019-08-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						},
+						"Sun Sep 01 2019 00:00:00 GMT+0000 (UTC)" : {
+							"periode" : ISODate("2019-09-01T00:00:00Z"),
+							"siret" : "01234567891011"
+						}
+					}
+				}
+			},
+			"scope" : "etablissement",
+			"index" : {
+				"algo1" : false,
+				"algo2" : false
+			},
+			"key" : "01234567891011"
+		}
+	}
+]
 // Documents from db.Features_debug, after call to /api/data/reduce:
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-01-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-01-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-02-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-02-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-03-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-03-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-04-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-04-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-05-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-05-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-06-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-06-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-07-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-07-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-08-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-08-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-09-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-09-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-10-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-10-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-11-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-11-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2014-12-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2014-12-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2015-01-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2015-01-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2015-02-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2015-02-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2015-03-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2015-03-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2015-04-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2015-04-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2015-05-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2015-05-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2015-06-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2015-06-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2015-07-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2015-07-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
-{ "_id" : { "batch" : "1910", "siret" : "01234567891011", "periode" : ISODate("2015-08-01T00:00:00Z") }, "value" : { "siret" : "01234567891011", "periode" : ISODate("2015-08-01T00:00:00Z"), "effectif" : null, "etat_proc_collective" : "in_bonis", "interessante_urssaf" : true, "outcome" : false, "cotisation_moy12m" : 0, "nbr_etablissements_connus" : 1 } }
+[
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-01-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-01-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-02-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-02-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-03-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-03-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-04-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-04-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-05-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-05-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-06-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-06-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-07-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-07-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-08-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-08-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-09-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-09-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-10-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-10-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-11-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-11-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-12-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2014-12-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-01-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-01-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-02-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-02-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-03-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-03-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-04-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-04-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-05-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-05-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-06-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-06-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-07-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-07-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-08-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-08-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-09-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-09-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-10-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-10-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-11-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-11-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-12-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2015-12-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-01-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-01-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-02-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-02-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-03-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-03-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-04-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-04-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-05-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-05-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-06-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-06-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-07-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-07-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-08-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-08-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-09-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-09-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-10-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-10-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-11-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-11-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-12-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2016-12-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-01-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-01-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-02-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-02-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-03-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-03-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-04-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-04-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-05-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-05-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-06-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-06-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-07-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-07-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-08-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-08-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-09-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-09-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-10-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-10-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-11-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-11-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-12-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2017-12-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-01-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-01-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-02-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-02-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-03-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-03-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-04-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-04-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-05-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-05-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-06-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-06-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-07-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-07-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-08-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-08-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-09-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-09-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-10-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-10-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-11-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-11-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-12-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2018-12-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-01-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-01-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-02-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-02-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-03-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-03-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-04-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-04-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-05-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-05-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-06-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-06-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-07-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-07-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-08-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-08-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	},
+	{
+		"_id" : {
+			"batch" : "1910",
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-09-01T00:00:00Z")
+		},
+		"value" : {
+			"siret" : "01234567891011",
+			"periode" : ISODate("2019-09-01T00:00:00Z"),
+			"effectif" : null,
+			"etat_proc_collective" : "in_bonis",
+			"interessante_urssaf" : true,
+			"outcome" : false,
+			"cotisation_moy12m" : 0,
+			"nbr_etablissements_connus" : 1
+		}
+	}
+]
 // Documents from db.Public_debug, after call to /api/data/public:
-{ "_id" : "etablissement_01234567891011", "value" : { "key" : "01234567891011", "batch" : "1910", "effectif" : [ ], "dernier_effectif" : undefined, "sirene" : {  }, "cotisation" : [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ], "debit" : [ { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 }, { "part_ouvriere" : 0, "part_patronale" : 0 } ], "apconso" : [ ], "apdemande" : [ ], "delai" : [ ], "compte" : undefined, "procol" : undefined, "last_procol" : { "etat" : "in_bonis" }, "idEntreprise" : "entreprise_012345678" } }
+[
+	{
+		"_id" : "etablissement_01234567891011",
+		"value" : {
+			"key" : "01234567891011",
+			"batch" : "1910",
+			"effectif" : [ ],
+			"dernier_effectif" : undefined,
+			"sirene" : {
+				
+			},
+			"cotisation" : [
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0
+			],
+			"debit" : [
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				},
+				{
+					"part_ouvriere" : 0,
+					"part_patronale" : 0
+				}
+			],
+			"apconso" : [ ],
+			"apdemande" : [ ],
+			"delai" : [ ],
+			"compte" : undefined,
+			"procol" : undefined,
+			"last_procol" : {
+				"etat" : "in_bonis"
+			},
+			"idEntreprise" : "entreprise_012345678"
+		}
+	}
+]

--- a/test-api.sh
+++ b/test-api.sh
@@ -10,7 +10,7 @@ set -e # will stop the script if any command fails with a non-zero exit code
 
 # Clean up on exit
 DATA_DIR=$(pwd)/tmp-opensignauxfaibles-data-raw
-trap "{ [ -f config.toml ] && rm config.toml; [ -f config.backup.toml ] && mv config.backup.toml config.toml; docker stop sf-mongodb; rm -rf ${DATA_DIR}; echo \"✨ Cleaned up temp directory\"; }" EXIT
+trap "{ killall dbmongo; [ -f config.toml ] && rm config.toml; [ -f config.backup.toml ] && mv config.backup.toml config.toml; docker stop sf-mongodb; rm -rf ${DATA_DIR}; echo \"✨ Cleaned up temp directory\"; }" EXIT
 
 echo ""
 echo "🐳 Starting MongoDB container..."
@@ -88,12 +88,10 @@ CONTENTS
 echo ""
 echo "⚙️ Computing Features and Public collections thru dbmongo API..."
 ./dbmongo &
-DBMONGO_PID=$!
 sleep 2 # give some time for dbmongo to start
 http --ignore-stdin :5000/api/data/compact batch=1910
 http --ignore-stdin :5000/api/data/reduce algo=algo2 batch=1910 key=012345678
 http --ignore-stdin :5000/api/data/public batch=1910 key=012345678
-kill ${DBMONGO_PID}
 
 echo ""
 echo "🕵️‍♀️ Checking resulting Features..."

--- a/test-api.sh
+++ b/test-api.sh
@@ -98,25 +98,17 @@ kill ${DBMONGO_PID}
 echo ""
 echo "🕵️‍♀️ Checking resulting Features..."
 cd ..
-docker exec -i sf-mongodb mongo signauxfaibles > test-api.output.txt << CONTENTS
+docker exec -i sf-mongodb mongo --quiet signauxfaibles > test-api.output.txt << CONTENTS
   print("// Documents from db.RawData, after call to /api/data/compact:");
-  db.RawData.find();
+  db.RawData.find().toArray();
   print("// Documents from db.Features_debug, after call to /api/data/reduce:");
-  db.Features_debug.find();
+  db.Features_debug.find().toArray();
   print("// Documents from db.Public_debug, after call to /api/data/public:");
-  db.Public_debug.find();
+  db.Public_debug.find().toArray();
 CONTENTS
 
-grep "^[^{/]" test-api.output.txt # display mongo connection info, for troubleshooting
-grep "^[{/]" test-api.output.txt > test-api.output-documents.txt
-
 # exclude random values
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' 's/ "random_order" : [0-9]*\.[0-9]*, / /g' test-api.output-documents.txt
-else
-  sed -i 's/ "random_order" : [0-9]*\.[0-9]*, / /g' test-api.output-documents.txt
-fi
-
+grep -v '"random_order" :' test-api.output.txt > test-api.output-documents.txt
 
 echo ""
 echo "🆎 Diff between expected and actual output:"


### PR DESCRIPTION
Problème: les résultats des tests de bout en bout sont trop peu lisibles pour détecter et investiguer les différences qui pourraient apparaitre.

Solution: cette PR formate les résultats JSON de manière à ce que chaque propriété soit affiché sur une ligne dédiée.

Bonus: ce formatage rend plus simple le filtrage des logs, et donc le script d'exécution des tests.