### PR TITLE
fix(TS): Sécurisation des fonctions TS (`noImplicitAny`)

### DIFF
--- a/dbmongo/js/common/generatePeriodSerie.d.ts
+++ b/dbmongo/js/common/generatePeriodSerie.d.ts
@@ -1,0 +1,1 @@
+export function generatePeriodSerie(date_debut: Date, date_fin: Date): Date[]

--- a/dbmongo/js/common/setBatchValueForType.ts
+++ b/dbmongo/js/common/setBatchValueForType.ts
@@ -1,0 +1,30 @@
+export function setBatchValueForType(
+  batchValue: BatchValue,
+  typeName: keyof BatchValue,
+  updatedValues: BatchValue[keyof BatchValue]
+): void {
+  switch (typeName) {
+    case "reporder":
+      batchValue[typeName] = updatedValues as BatchValue["reporder"]
+      break
+    case "compact":
+      batchValue[typeName] = updatedValues as BatchValue["compact"]
+      break
+    case "effectif":
+      batchValue[typeName] = updatedValues as BatchValue["effectif"]
+      break
+    case "apconso":
+      batchValue[typeName] = updatedValues as BatchValue["apconso"]
+      break
+    case "apdemande":
+      batchValue[typeName] = updatedValues as BatchValue["apdemande"]
+      break
+    default:
+      // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
+      // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
+      // source: https://stackoverflow.com/a/61806149/592254
+      ;((caseVal: never): void => {
+        throw new Error(`case "${caseVal}" should be added to switch`)
+      })(typeName)
+  }
+}

