### PR TITLE
tests(TS): Tests d'integration pour fonctions map/reduce/finalize de `public`

### DIFF
--- a/dbmongo/js/public/apconso.d.ts
+++ b/dbmongo/js/public/apconso.d.ts
@@ -1,0 +1,1 @@
+export function apconso<T>(apconso: { [key: string]: T }): T[]

--- a/dbmongo/js/public/apconso.js
+++ b/dbmongo/js/public/apconso.js
@@ -2,3 +2,5 @@ function apconso(apconso) {
   "use strict";
   return f.iterable(apconso).sort((p1, p2) => p1.periode < p2.periode)
 }
+
+exports.apconso = apconso

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -103,7 +103,34 @@ const expectedMapResults = {
 
 const expectedReduceResults = expectedMapResults[etablissementKey] // TODO: à confirmer
 
-const expectedFinalizeResultValue = {} // TODO: to populate
+// TODO: à comparer avec la sortie de l'API /public, définie dans test-api.sh
+const expectedFinalizeResultValue = {
+  apconso: [],
+  apdemande: [],
+  batch: "1910",
+  compte: undefined,
+  cotisation: [0, 0],
+  debit: [
+    {
+      part_ouvriere: 0,
+      part_patronale: 0,
+    },
+    {
+      part_ouvriere: 0,
+      part_patronale: 0,
+    },
+  ],
+  delai: [],
+  dernier_effectif: undefined,
+  effectif: [],
+  idEntreprise: "entreprise_012345678",
+  key: "01234567891011",
+  last_procol: {
+    etat: "in_bonis",
+  },
+  procol: undefined,
+  sirene: {},
+}
 
 // exécution complète de la chaine "public"
 

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -83,11 +83,8 @@ const expectedMapResults = {
     apdemande: [],
     batch: batchKey,
     compte: undefined,
-    cotisation: [0, 0],
-    debit: [
-      { part_ouvriere: 0, part_patronale: 0 },
-      { part_ouvriere: 0, part_patronale: 0 },
-    ],
+    cotisation: dates.map(() => 0),
+    debit: dates.map(() => ({ part_ouvriere: 0, part_patronale: 0 })),
     delai: [],
     dernier_effectif: undefined,
     effectif: [],

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -17,7 +17,7 @@ import { apconso } from "./apconso.js"
 import { delai } from "./delai.js"
 import { compte } from "./compte.js"
 import { dealWithProcols } from "./dealWithProcols.js"
-// import { reduce } from "./reduce"
+import { reduce } from "./reduce"
 // import { finalize } from "./finalize"
 
 const global = globalThis as any // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -74,8 +74,10 @@ const rawData = {
   key: siret,
 }
 
+const etablissementKey = scope + "_" + siret
+
 const expectedMapResults = {
-  [scope + "_" + siret]: {
+  [etablissementKey]: {
     apconso: [],
     apdemande: [],
     batch: batchKey,
@@ -97,23 +99,24 @@ const expectedMapResults = {
     sirene: {},
   },
 }
+
+const expectedReduceResults = {} // TODO: populate
+
 // exécution complète de la chaine "public"
 
-test.serial(`public.map()`, (t: ExecutionContext) => {
-  const mapResults = runMongoMap(map, { value: rawData })
-  t.deepEqual(mapResults, expectedMapResults)
-})
-
-test.todo(
-  `public.reduce()`
-  /*
+test.serial(
+  `public.map() retourne les propriétés d'établissement présentées sur le frontal`,
   (t: ExecutionContext) => {
-    const reduceValues: CompanyDataValues[] = [expectedMapResults[siret]]
-    const reduceResults = reduce(siret, reduceValues)
-    t.deepEqual(reduceResults, expectedReduceResults)
+    const mapResults = runMongoMap(map, { value: rawData })
+    t.deepEqual(mapResults, expectedMapResults)
   }
-  */
 )
+
+test.serial(`public.reduce()`, (t: ExecutionContext) => {
+  const reduceValues = [expectedMapResults[etablissementKey]]
+  const reduceResults = reduce({ scope }, reduceValues)
+  t.deepEqual(reduceResults, expectedReduceResults)
+})
 
 test.todo(
   `public.finalize()`

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -59,15 +59,7 @@ global.serie_periode = dates // used by effectifs(), which is called by map()
 
 const rawData = {
   batch: {
-    [batchKey]: {
-      reporder: dates.reduce(
-        (reporder, date) => ({
-          ...reporder,
-          [date.toString()]: { periode: date, siret },
-        }),
-        {}
-      ),
-    } as BatchValue, // TODO: rendre optionnelles les props de BatchValues, pour retirer ce cast
+    [batchKey]: {} as BatchValue, // TODO: rendre optionnelles les props de BatchValues, pour retirer ce cast
   },
   scope,
   index: { algo1: false, algo2: false }, // car il n'y a pas de données justifiant que l'établissement compte 10 employés ou pas

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -18,7 +18,7 @@ import { delai } from "./delai.js"
 import { compte } from "./compte.js"
 import { dealWithProcols } from "./dealWithProcols.js"
 import { reduce } from "./reduce"
-// import { finalize } from "./finalize"
+import { finalize } from "./finalize"
 
 const global = globalThis as any // eslint-disable-line @typescript-eslint/no-explicit-any
 global.f = {
@@ -103,6 +103,8 @@ const expectedMapResults = {
 
 const expectedReduceResults = expectedMapResults[etablissementKey] // TODO: à confirmer
 
+const expectedFinalizeResultValue = {} // TODO: to populate
+
 // exécution complète de la chaine "public"
 
 test.serial(
@@ -113,28 +115,25 @@ test.serial(
   }
 )
 
-test.serial(`public.reduce()`, (t: ExecutionContext) => {
-  const reduceValues = [expectedMapResults[etablissementKey]]
-  const reduceResults = reduce({ scope }, reduceValues)
-  t.deepEqual(reduceResults, expectedReduceResults)
-})
-
-test.todo(
-  `public.finalize()`
-  /*
+test.serial(
+  `public.reduce() retourne les propriétés d'établissement, telles quelles`,
   (t: ExecutionContext) => {
-    const global = globalThis as any // eslint-disable-line @typescript-eslint/no-explicit-any
-    global.serie_periode = dates // used by complete_reporder(), which is called by finalize()
-    const finalizeResult = finalize(siret, expectedReduceResults)
-    const { reporder } = finalizeResult.batch[batchKey]
-    // reporder contient une propriété par periode
-    t.is(Object.keys(reporder).length, dates.length)
-    Object.keys(reporder).forEach((periodKey) => {
-      t.is(typeof reporder[periodKey].random_order, "number")
-    })
-    // vérification de la structure complète, sans les nombres aléatoires
-    removeRandomOrder(finalizeResult.batch[batchKey].reporder) // will mutate finalizeResult
-    t.deepEqual(finalizeResult, expectedFinalizeResultValue)
+    const reduceValues = [expectedMapResults[etablissementKey]]
+    const reduceResults = reduce({ scope }, reduceValues)
+    t.deepEqual(reduceResults, expectedReduceResults)
   }
-  */
 )
+
+test.serial(`public.finalize()`, (t: ExecutionContext) => {
+  const global = globalThis as any // eslint-disable-line @typescript-eslint/no-explicit-any
+  global.serie_periode = dates // used by complete_reporder(), which is called by finalize()
+  const finalizeResult = finalize({ scope }, expectedReduceResults)
+  const { reporder } = finalizeResult.batch[batchKey]
+  // reporder contient une propriété par periode
+  t.is(Object.keys(reporder).length, dates.length)
+  Object.keys(reporder).forEach((periodKey) => {
+    t.is(typeof reporder[periodKey].random_order, "number")
+  })
+  // vérification de la structure complète, sans les nombres aléatoires
+  t.deepEqual(finalizeResult, expectedFinalizeResultValue)
+})

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -100,7 +100,34 @@ const expectedMapResults = {
   },
 }
 
-const expectedReduceResults = {} // TODO: populate
+// TODO: re-exprimer à l'aide des variables
+const expectedReduceResults = {
+  apconso: [],
+  apdemande: [],
+  batch: "1910",
+  compte: undefined,
+  cotisation: [0, 0],
+  debit: [
+    {
+      part_ouvriere: 0,
+      part_patronale: 0,
+    },
+    {
+      part_ouvriere: 0,
+      part_patronale: 0,
+    },
+  ],
+  delai: [],
+  dernier_effectif: undefined,
+  effectif: [],
+  idEntreprise: "entreprise_012345678",
+  key: "01234567891011",
+  last_procol: {
+    etat: "in_bonis",
+  },
+  procol: undefined,
+  sirene: {},
+}
 
 // exécution complète de la chaine "public"
 

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -1,0 +1,114 @@
+// Objectif de cette suite de tests d'intégration:
+// Vérifier la compatibilité des types et mesurer la couverture lors du passage
+// de données entre les fonctions map(), reduce() et finalize(), en s'appuyant
+// sur le jeu de données minimal utilisé dans notre suite de bout en bout
+// définie dans test-api.sh.
+
+import test, { ExecutionContext } from "ava"
+import "../globals"
+import { map } from "./map.js"
+import { flatten } from "./flatten.js"
+import { effectifs } from "./effectifs.js"
+import { iterable } from "./iterable.js"
+import { sirene } from "./sirene.js"
+import { cotisations } from "./cotisations.js"
+import { debits } from "./debits.js"
+import { apconso } from "./apconso.js"
+import { delai } from "./delai.js"
+import { compte } from "./compte.js"
+import { dealWithProcols } from "./dealWithProcols.js"
+// import { reduce } from "./reduce"
+// import { finalize } from "./finalize"
+
+const global = globalThis as any // eslint-disable-line @typescript-eslint/no-explicit-any
+global.f = {
+  flatten,
+  effectifs,
+  iterable,
+  sirene,
+  cotisations,
+  debits,
+  apconso,
+  delai,
+  compte,
+  dealWithProcols,
+}
+
+const ISODate = (date: string): Date => new Date(date)
+
+const runMongoMap = (mapFct: () => void, keyVal: object): object => {
+  const results: { [key: string]: any } = {}
+  global.emit = (key: any, value: any): void => {
+    results[key] = value
+  }
+  mapFct.call(keyVal)
+  return results
+}
+
+// test data inspired by test-api.sh
+const siret: SiretOrSiren = "01234567891011"
+const scope: Scope = "etablissement"
+const batchKey = "1910"
+const dates = [
+  ISODate("2015-12-01T00:00:00.000+0000"),
+  ISODate("2016-01-01T00:00:00.000+0000"),
+]
+global.actual_batch = batchKey // used by map()
+global.serie_periode = dates // used by effectifs(), which is called by map()
+
+const rawData = {
+  batch: {
+    [batchKey]: {
+      reporder: dates.reduce(
+        (reporder, date) => ({
+          ...reporder,
+          [date.toString()]: { periode: date, siret },
+        }),
+        {}
+      ),
+    } as BatchValue, // TODO: rendre optionnelles les props de BatchValues, pour retirer ce cast
+  },
+  scope,
+  index: { algo1: false, algo2: false }, // car il n'y a pas de données justifiant que l'établissement compte 10 employés ou pas
+  key: siret,
+}
+
+const expectedMapResults = {}
+
+// exécution complète de la chaine "public"
+
+test.serial(`public.map()`, (t: ExecutionContext) => {
+  const mapResults = runMongoMap(map, { value: rawData })
+  t.deepEqual(mapResults, expectedMapResults)
+})
+
+test.todo(
+  `public.reduce()`
+  /*
+  (t: ExecutionContext) => {
+    const reduceValues: CompanyDataValues[] = [expectedMapResults[siret]]
+    const reduceResults = reduce(siret, reduceValues)
+    t.deepEqual(reduceResults, expectedReduceResults)
+  }
+  */
+)
+
+test.todo(
+  `public.finalize()`
+  /*
+  (t: ExecutionContext) => {
+    const global = globalThis as any // eslint-disable-line @typescript-eslint/no-explicit-any
+    global.serie_periode = dates // used by complete_reporder(), which is called by finalize()
+    const finalizeResult = finalize(siret, expectedReduceResults)
+    const { reporder } = finalizeResult.batch[batchKey]
+    // reporder contient une propriété par periode
+    t.is(Object.keys(reporder).length, dates.length)
+    Object.keys(reporder).forEach((periodKey) => {
+      t.is(typeof reporder[periodKey].random_order, "number")
+    })
+    // vérification de la structure complète, sans les nombres aléatoires
+    removeRandomOrder(finalizeResult.batch[batchKey].reporder) // will mutate finalizeResult
+    t.deepEqual(finalizeResult, expectedFinalizeResultValue)
+  }
+  */
+)

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -77,6 +77,7 @@ const rawData = {
 const etablissementKey = scope + "_" + siret
 
 const expectedMapResults = {
+  // TODO: structure et valeurs à confirmer
   [etablissementKey]: {
     apconso: [],
     apdemande: [],
@@ -100,34 +101,7 @@ const expectedMapResults = {
   },
 }
 
-// TODO: re-exprimer à l'aide des variables
-const expectedReduceResults = {
-  apconso: [],
-  apdemande: [],
-  batch: "1910",
-  compte: undefined,
-  cotisation: [0, 0],
-  debit: [
-    {
-      part_ouvriere: 0,
-      part_patronale: 0,
-    },
-    {
-      part_ouvriere: 0,
-      part_patronale: 0,
-    },
-  ],
-  delai: [],
-  dernier_effectif: undefined,
-  effectif: [],
-  idEntreprise: "entreprise_012345678",
-  key: "01234567891011",
-  last_procol: {
-    etat: "in_bonis",
-  },
-  procol: undefined,
-  sirene: {},
-}
+const expectedReduceResults = expectedMapResults[etablissementKey] // TODO: à confirmer
 
 // exécution complète de la chaine "public"
 

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -46,6 +46,7 @@ const runMongoMap = (mapFct: () => void, keyVal: object): object => {
 }
 
 // test data inspired by test-api.sh
+const SIREN_LENGTH = 9
 const siret: SiretOrSiren = "01234567891011"
 const scope: Scope = "etablissement"
 const batchKey = "1910"
@@ -73,29 +74,22 @@ const rawData = {
   key: siret,
 }
 
-// TODO: re-exprimer cet objet attendu à l'aide des variables définies ci-dessus
 const expectedMapResults = {
-  etablissement_01234567891011: {
+  [scope + "_" + siret]: {
     apconso: [],
     apdemande: [],
-    batch: "1910",
+    batch: batchKey,
     compte: undefined,
     cotisation: [0, 0],
     debit: [
-      {
-        part_ouvriere: 0,
-        part_patronale: 0,
-      },
-      {
-        part_ouvriere: 0,
-        part_patronale: 0,
-      },
+      { part_ouvriere: 0, part_patronale: 0 },
+      { part_ouvriere: 0, part_patronale: 0 },
     ],
     delai: [],
     dernier_effectif: undefined,
     effectif: [],
-    idEntreprise: "entreprise_012345678",
-    key: "01234567891011",
+    idEntreprise: "entreprise_" + siret.substr(0, SIREN_LENGTH),
+    key: siret,
     last_procol: {
       etat: "in_bonis",
     },

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -125,15 +125,6 @@ test.serial(
 )
 
 test.serial(`public.finalize()`, (t: ExecutionContext) => {
-  const global = globalThis as any // eslint-disable-line @typescript-eslint/no-explicit-any
-  global.serie_periode = dates // used by complete_reporder(), which is called by finalize()
   const finalizeResult = finalize({ scope }, expectedReduceResults)
-  const { reporder } = finalizeResult.batch[batchKey]
-  // reporder contient une propriété par periode
-  t.is(Object.keys(reporder).length, dates.length)
-  Object.keys(reporder).forEach((periodKey) => {
-    t.is(typeof reporder[periodKey].random_order, "number")
-  })
-  // vérification de la structure complète, sans les nombres aléatoires
   t.deepEqual(finalizeResult, expectedFinalizeResultValue)
 })

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -73,8 +73,36 @@ const rawData = {
   key: siret,
 }
 
-const expectedMapResults = {}
-
+// TODO: re-exprimer cet objet attendu à l'aide des variables définies ci-dessus
+const expectedMapResults = {
+  etablissement_01234567891011: {
+    apconso: [],
+    apdemande: [],
+    batch: "1910",
+    compte: undefined,
+    cotisation: [0, 0],
+    debit: [
+      {
+        part_ouvriere: 0,
+        part_patronale: 0,
+      },
+      {
+        part_ouvriere: 0,
+        part_patronale: 0,
+      },
+    ],
+    delai: [],
+    dernier_effectif: undefined,
+    effectif: [],
+    idEntreprise: "entreprise_012345678",
+    key: "01234567891011",
+    last_procol: {
+      etat: "in_bonis",
+    },
+    procol: undefined,
+    sirene: {},
+  },
+}
 // exécution complète de la chaine "public"
 
 test.serial(`public.map()`, (t: ExecutionContext) => {

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -105,31 +105,34 @@ const expectedReduceResults = expectedMapResults[etablissementKey] // TODO: à c
 
 // TODO: à comparer avec la sortie de l'API /public, définie dans test-api.sh
 const expectedFinalizeResultValue = {
-  apconso: [],
-  apdemande: [],
-  batch: "1910",
-  compte: undefined,
-  cotisation: [0, 0],
-  debit: [
-    {
-      part_ouvriere: 0,
-      part_patronale: 0,
+  _id: "etablissement_01234567891011",
+  value: {
+    key: "01234567891011",
+    batch: "1910",
+    effectif: [],
+    dernier_effectif: undefined,
+    sirene: {},
+    cotisation: [0, 0],
+    debit: [
+      {
+        part_ouvriere: 0,
+        part_patronale: 0,
+      },
+      {
+        part_ouvriere: 0,
+        part_patronale: 0,
+      },
+    ],
+    apconso: [],
+    apdemande: [],
+    delai: [],
+    compte: undefined,
+    procol: undefined,
+    last_procol: {
+      etat: "in_bonis",
     },
-    {
-      part_ouvriere: 0,
-      part_patronale: 0,
-    },
-  ],
-  delai: [],
-  dernier_effectif: undefined,
-  effectif: [],
-  idEntreprise: "entreprise_012345678",
-  key: "01234567891011",
-  last_procol: {
-    etat: "in_bonis",
+    idEntreprise: "entreprise_012345678",
   },
-  procol: undefined,
-  sirene: {},
 }
 
 // exécution complète de la chaine "public"
@@ -152,6 +155,7 @@ test.serial(
 )
 
 test.serial(`public.finalize()`, (t: ExecutionContext) => {
-  const finalizeResult = finalize({ scope }, expectedReduceResults)
+  const finalizeResultValue = finalize({ scope }, expectedReduceResults)
+  const finalizeResult = { _id: etablissementKey, value: finalizeResultValue }
   t.deepEqual(finalizeResult, expectedFinalizeResultValue)
 })

--- a/dbmongo/js/public/ava_tests.ts
+++ b/dbmongo/js/public/ava_tests.ts
@@ -103,37 +103,7 @@ const expectedMapResults = {
 
 const expectedReduceResults = expectedMapResults[etablissementKey] // TODO: à confirmer
 
-// TODO: à comparer avec la sortie de l'API /public, définie dans test-api.sh
-const expectedFinalizeResultValue = {
-  _id: "etablissement_01234567891011",
-  value: {
-    key: "01234567891011",
-    batch: "1910",
-    effectif: [],
-    dernier_effectif: undefined,
-    sirene: {},
-    cotisation: [0, 0],
-    debit: [
-      {
-        part_ouvriere: 0,
-        part_patronale: 0,
-      },
-      {
-        part_ouvriere: 0,
-        part_patronale: 0,
-      },
-    ],
-    apconso: [],
-    apdemande: [],
-    delai: [],
-    compte: undefined,
-    procol: undefined,
-    last_procol: {
-      etat: "in_bonis",
-    },
-    idEntreprise: "entreprise_012345678",
-  },
-}
+const expectedFinalizeResultValue = expectedMapResults[etablissementKey] // TODO: à confirmer
 
 // exécution complète de la chaine "public"
 
@@ -154,8 +124,10 @@ test.serial(
   }
 )
 
-test.serial(`public.finalize()`, (t: ExecutionContext) => {
-  const finalizeResultValue = finalize({ scope }, expectedReduceResults)
-  const finalizeResult = { _id: etablissementKey, value: finalizeResultValue }
-  t.deepEqual(finalizeResult, expectedFinalizeResultValue)
-})
+test.serial(
+  `public.finalize() retourne les propriétés d'établissement, telles quelles`,
+  (t: ExecutionContext) => {
+    const finalizeResultValue = finalize({ scope }, expectedReduceResults)
+    t.deepEqual(finalizeResultValue, expectedFinalizeResultValue)
+  }
+)

--- a/dbmongo/js/public/compte.d.ts
+++ b/dbmongo/js/public/compte.d.ts
@@ -1,0 +1,1 @@
+export function compte<T>(compte: { [key: string]: T }): T | undefined

--- a/dbmongo/js/public/compte.js
+++ b/dbmongo/js/public/compte.js
@@ -3,3 +3,5 @@ function compte(compte) {
   const c = f.iterable(compte)
   return (c.length>0)?c[c.length-1]:undefined
 }
+
+exports.compte = compte

--- a/dbmongo/js/public/cotisations.d.ts
+++ b/dbmongo/js/public/cotisations.d.ts
@@ -1,0 +1,3 @@
+export function cotisations(vcotisation: {
+  [h: string]: { periode: { start: Date; end: Date } }
+}): number[]

--- a/dbmongo/js/public/cotisations.js
+++ b/dbmongo/js/public/cotisations.js
@@ -25,3 +25,5 @@ function cotisations(vcotisation) {
 
   return(output_cotisation)
 }
+
+exports.cotisations = cotisations

--- a/dbmongo/js/public/dealWithProcols.d.ts
+++ b/dbmongo/js/public/dealWithProcols.d.ts
@@ -1,0 +1,12 @@
+export function dealWithProcols(
+  data_source: {
+    [h: string]: {
+      code_evenement: any
+      action_procol: any
+      stade_procol: any
+      date_effet: any
+    }
+  },
+  altar_or_procol: "altares" | "procol",
+  output_indexed: any
+): { etat: any; date_procol: Date }[]

--- a/dbmongo/js/public/dealWithProcols.js
+++ b/dbmongo/js/public/dealWithProcols.js
@@ -17,3 +17,5 @@ function dealWithProcols(data_source, altar_or_procol, output_indexed){
     (a,b) => {return(a.date_procol.getTime() > b.date_procol.getTime())}
   )
 }
+
+exports.dealWithProcols = dealWithProcols

--- a/dbmongo/js/public/debits.d.ts
+++ b/dbmongo/js/public/debits.d.ts
@@ -1,0 +1,13 @@
+export function debits(vdebit: {
+  [h: string]: {
+    periode: { start: Date; end: Date }
+    numero_ecart_negatif: any
+    numero_compte: any
+    numero_historique: any
+    date_traitement: any
+  }
+}): {
+  part_ouvriere: number
+  part_patronale: number
+  periode: Periode
+}[]

--- a/dbmongo/js/public/debits.js
+++ b/dbmongo/js/public/debits.js
@@ -85,3 +85,5 @@ function debits(vdebit) {
 
   return(output_dette)
 }
+
+exports.debits = debits

--- a/dbmongo/js/public/delai.d.ts
+++ b/dbmongo/js/public/delai.d.ts
@@ -1,0 +1,1 @@
+export function delai<T>(delai: { [key: string]: T }): T[]

--- a/dbmongo/js/public/delai.js
+++ b/dbmongo/js/public/delai.js
@@ -2,3 +2,5 @@ function delai(delai) {
   "use strict";
   return f.iterable(delai)
 }
+
+exports.delai = delai

--- a/dbmongo/js/public/effectifs.d.ts
+++ b/dbmongo/js/public/effectifs.d.ts
@@ -1,0 +1,6 @@
+export function effectifs(v: {
+  effectif: Effectif
+}): {
+  periode: Periode
+  effectif: number
+}

--- a/dbmongo/js/public/effectifs.js
+++ b/dbmongo/js/public/effectifs.js
@@ -11,3 +11,5 @@ function effectifs(v) {
     }
   }).filter(p => p.effectif)
 }
+
+exports.effectifs = effectifs

--- a/dbmongo/js/public/finalize.d.ts
+++ b/dbmongo/js/public/finalize.d.ts
@@ -1,0 +1,1 @@
+export function finalize(k: { scope: Scope }, v: any): any

--- a/dbmongo/js/public/finalize.js
+++ b/dbmongo/js/public/finalize.js
@@ -2,3 +2,5 @@ function finalize(_, v) {
   "use strict";
   return v
 }
+
+exports.finalize = finalize

--- a/dbmongo/js/public/flatten.d.ts
+++ b/dbmongo/js/public/flatten.d.ts
@@ -1,0 +1,4 @@
+export function flatten(
+  v: { key: any; scope: Scope; batch: BatchValues },
+  actual_batch: number
+): { key: any; scope: Scope }

--- a/dbmongo/js/public/flatten.js
+++ b/dbmongo/js/public/flatten.js
@@ -27,3 +27,5 @@ function flatten(v, actual_batch) {
 
   return(res)
 }
+
+exports.flatten = flatten

--- a/dbmongo/js/public/iterable.d.ts
+++ b/dbmongo/js/public/iterable.d.ts
@@ -1,0 +1,1 @@
+export function iterable<T>(dict: { [key: string | number]: T }): T[]

--- a/dbmongo/js/public/iterable.js
+++ b/dbmongo/js/public/iterable.js
@@ -8,3 +8,5 @@ function iterable(dict) {
     return []
   }
 }
+
+exports.iterable = iterable

--- a/dbmongo/js/public/map.d.ts
+++ b/dbmongo/js/public/map.d.ts
@@ -1,0 +1,1 @@
+export function map(): void

--- a/dbmongo/js/public/map.js
+++ b/dbmongo/js/public/map.js
@@ -48,3 +48,5 @@ function map() {
     }
   }
 }
+
+exports.map = map

--- a/dbmongo/js/public/reduce.d.ts
+++ b/dbmongo/js/public/reduce.d.ts
@@ -1,0 +1,4 @@
+export function reduce(
+  key: { scope: Scope },
+  values: { sirets: any[] }[]
+): any[]

--- a/dbmongo/js/public/reduce.d.ts
+++ b/dbmongo/js/public/reduce.d.ts
@@ -1,4 +1,1 @@
-export function reduce(
-  key: { scope: Scope },
-  values: { sirets: any[] }[]
-): any[]
+export function reduce(key: { scope: Scope }, values: any[]): any[]

--- a/dbmongo/js/public/reduce.d.ts
+++ b/dbmongo/js/public/reduce.d.ts
@@ -1,1 +1,1 @@
-export function reduce(key: { scope: Scope }, values: any[]): any[]
+export function reduce<T>(key: { scope: Scope }, values: T[]): T

--- a/dbmongo/js/public/reduce.js
+++ b/dbmongo/js/public/reduce.js
@@ -12,3 +12,5 @@ function reduce(key, values) {
   }
   return values
 }
+
+exports.reduce = reduce

--- a/dbmongo/js/public/sirene.d.ts
+++ b/dbmongo/js/public/sirene.d.ts
@@ -1,0 +1,1 @@
+export function sirene<T>(sireneArray: T[]): T

--- a/dbmongo/js/public/sirene.js
+++ b/dbmongo/js/public/sirene.js
@@ -4,3 +4,5 @@ function sirene(sireneArray) {
     return k
   }, {})
 }
+
+exports.sirene = sirene


### PR DESCRIPTION
Suite de PR #60. Démarche similaire à PR #60, appliquée au calcul de `public`.

## Problème

Nous avons bien avancé sur le typage des donnés manipulées par les fonctions TS/JS, mais rien ne nous prouve que les valeurs passées par MongoDB d'un étape à une autre (c.a.d. `map()` --> `reduce()` --> `finalize()`) respectent ces types dans tous les cas, car MongoDB ne voit pas nos types. Notamment depuis les modifs proposées dans PR #59.

=> Risque: les traitements "compact", "reduce" et "public" risquent toujours d'échouer après des heures de calculs.

## Solution proposée

Ajout d'une suite de tests d'intégration en TypeScript pour vérifier la compatibilité des types et mesurer la couverture lors du passage de données entre les fonctions `map()`, `reduce()` et `finalize()`, en s'appuyant sur le jeu de données minimal utilisé dans notre suite de bout en bout définie dans `test-api.sh`.

## Résultats observés

Taux de couverture du code JS/TS par les tests Ava, avant et après cette PR:

| | Statements | Branches | Functions | Lines |
|--|--|--|--|--|
| avant PR #60 | 3.1% | 2.5% | 2.5% | 2.61% |
| après PR #60 (`compact` testé) | 8.79% | 4.16% | 7.83% | 9.05% |
| après PRs #60 et #61 (`compact` et `public` testés) | 17.24% | 8.04% | 16.88% | 17.75% |

Attention: la couverture de ces fonctions reste à relativiser car les tests ajoutés par cette PR sont assez artificiels et ne couvrent donc pas forcément des cas très réalistes.

## Comment tester

```sh
$ cd dbmongo/js
$ npm install
$ npm test
```

## Prochaines étapes

- [x] Discuter ensemble des points soulevés dans les commentaires de cette PR.
- [x] Suivre la même démarche pour `reduce.algo2`
