### PR TITLE
fix(TS): Activation de strictFunctionTypes

### DIFF
--- a/dbmongo/js/compact/ava_tests.ts
+++ b/dbmongo/js/compact/ava_tests.ts
@@ -10,6 +10,8 @@ import { map } from "./map"
 import { reduce } from "./reduce"
 import { finalize } from "./finalize"
 
+const global = globalThis as any // eslint-disable-line @typescript-eslint/no-explicit-any
+
 const ISODate = (date: string): Date => new Date(date)
 
 const removeRandomOrder = (reporderProp: { [key: string]: RepOrder }): void =>
@@ -19,7 +21,7 @@ const removeRandomOrder = (reporderProp: { [key: string]: RepOrder }): void =>
 
 const runMongoMap = (mapFct: () => void, keyVal: object): object => {
   const results: { [key: string]: any } = {}
-  globalThis.emit = (key: string, value: CompanyDataValuesWithFlags): void => {
+  global.emit = (key: string, value: CompanyDataValuesWithFlags): void => {
     results[key] = value
   }
   mapFct.call(keyVal)

--- a/dbmongo/js/compact/currentState.ts
+++ b/dbmongo/js/compact/currentState.ts
@@ -17,10 +17,10 @@ export function currentState(batches: BatchValue[]): CurrentDataState {
       //2. On ajoute les nouvelles clés
       Object.keys(batch)
         .filter((type) => type !== "compact")
-        .forEach((type: keyof BatchValue) => {
+        .forEach((type) => {
           m[type] = m[type] || new Set()
 
-          Object.keys(batch[type]).forEach((key) => {
+          Object.keys(batch[type as keyof BatchValue]).forEach((key) => {
             m[type].add(key)
           })
         })

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -25,7 +25,8 @@ export function reduce(
     (m, value: CompanyDataValues) => {
       Object.keys(value.batch).forEach((batch) => {
         m.batch[batch] = m.batch[batch] || {}
-        Object.keys(value.batch[batch]).forEach((type: keyof BatchValue) => {
+        Object.keys(value.batch[batch]).forEach((strType) => {
+          const type = strType as keyof BatchValue
           const updatedValues = {
             ...m.batch[batch][type],
             ...value.batch[batch][type],
@@ -93,7 +94,7 @@ export function reduce(
     const hashToDelete: { [dataType: string]: Set<DataHash> } = {}
     const hashToAdd: { [dataType: string]: Set<DataHash> } = {}
 
-    all_interesting_types.forEach((type: keyof BatchValue) => {
+    all_interesting_types.forEach((type) => {
       // Le type compact gère les clés supprimées
       if (type === "compact") {
         if (reduced_value.batch[batch].compact.delete) {
@@ -110,7 +111,9 @@ export function reduce(
           )
         }
       } else {
-        Object.keys(reduced_value.batch[batch][type] || {}).forEach((hash) => {
+        Object.keys(
+          reduced_value.batch[batch][type as keyof BatchValue] || {}
+        ).forEach((hash) => {
           hashToAdd[type] = hashToAdd[type] || new Set()
           hashToAdd[type].add(hash)
         })
@@ -196,7 +199,8 @@ export function reduce(
       }
     })
 
-    new_types.forEach((type: keyof BatchValue) => {
+    new_types.forEach((strType) => {
+      const type = strType as keyof BatchValue
       if (hashToAdd[type] && type !== "compact") {
         const hashedValues = reduced_value.batch[batch][type]
 
@@ -218,13 +222,12 @@ export function reduce(
 
     if (reduced_value.batch[batch]) {
       //types vides
-      Object.keys(reduced_value.batch[batch]).forEach(
-        (type: keyof BatchValue) => {
-          if (Object.keys(reduced_value.batch[batch][type]).length === 0) {
-            delete reduced_value.batch[batch][type]
-          }
+      Object.keys(reduced_value.batch[batch]).forEach((strType) => {
+        const type = strType as keyof BatchValue
+        if (Object.keys(reduced_value.batch[batch][type]).length === 0) {
+          delete reduced_value.batch[batch][type]
         }
-      )
+      })
       //hash à supprimer vides (compact.delete)
       if (
         reduced_value.batch[batch].compact &&

--- a/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
+++ b/dbmongo/js/reduce.algo2/fraisFinancier_tests.ts
@@ -42,12 +42,12 @@ const proprietes = [
   "charge_exceptionnelle",
   "charges_financieres",
 ]
-proprietes.forEach((propriete: DianeProperty) =>
+proprietes.forEach((propriete) =>
   test(`fraisFinancier est nul si "${propriete}" n'est pas disponible dans Diane`, (t) => {
     const diane = fakeDiane() as DianePartial
-    diane[propriete] = null
+    diane[propriete as DianeProperty] = null
     t.is(fraisFinancier(diane), null)
-    delete diane[propriete]
+    delete diane[propriete as DianeProperty]
     t.is(fraisFinancier(diane), null)
   })
 )

--- a/dbmongo/js/test/test_algo2.sh
+++ b/dbmongo/js/test/test_algo2.sh
@@ -6,8 +6,8 @@ result_add=$(jsc \
   helpers/testing.js \
   helpers/fakes.js \
   helpers/fake_emit_for_algo2.js \
-  ../common/!(*_test).js \
-  ../reduce.algo2/!(*_test).js \
+  ../common/!(*_test*).js \
+  ../reduce.algo2/!(*_test*).js \
   ../reduce.algo2/add_test.js \
   2>&1)
 if [ "$result_add" != 'true' ]; then
@@ -19,8 +19,8 @@ result_lookAhead=$(jsc \
   helpers/testing.js \
   helpers/fakes.js \
   helpers/fake_emit_for_algo2.js \
-  ../common/!(*_test).js \
-  ../reduce.algo2/!(*_test).js \
+  ../common/!(*_test*).js \
+  ../reduce.algo2/!(*_test*).js \
   ../reduce.algo2/lookAhead_test.js \
   2>&1)
 if [ "$result_lookAhead" != 'true' ]; then
@@ -32,8 +32,8 @@ result_cibleApprentissage=$(jsc \
   helpers/testing.js \
   helpers/fakes.js \
   helpers/fake_emit_for_algo2.js \
-  ../common/!(*_test).js \
-  ../reduce.algo2/!(*_test).js \
+  ../common/!(*_test*).js \
+  ../reduce.algo2/!(*_test*).js \
   ../reduce.algo2/cibleApprentissage_test.js \
   2>&1)
 if [ "$result_cibleApprentissage" != 'true' ]; then
@@ -43,8 +43,8 @@ fi
 
 result_mapreduce=$(jsc \
   helpers/fakes.js \
-  ../reduce.algo2/!(*_test).js \
-  ../common/!(*_test).js \
+  ../reduce.algo2/!(*_test*).js \
+  ../common/!(*_test*).js \
   helpers/fake_emit_for_algo2.js \
   data/naf.js \
   data/objects.js \

--- a/dbmongo/js/test/test_common.sh
+++ b/dbmongo/js/test/test_common.sh
@@ -5,7 +5,7 @@ shopt -s extglob # enable exclusion of test files in wildcard
 result_raison_sociale=$(jsc \
   helpers/testing.js \
   helpers/fakes.js \
-  ../common/!(*_test).js \
+  ../common/!(*_test*).js \
   ../common/raison_sociale_test.js \
   2>&1)
 if [ "$result_raison_sociale" != 'true' ]; then

--- a/dbmongo/js/test/test_compact.sh
+++ b/dbmongo/js/test/test_compact.sh
@@ -14,7 +14,7 @@ fi
 result_reduce=$(jsc \
   ./helpers/fakes.js \
   ./helpers/testing.js \
-  ../common/!(*_test).js \
+  ../common/!(*_test*).js \
   ../compact/currentState.js \
   ../compact/reduce.js \
   ../compact/reduce_test.js\

--- a/dbmongo/js/test/test_finalize_algo2.sh
+++ b/dbmongo/js/test/test_finalize_algo2.sh
@@ -27,10 +27,10 @@ echo "makeTestData = ({ ISODate, NumberInt }) => (${JSON_TEST_DATASET});" \
 # Run tests
 jsc \
   ./helpers/fakes.js \
-  ../common/!(*_test).js \
+  ../common/!(*_test*).js \
   ${TMP_PATH}/reduce_test_data.js \
   ./data/naf.js \
-  ../reduce.algo2/!(*_test).js \
+  ../reduce.algo2/!(*_test*).js \
   ../reduce.algo2/finalize_test.js \
   2>&1 \
   > ${TMP_PATH}/finalize_stdout.log

--- a/dbmongo/js/test/test_map_algo2.sh
+++ b/dbmongo/js/test/test_map_algo2.sh
@@ -27,10 +27,10 @@ echo "makeTestData = ({ ISODate, NumberInt }) => (${JSON_TEST_DATASET});" \
 # Run tests
 jsc \
   ./helpers/fakes.js \
-  ../common/!(*_test).js \
+  ../common/!(*_test*).js \
   ${TMP_PATH}/reduce_test_data.js \
   ./data/naf.js \
-  ../reduce.algo2/!(*_test).js \
+  ../reduce.algo2/!(*_test*).js \
   ../reduce.algo2/map_test.js \
   2>&1 \
   > ${TMP_PATH}/map_stdout.log

--- a/dbmongo/js/test/test_public.sh
+++ b/dbmongo/js/test/test_public.sh
@@ -6,8 +6,8 @@ result_public=$(jsc \
   helpers/fakes.js \
   helpers/fake_emit_for_public.js \
   data/objects.js \
-  ../common/!(*_test).js \
-  ../public/!(*_test).js \
+  ../common/!(*_test*).js \
+  ../public/!(*_test*).js \
   ../public/_test.js \
   2>&1)
 if [ "$result_public" != 'true' ]; then

--- a/dbmongo/js/tsconfig-transpilation.json
+++ b/dbmongo/js/tsconfig-transpilation.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "*/*_tests.ts"]
+}

--- a/dbmongo/js/tsconfig.json
+++ b/dbmongo/js/tsconfig.json
@@ -30,7 +30,7 @@
     // "strict": true,                           /* Enable all strict type-checking options. */
     "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
     "strictNullChecks": true /* Enable strict null checks. */,
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    "strictFunctionTypes": true /* Enable strict checking of function types. */,
     "strictBindCallApply": true /* Enable strict 'bind', 'call', and 'apply' methods on functions. */,
     "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
     "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,

--- a/dbmongo/js/tsconfig.json
+++ b/dbmongo/js/tsconfig.json
@@ -45,7 +45,7 @@
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
@@ -71,5 +71,5 @@
   },
   "compileOnSave": true,
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "*/*_tests.ts"]
+  "exclude": ["node_modules"]
 }

--- a/dbmongo/js/tsconfig.json
+++ b/dbmongo/js/tsconfig.json
@@ -45,7 +45,7 @@
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
 
     /* Module Resolution Options */
-    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -304,7 +304,8 @@ function reduce(key, values) {
     const reduced_value = values.reduce((m, value) => {
         Object.keys(value.batch).forEach((batch) => {
             m.batch[batch] = m.batch[batch] || {};
-            Object.keys(value.batch[batch]).forEach((type) => {
+            Object.keys(value.batch[batch]).forEach((strType) => {
+                const type = strType;
                 const updatedValues = Object.assign(Object.assign({}, m.batch[batch][type]), value.batch[batch][type]);
                 setBatchValueForType(m.batch[batch], type, updatedValues);
             });
@@ -435,7 +436,8 @@ function reduce(key, values) {
                 ];
             }
         });
-        new_types.forEach((type) => {
+        new_types.forEach((strType) => {
+            const type = strType;
             if (hashToAdd[type] && type !== "compact") {
                 const hashedValues = reduced_value.batch[batch][type];
                 const updatedValues = Object.keys(hashedValues || {})
@@ -453,7 +455,8 @@ function reduce(key, values) {
         // ------------
         if (reduced_value.batch[batch]) {
             //types vides
-            Object.keys(reduced_value.batch[batch]).forEach((type) => {
+            Object.keys(reduced_value.batch[batch]).forEach((strType) => {
+                const type = strType;
                 if (Object.keys(reduced_value.batch[batch][type]).length === 0) {
                     delete reduced_value.batch[batch][type];
                 }

--- a/dbmongo/lib/engine/typescript.go
+++ b/dbmongo/lib/engine/typescript.go
@@ -50,7 +50,7 @@ func DeleteTranspiledFiles(tsFiles []string) {
 
 // TranspileTsFunctions convertit les fichiers TypeScript au format JavaScript.
 func TranspileTsFunctions(jsRootDir string) {
-	cmd := exec.Command("npx", "typescript", "--p", filepath.Join(jsRootDir, "tsconfig.json")) // output: .js files
+	cmd := exec.Command("npx", "typescript", "--p", filepath.Join(jsRootDir, "tsconfig-transpilation.json")) // output: .js files
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()


### PR DESCRIPTION
Objectif: sécurisation encore plus stricte du code JS/TS, pour réduire le risque d'interruption après des heures de calculs.

## Changements apportés

- activation de `strictFunctionTypes` dans `tsconfig.json`
- correction des scripts, majoritairement: cesser de forcer le type du paramètre passé par `forEach`
- application des flags de tsconfig aux tests ava, pour voir les erreurs depuis l'IDE (au lieu de les découvrir à l'exécution, avec des numéros de lignes incorrects)
- introduction de `tsconfig-transpilation.json` pour éviter que les tests ava ne soient transpilés puis importés dans `jsFunctions.go` lors de l'appel à `go generate`

## Comment tester

```sh
$ cd dbmongo
$ (cd lib/engine && go generate .) && \
  (cd js && npm run lint && npm test) && \
  go test && \
  (killall dbmongo; go build) && \
  (cd .. && ./test-api.sh)
```