--- a/dbmongo/js/common/setBatchValueForType.ts
+++ b/dbmongo/js/common/setBatchValueForType.ts
@@ -23,6 +23,7 @@ export function setBatchValueForType(
       // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
       // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
       // source: https://stackoverflow.com/a/61806149/592254
+      // eslint-disable-next-line no-extra-semi
       ;((caseVal: never): void => {
         throw new Error(`case "${caseVal}" should be added to switch`)
       })(typeName)

--- a/dbmongo/js/common/setBatchValueForType.ts
+++ b/dbmongo/js/common/setBatchValueForType.ts
@@ -1,31 +1,10 @@
-export function setBatchValueForType(
+// Cette fonction TypeScript permet de vérifier que seuls les types reconnus
+// peuvent être intégrés dans un BatchValue de destination.
+// Ex: setBatchValueForType(batchValue, "pouet", {}) cause une erreur ts(2345).
+export function setBatchValueForType<T extends keyof BatchValue>(
   batchValue: BatchValue,
-  typeName: keyof BatchValue,
-  updatedValues: BatchValue[keyof BatchValue]
+  typeName: T,
+  updatedValues: BatchValue[T]
 ): void {
-  switch (typeName) {
-    case "reporder":
-      batchValue[typeName] = updatedValues as BatchValue["reporder"]
-      break
-    case "compact":
-      batchValue[typeName] = updatedValues as BatchValue["compact"]
-      break
-    case "effectif":
-      batchValue[typeName] = updatedValues as BatchValue["effectif"]
-      break
-    case "apconso":
-      batchValue[typeName] = updatedValues as BatchValue["apconso"]
-      break
-    case "apdemande":
-      batchValue[typeName] = updatedValues as BatchValue["apdemande"]
-      break
-    default:
-      // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
-      // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
-      // source: https://stackoverflow.com/a/61806149/592254
-      // eslint-disable-next-line no-extra-semi
-      ;((caseVal: never): void => {
-        throw new Error(`case "${caseVal}" should be added to switch`)
-      })(typeName)
-  }
+  batchValue[typeName] = updatedValues
 }

--- a/dbmongo/js/compact/complete_reporder.ts
+++ b/dbmongo/js/compact/complete_reporder.ts
@@ -9,7 +9,7 @@ export function complete_reporder(
   "use strict"
   const batches = Object.keys(object.batch)
   batches.sort()
-  const missing = {}
+  const missing: { [key: string]: boolean } = {}
   serie_periode.forEach((p) => {
     missing[p.getTime()] = true
   })

--- a/dbmongo/js/compact/currentState.ts
+++ b/dbmongo/js/compact/currentState.ts
@@ -17,7 +17,7 @@ export function currentState(batches: BatchValue[]): CurrentDataState {
       //2. On ajoute les nouvelles clés
       Object.keys(batch)
         .filter((type) => type !== "compact")
-        .forEach((type) => {
+        .forEach((type: keyof BatchValue) => {
           m[type] = m[type] || new Set()
 
           Object.keys(batch[type]).forEach((key) => {

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -1,37 +1,6 @@
 import "../globals.ts"
-
+import { setBatchValueForType } from "../common/setBatchValueForType"
 import * as f from "./currentState"
-
-const setBatchValueForType = (
-  batchValue: BatchValue,
-  typeName: keyof BatchValue,
-  updatedValues: BatchValue[keyof BatchValue]
-): void => {
-  switch (typeName) {
-    case "reporder":
-      batchValue[typeName] = updatedValues as BatchValue["reporder"]
-      break
-    case "compact":
-      batchValue[typeName] = updatedValues as BatchValue["compact"]
-      break
-    case "effectif":
-      batchValue[typeName] = updatedValues as BatchValue["effectif"]
-      break
-    case "apconso":
-      batchValue[typeName] = updatedValues as BatchValue["apconso"]
-      break
-    case "apdemande":
-      batchValue[typeName] = updatedValues as BatchValue["apdemande"]
-      break
-    default:
-      // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
-      // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
-      // source: https://stackoverflow.com/a/61806149/592254
-      ;((caseVal: never): void => {
-        throw new Error(`case "${caseVal}" should be added to switch`)
-      })(typeName)
-  }
-}
 
 // Entrée: données d'entreprises venant de ImportedData, regroupées par entreprise ou établissement.
 // Sortie: un objet fusionné par entreprise ou établissement, contenant les données historiques et les données importées, à destination de la collection RawData.

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -196,14 +196,11 @@ export function reduce(
       }
     })
 
-    new_types.forEach((typeName: keyof BatchValue) => {
-      if (hashToAdd[typeName] && typeName !== "compact") {
-        const type = typeName as keyof Omit<BatchValue, "compact">
-        typeof reduced_value.batch[batch][type]
-        const batchValue = reduced_value.batch[batch]
-        const hashedValues = batchValue[type]
+    new_types.forEach((type: keyof BatchValue) => {
+      if (hashToAdd[type] && type !== "compact") {
+        const hashedValues = reduced_value.batch[batch][type]
 
-        const updatedValues = Object.keys(batchValue[type] || {})
+        const updatedValues = Object.keys(hashedValues || {})
           .filter((hash) => {
             return hashToAdd[type].has(hash)
           })
@@ -212,7 +209,7 @@ export function reduce(
             return m
           }, {})
 
-        setBatchValueForType(batchValue, typeName, updatedValues)
+        setBatchValueForType(reduced_value.batch[batch], type, updatedValues)
       }
     })
 

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -26,7 +26,27 @@ export function reduce(
       Object.keys(value.batch).forEach((batch) => {
         m.batch[batch] = m.batch[batch] || {}
         Object.keys(value.batch[batch]).forEach((type: keyof BatchValue) => {
-          Object.assign(m.batch[batch][type], value.batch[batch][type])
+          const updatedValues = {
+            ...m.batch[batch][type],
+            ...value.batch[batch][type],
+          }
+          switch (type) {
+            case "reporder":
+              m.batch[batch][type] = updatedValues as BatchValue["reporder"]
+              break
+            case "effectif":
+              m.batch[batch][type] = updatedValues as BatchValue["effectif"]
+              break
+            case "compact":
+              m.batch[batch][type] = updatedValues as BatchValue["compact"]
+              break
+            default:
+              // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
+              // source: https://stackoverflow.com/a/61806149/592254
+              ;((caseVal: never): void => {
+                throw new Error(`case "${caseVal}" should be added to switch`)
+              })(type) // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
+          }
         })
       })
       return m
@@ -192,26 +212,37 @@ export function reduce(
       }
     })
 
-    new_types.forEach((type: keyof BatchValue) => {
-      if (hashToAdd[type]) {
-        reduced_value.batch[batch][type] = Object.keys(
-          reduced_value.batch[batch][type] || {}
-        )
+    new_types.forEach((typeName: keyof BatchValue) => {
+      if (hashToAdd[typeName] && typeName !== "compact") {
+        const type = typeName as keyof Omit<BatchValue, "compact">
+        typeof reduced_value.batch[batch][type]
+        const batchValue = reduced_value.batch[batch]
+        const hashedValues = batchValue[type]
+
+        const updatedValues = Object.keys(batchValue[type] || {})
           .filter((hash) => {
             return hashToAdd[type].has(hash)
           })
-          .reduce((m, hash: DataHash) => {
-            const batchValue = reduced_value.batch[batch]
-            const values = batchValue[type]
-            m[hash] = values[hash]
-            // TODO: the assignment above is too generic compared to the CompanyDataValues type of reduced_value / m.
-            // I.e. hash may actually be a period, a dataDash or "delete"!
-            // => Do we want to merge them all into reduced_value, including "delete"? => What should the type of m be?
-            // Note: Making CompanyDataValues less strict may have an impact on may other functions that rely on it.
-            // => We should write a TS integration test that calls map() reduce() and finalize() while checking types,
-            // to make sure that the types of all our functions are still compatible.
+          .reduce((m: typeof hashedValues, hash: string) => {
+            m[hash] = hashedValues[hash]
             return m
           }, {})
+
+        switch (typeName) {
+          case "reporder":
+            batchValue[typeName] = updatedValues as BatchValue["reporder"]
+            break
+          case "effectif":
+            batchValue[typeName] = updatedValues as BatchValue["effectif"]
+            break
+          default:
+            // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
+            // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
+            // source: https://stackoverflow.com/a/61806149/592254
+            ;((caseVal: never): void => {
+              throw new Error(`case "${caseVal}" should be added to switch`)
+            })(typeName)
+        }
       }
     })
 

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -40,6 +40,9 @@ export function reduce(
             case "compact":
               m.batch[batch][type] = updatedValues as BatchValue["compact"]
               break
+            case "apconso":
+              m.batch[batch][type] = updatedValues as BatchValue["apconso"]
+              break
             default:
               // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
               // source: https://stackoverflow.com/a/61806149/592254
@@ -234,6 +237,9 @@ export function reduce(
             break
           case "effectif":
             batchValue[typeName] = updatedValues as BatchValue["effectif"]
+            break
+          case "apconso":
+            batchValue[typeName] = updatedValues as BatchValue["apconso"]
             break
           default:
             // This switch should be exhaustive: cover all the keys defined in the BatchValue type.

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -2,6 +2,34 @@ import "../globals.ts"
 
 import * as f from "./currentState"
 
+const setBatchValueForType = (
+  batchValue: BatchValue,
+  typeName: keyof BatchValue,
+  updatedValues: BatchValue[keyof BatchValue]
+): void => {
+  switch (typeName) {
+    case "reporder":
+      batchValue[typeName] = updatedValues as BatchValue["reporder"]
+      break
+    case "compact":
+      batchValue[typeName] = updatedValues as BatchValue["compact"]
+      break
+    case "effectif":
+      batchValue[typeName] = updatedValues as BatchValue["effectif"]
+      break
+    case "apconso":
+      batchValue[typeName] = updatedValues as BatchValue["apconso"]
+      break
+    default:
+      // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
+      // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
+      // source: https://stackoverflow.com/a/61806149/592254
+      ;((caseVal: never): void => {
+        throw new Error(`case "${caseVal}" should be added to switch`)
+      })(typeName)
+  }
+}
+
 // Entrée: données d'entreprises venant de ImportedData, regroupées par entreprise ou établissement.
 // Sortie: un objet fusionné par entreprise ou établissement, contenant les données historiques et les données importées, à destination de la collection RawData.
 // Opérations: retrait des données doublons et application des corrections de données éventuelles.
@@ -30,26 +58,7 @@ export function reduce(
             ...m.batch[batch][type],
             ...value.batch[batch][type],
           }
-          switch (type) {
-            case "reporder":
-              m.batch[batch][type] = updatedValues as BatchValue["reporder"]
-              break
-            case "effectif":
-              m.batch[batch][type] = updatedValues as BatchValue["effectif"]
-              break
-            case "compact":
-              m.batch[batch][type] = updatedValues as BatchValue["compact"]
-              break
-            case "apconso":
-              m.batch[batch][type] = updatedValues as BatchValue["apconso"]
-              break
-            default:
-              // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
-              // source: https://stackoverflow.com/a/61806149/592254
-              ;((caseVal: never): void => {
-                throw new Error(`case "${caseVal}" should be added to switch`)
-              })(type) // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
-          }
+          setBatchValueForType(m.batch[batch], type, updatedValues)
         })
       })
       return m
@@ -231,24 +240,7 @@ export function reduce(
             return m
           }, {})
 
-        switch (typeName) {
-          case "reporder":
-            batchValue[typeName] = updatedValues as BatchValue["reporder"]
-            break
-          case "effectif":
-            batchValue[typeName] = updatedValues as BatchValue["effectif"]
-            break
-          case "apconso":
-            batchValue[typeName] = updatedValues as BatchValue["apconso"]
-            break
-          default:
-            // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
-            // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
-            // source: https://stackoverflow.com/a/61806149/592254
-            ;((caseVal: never): void => {
-              throw new Error(`case "${caseVal}" should be added to switch`)
-            })(typeName)
-        }
+        setBatchValueForType(batchValue, typeName, updatedValues)
       }
     })
 

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -20,6 +20,9 @@ const setBatchValueForType = (
     case "apconso":
       batchValue[typeName] = updatedValues as BatchValue["apconso"]
       break
+    case "apdemande":
+      batchValue[typeName] = updatedValues as BatchValue["apdemande"]
+      break
     default:
       // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
       // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.

--- a/dbmongo/js/compact/reduce_test.js
+++ b/dbmongo/js/compact/reduce_test.js
@@ -392,9 +392,6 @@ const test_cases = [
 ]
 Object.freeze(test_cases)
 
-const f = { currentState }
-Object.freeze(f)
-
 const jsParams = this // => all properties of this object will become global. TODO: remove this when merging namespace (https://github.com/signaux-faibles/opensignauxfaibles/pull/40)
 
 const test_results = test_cases.map(function(tc, id) {

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -1,9 +1,5 @@
 // Déclaration des fonctions globales fournies par MongoDB
 declare function emit(key: string, value: object): void
-// declare function print(...any): void
-
-// Déclaration des fonctions globales fournies par JSC
-// declare function debug(string) // supported by jsc, to print in stdout
 
 // Paramètres globaux utilisés par "compact"
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -39,7 +39,8 @@ type BatchValue = {
   reporder: { [periode: string]: RepOrder }
   compact: { delete: { [dataType: string]: DataHash[] } }
   effectif: { [dataHash: string]: Effectif }
-  apconso: { [key: string]: any } // TODO: définition de type à vérifier !
+  apconso: { [key: string]: any } // TODO: définir type plus précisément
+  apdemande: { [key: string]: any } // TODO: définir type plus précisément
 }
 
 type DataHash = string

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -1,9 +1,9 @@
 // Déclaration des fonctions globales fournies par MongoDB
-declare function emit(key: any, value: any): void
-declare function print(...any): void
+declare function emit(key: string, value: object): void
+// declare function print(...any): void
 
 // Déclaration des fonctions globales fournies par JSC
-declare function debug(string) // supported by jsc, to print in stdout
+// declare function debug(string) // supported by jsc, to print in stdout
 
 // Paramètres globaux utilisés par "compact"
 /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -39,6 +39,7 @@ type BatchValue = {
   reporder: { [periode: string]: RepOrder }
   compact: { delete: { [dataType: string]: DataHash[] } }
   effectif: { [dataHash: string]: Effectif }
+  apconso: { [key: string]: any } // TODO: définition de type à vérifier !
 }
 
 type DataHash = string

--- a/dbmongo/js/package.json
+++ b/dbmongo/js/package.json
@@ -7,8 +7,8 @@
     "test": "test"
   },
   "scripts": {
-    "lint": "eslint **/*.ts",
-    "lint:fix": "eslint **/*.ts --fix",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix",
     "test": "ava",
     "test:coverage": "TS_NODE_FILES=true nyc npm test"
   },

--- a/dbmongo/js/reduce.algo2/fraisFinancier.ts
+++ b/dbmongo/js/reduce.algo2/fraisFinancier.ts
@@ -1,4 +1,20 @@
-export function fraisFinancier(diane): number | null {
+export type DianeProperty =
+  | "interets"
+  | "excedent_brut_d_exploitation"
+  | "produits_financiers"
+  | "produit_exceptionnel"
+  | "charge_exceptionnelle"
+  | "charges_financieres"
+
+export type Diane = {
+  [prop in DianeProperty]: number
+}
+
+export type DianePartial = {
+  [prop in DianeProperty]: number | null
+}
+
+export function fraisFinancier(diane: DianePartial): number | null {
   "use strict"
   if (
     "interets" in diane &&

--- a/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
+++ b/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
@@ -1,14 +1,10 @@
 import test from "ava"
-import { fraisFinancier } from "./fraisFinancier"
-
-type Diane = {
-  interets: number
-  excedent_brut_d_exploitation: number
-  produits_financiers: number
-  produit_exceptionnel: number
-  charge_exceptionnelle: number
-  charges_financieres: number
-}
+import {
+  fraisFinancier,
+  Diane,
+  DianePartial,
+  DianeProperty,
+} from "./fraisFinancier"
 
 const fakeDiane = (): Diane => ({
   interets: 50,
@@ -46,9 +42,9 @@ const proprietes = [
   "charge_exceptionnelle",
   "charges_financieres",
 ]
-proprietes.forEach((propriete) =>
+proprietes.forEach((propriete: DianeProperty) =>
   test(`fraisFinancier est nul si "${propriete}" n'est pas disponible dans Diane`, (t) => {
-    const diane = fakeDiane()
+    const diane = fakeDiane() as DianePartial
     diane[propriete] = null
     t.is(fraisFinancier(diane), null)
     delete diane[propriete]

--- a/dbmongo/js/reduce.algo2/map.d.ts
+++ b/dbmongo/js/reduce.algo2/map.d.ts
@@ -1,0 +1,1 @@
+export function map(): void

--- a/dbmongo/js/test/test_compact.sh
+++ b/dbmongo/js/test/test_compact.sh
@@ -1,5 +1,7 @@
 # This file is run by dbmongo/js_test.go.
 
+shopt -s extglob # enable exclusion of test files in wildcard
+
 result_currentState=$(jsc \
   ../compact/currentState.js \
   ../compact/currentState_test.js\

--- a/dbmongo/js/test/test_compact.sh
+++ b/dbmongo/js/test/test_compact.sh
@@ -11,6 +11,7 @@ fi
 
 result_reduce=$(jsc \
   ./helpers/testing.js \
+  ../common/!(*_test).js \
   ../compact/currentState.js \
   ../compact/reduce.js \
   ../compact/reduce_test.js\

--- a/dbmongo/js/test/test_compact.sh
+++ b/dbmongo/js/test/test_compact.sh
@@ -12,6 +12,7 @@ if [ "$result_currentState" != 'true' ]; then
 fi
 
 result_reduce=$(jsc \
+  ./helpers/fakes.js \
   ./helpers/testing.js \
   ../common/!(*_test).js \
   ../compact/currentState.js \

--- a/dbmongo/js/test/test_compact.sh
+++ b/dbmongo/js/test/test_compact.sh
@@ -1,22 +1,22 @@
 # This file is run by dbmongo/js_test.go.
 
-result_add=$(jsc \
+result_currentState=$(jsc \
   ../compact/currentState.js \
   ../compact/currentState_test.js\
   2>&1)
-if [ "$result_add" != 'true' ]; then
-  echo "$result_add"
+if [ "$result_currentState" != 'true' ]; then
+  echo "result_currentState: $result_currentState"
   exit 1
 fi
 
-result_add=$(jsc \
+result_reduce=$(jsc \
   ./helpers/testing.js \
   ../compact/currentState.js \
   ../compact/reduce.js \
   ../compact/reduce_test.js\
   2>&1)
-if [ "$result_add" != 'true' ]; then
-  echo "$result_add"
+if [ "$result_reduce" != 'true' ]; then
+  echo "result_reduce: $result_reduce"
   exit 1
 fi
 

--- a/dbmongo/js/tsconfig.json
+++ b/dbmongo/js/tsconfig.json
@@ -28,7 +28,7 @@
 
     /* Strict Type-Checking Options */
     // "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
     "strictNullChecks": true /* Enable strict null checks. */,
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */

--- a/dbmongo/js/tsconfig.json
+++ b/dbmongo/js/tsconfig.json
@@ -32,7 +32,7 @@
     "strictNullChecks": true /* Enable strict null checks. */,
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     "strictBindCallApply": true /* Enable strict 'bind', 'call', and 'apply' methods on functions. */,
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
     "noImplicitUseStrict": true /* to not add "use strict" at the top of transpiled JS files */,

--- a/dbmongo/js/tsconfig.json
+++ b/dbmongo/js/tsconfig.json
@@ -39,10 +39,10 @@
     "skipLibCheck": true /* to speed up transpilation, when running go generate and go test */,
 
     /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noUnusedParameters": true /* Report errors on unused parameters. */,
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */

--- a/dbmongo/js/tsconfig.json
+++ b/dbmongo/js/tsconfig.json
@@ -33,7 +33,7 @@
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     "strictBindCallApply": true /* Enable strict 'bind', 'call', and 'apply' methods on functions. */,
     "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
     "noImplicitUseStrict": true /* to not add "use strict" at the top of transpiled JS files */,
     "skipLibCheck": true /* to speed up transpilation, when running go generate and go test */,

--- a/dbmongo/js/tsconfig.json
+++ b/dbmongo/js/tsconfig.json
@@ -31,7 +31,7 @@
     "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
     "strictNullChecks": true /* Enable strict null checks. */,
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    "strictBindCallApply": true /* Enable strict 'bind', 'call', and 'apply' methods on functions. */,
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -207,6 +207,7 @@ package engine
             // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
             // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
             // source: https://stackoverflow.com/a/61806149/592254
+            // eslint-disable-next-line no-extra-semi
             ;
             ((caseVal) => {
                 throw new Error(` + "`" + `case "${caseVal}" should be added to switch` + "`" + `);

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -296,6 +296,9 @@ function finalize(k, o) {
         case "apconso":
             batchValue[typeName] = updatedValues;
             break;
+        case "apdemande":
+            batchValue[typeName] = updatedValues;
+            break;
         default:
             // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
             // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -186,33 +186,11 @@ package engine
   }
   return(reg)
 }`,
-"setBatchValueForType": `function setBatchValueForType(batchValue, typeName, updatedValues) {
-    switch (typeName) {
-        case "reporder":
-            batchValue[typeName] = updatedValues;
-            break;
-        case "compact":
-            batchValue[typeName] = updatedValues;
-            break;
-        case "effectif":
-            batchValue[typeName] = updatedValues;
-            break;
-        case "apconso":
-            batchValue[typeName] = updatedValues;
-            break;
-        case "apdemande":
-            batchValue[typeName] = updatedValues;
-            break;
-        default:
-            // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
-            // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
-            // source: https://stackoverflow.com/a/61806149/592254
-            // eslint-disable-next-line no-extra-semi
-            ;
-            ((caseVal) => {
-                throw new Error(` + "`" + `case "${caseVal}" should be added to switch` + "`" + `);
-            })(typeName);
-    }
+"setBatchValueForType": `// Cette fonction TypeScript permet de vérifier que seuls les types reconnus
+// peuvent être intégrés dans un BatchValue de destination.
+// Ex: setBatchValueForType(batchValue, "pouet", {}) cause une erreur ts(2345).
+function setBatchValueForType(batchValue, typeName, updatedValues) {
+    batchValue[typeName] = updatedValues;
 }`,
 },
 "compact":{

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -457,13 +457,10 @@ function reduce(key, values) {
                 ];
             }
         });
-        new_types.forEach((typeName) => {
-            if (hashToAdd[typeName] && typeName !== "compact") {
-                const type = typeName;
-                typeof reduced_value.batch[batch][type];
-                const batchValue = reduced_value.batch[batch];
-                const hashedValues = batchValue[type];
-                const updatedValues = Object.keys(batchValue[type] || {})
+        new_types.forEach((type) => {
+            if (hashToAdd[type] && type !== "compact") {
+                const hashedValues = reduced_value.batch[batch][type];
+                const updatedValues = Object.keys(hashedValues || {})
                     .filter((hash) => {
                     return hashToAdd[type].has(hash);
                 })
@@ -471,7 +468,7 @@ function reduce(key, values) {
                     m[hash] = hashedValues[hash];
                     return m;
                 }, {});
-                setBatchValueForType(batchValue, typeName, updatedValues);
+                setBatchValueForType(reduced_value.batch[batch], type, updatedValues);
             }
         });
         // 6. nettoyage

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -186,6 +186,33 @@ package engine
   }
   return(reg)
 }`,
+"setBatchValueForType": `function setBatchValueForType(batchValue, typeName, updatedValues) {
+    switch (typeName) {
+        case "reporder":
+            batchValue[typeName] = updatedValues;
+            break;
+        case "compact":
+            batchValue[typeName] = updatedValues;
+            break;
+        case "effectif":
+            batchValue[typeName] = updatedValues;
+            break;
+        case "apconso":
+            batchValue[typeName] = updatedValues;
+            break;
+        case "apdemande":
+            batchValue[typeName] = updatedValues;
+            break;
+        default:
+            // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
+            // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
+            // source: https://stackoverflow.com/a/61806149/592254
+            ;
+            ((caseVal) => {
+                throw new Error(` + "`" + `case "${caseVal}" should be added to switch` + "`" + `);
+            })(typeName);
+    }
+}`,
 },
 "compact":{
 "complete_reporder": `// complete_reporder ajoute une propriété "reporder" pour chaque couple
@@ -282,34 +309,7 @@ function finalize(k, o) {
     }
     emit(this.value.key, this.value);
 }`,
-"reduce": `const setBatchValueForType = (batchValue, typeName, updatedValues) => {
-    switch (typeName) {
-        case "reporder":
-            batchValue[typeName] = updatedValues;
-            break;
-        case "compact":
-            batchValue[typeName] = updatedValues;
-            break;
-        case "effectif":
-            batchValue[typeName] = updatedValues;
-            break;
-        case "apconso":
-            batchValue[typeName] = updatedValues;
-            break;
-        case "apdemande":
-            batchValue[typeName] = updatedValues;
-            break;
-        default:
-            // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
-            // => Warning TS(2345) if we miss a case, e.g. Argument of type '"new_effectif"' is not assignable to parameter of type 'never'.
-            // source: https://stackoverflow.com/a/61806149/592254
-            ;
-            ((caseVal) => {
-                throw new Error(` + "`" + `case "${caseVal}" should be added to switch` + "`" + `);
-            })(typeName);
-    }
-};
-// Entrée: données d'entreprises venant de ImportedData, regroupées par entreprise ou établissement.
+"reduce": `// Entrée: données d'entreprises venant de ImportedData, regroupées par entreprise ou établissement.
 // Sortie: un objet fusionné par entreprise ou établissement, contenant les données historiques et les données importées, à destination de la collection RawData.
 // Opérations: retrait des données doublons et application des corrections de données éventuelles.
 function reduce(key, values) {

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -310,6 +310,9 @@ function reduce(key, values) {
                     case "compact":
                         m.batch[batch][type] = updatedValues;
                         break;
+                    case "apconso":
+                        m.batch[batch][type] = updatedValues;
+                        break;
                     default:
                         // This switch should be exhaustive: cover all the keys defined in the BatchValue type.
                         // source: https://stackoverflow.com/a/61806149/592254
@@ -465,6 +468,9 @@ function reduce(key, values) {
                         batchValue[typeName] = updatedValues;
                         break;
                     case "effectif":
+                        batchValue[typeName] = updatedValues;
+                        break;
+                    case "apconso":
                         batchValue[typeName] = updatedValues;
                         break;
                     default:


### PR DESCRIPTION
## Problème

Avec la configuration TypeScript actuelle, il reste possible que nous ne soyons pas alertés si nous passons un objet incomplet (ex: contenant des propriétés `null` ou `undefined`) à une fonction dans laquelle nous aurions oublié de définir le type des paramètres.

Or on souhaite justement éviter que ce genre de cas entrainent une erreur en runtime après des heures de calculs !

## Solution proposée

Activer `noImplicitAny` dans la configuration de TypeScript permet de nous forcer à typer explicitement tous les paramètres et les retours de nos fonctions, et donc à activer la validation de ces types (et notamment vérifier que les propriétés non optionnelles soient fournies) dans toutes nos fonctions, y compris les fonctions que nous n'avons pas encore passé en TypeScript. (grâce à l'ajout de fichiers de déclaration `*.d.ts` que nous pourrons retirer une fois que ces fichiers JS auront été convertis en TS)

## Démarche suivie

1. Dans un premier temps, pour réduire le périmètre de travail, j'ai ajouté les types réclamés lors de l'exécution de `npm test` (c.a.d. les tests unitaires de nos fonctions TypeScript)
2. Un fois que tous les tests unitaires passaient, j'ai complété les types des autres fonctions, dans l'intention que l'étape de transpilation lancée par `go generate ./...` fonctionne sur l'ensemble des fichiers (TS et JS) à bundler dans `jsFunctions`. ~~⚠️J'ai été interrompu par une anomalie de type que j'ai du mal à résoudre seul: https://github.com/signaux-faibles/opensignauxfaibles/pull/59#discussion_r431001614~~
3. Une fois que `go generate` fonctionnait, j'ai corrigé la logique de manière à ce que  `go test` passe également
4. Enfin, j'ai activé des flags de vérifications TypeScript supplémentaires à `tsconfig.json`, de manière à éviter qu'on ne devienne trop laxistes sur le typage des fonctions à venir. (sauf `strictFunctionTypes`, car cela impliquerait des changements non triviaux => à faire plus tard)

## Next steps

- [x] Corriger l'[anomalie de types du reduce](https://github.com/signaux-faibles/opensignauxfaibles/pull/59#discussion_r431001614) avec l'aide de Pierre
- [x] Faire en sorte que `go generate ./...` fonctionne sans erreurs
- [x] Faire en sorte que tous nos tests fonctionnent sans erreurs
- [ ] Définir précisément les types `BatchValue.apconso` et `BatchValue.apdemande`