### PR TITLE
tests: Ajout d'un script pour exécuter tous les tests, y compris de bout en bout

### DIFF
--- a/test-all.sh
+++ b/test-all.sh
@@ -1,0 +1,6 @@
+(cd dbmongo/lib/engine && go generate .) && \
+(cd dbmongo/js && npm run lint && npm test) && \
+(cd dbmongo && go test) && \
+(killall dbmongo; cd dbmongo && go build) && \
+./test-api.sh && \
+./test-api-2.sh

--- a/test-all.sh
+++ b/test-all.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 (cd dbmongo/lib/engine && go generate .) && \
 (cd dbmongo/js && npm run lint && npm test) && \
 (cd dbmongo && go test) && \


### PR DESCRIPTION
Problème: `go test` n'exécute que les tests unitaires et d'intégration, mais pas les tests de bout en bout. (`test-api.sh` et `test-api-2.sh`) => Tout breaking change non détecté par les tests unitaires et d'intégration ne serait découvert qu'au moment du passage en CI, c'est à dire trop tard quand on est en plein développement.

Workaround appliqué jusqu'à présent: j'inclue le contenu de ce script dans la description de chaque PR.

Proposition: ajouter le script `test-all.sh` à la racine du projet pour exécuter `go test` et les tests de bout en bout. En profiter pour exécuter le linter et les tests JS avant de lancer ceux-ci. (car ces premiers sont plus rapides => gain de temps en cas d'erreur JS, en tout cas pour l'instant)

Comment tester:

```sh
$ ./test-all.sh
```

