### PR TITLE
refactor(compact): Suppression du paramètre `types` désormais inutile

### DIFF
--- a/dbmongo/data.go
+++ b/dbmongo/data.go
@@ -78,15 +78,14 @@ func publicHandler(c *gin.Context) {
 
 func compactHandler(c *gin.Context) {
 	var params struct {
-		BatchKey string   `json:"batch"`
-		Types    []string `json:"types"`
+		BatchKey string `json:"batch"`
 	}
 	err := c.ShouldBind(&params)
 	if err != nil {
 		c.JSON(400, err.Error())
 	}
 
-	err = engine.Compact(params.BatchKey, params.Types)
+	err = engine.Compact(params.BatchKey)
 	if err != nil {
 		c.JSON(500, err.Error())
 		return

--- a/dbmongo/handlers.go
+++ b/dbmongo/handlers.go
@@ -155,12 +155,11 @@ func processBatchHandler(c *gin.Context) {
 	// TODO: valider que tous les batches demandés existent
 
 	parsers, err := resolveParsers(query.Parsers)
-	types := query.Parsers
 	if err != nil {
 		c.JSON(404, err.Error())
 	}
 	sort.Strings(query.Batches)
-	err = engine.ProcessBatch(query.Batches, parsers, types)
+	err = engine.ProcessBatch(query.Batches, parsers)
 	if err != nil {
 		c.JSON(500, err.Error())
 		return

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -82,7 +82,7 @@ export function reduce(
 
     const hashToDelete: { [dataType: string]: Set<DataHash> } = {}
     type DataType = string
-    const hashToAdd: Record< DataType, Set<DataHash> > = {}
+    const hashToAdd: Record<DataType, Set<DataHash>> = {}
 
     all_interesting_types.forEach((type) => {
       // Le type compact gère les clés supprimées
@@ -98,7 +98,9 @@ export function reduce(
         }
       } else {
         Object.keys(
-          reduced_value.batch[batch][type as keyof BatchValue] || {}
+          reduced_value.batch[batch][
+            type as Exclude<keyof BatchValue, "compact">
+          ] || {}
         ).forEach((hash) => {
           hashToAdd[type] = hashToAdd[type] || new Set()
           hashToAdd[type].add(hash)
@@ -184,9 +186,7 @@ export function reduce(
 
     // filtrage des données en fonction de new_types et hashToAdd
     type AllValueTypesButCompact = Exclude<keyof BatchValue, "compact">
-    const typesToAdd = Object.keys(hashToAdd).filter(
-      (type) => type !== "compact"
-    ) as AllValueTypesButCompact[]
+    const typesToAdd = Object.keys(hashToAdd) as AllValueTypesButCompact[]
     typesToAdd.forEach((type) => {
       if (!new_types.includes(type)) {
         delete reduced_value.batch[batch][type]

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -81,7 +81,8 @@ export function reduce(
     // -----------------------------------------------------
 
     const hashToDelete: { [dataType: string]: Set<DataHash> } = {}
-    const hashToAdd: { [dataType: string]: Set<DataHash> } = {}
+    type DataType = string
+    const hashToAdd: Record< DataType, Set<DataHash> > = {}
 
     all_interesting_types.forEach((type) => {
       // Le type compact gère les clés supprimées

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -68,14 +68,12 @@ export function reduce(
   modified_batches.forEach((batch: string) => {
     reduced_value.batch[batch] = reduced_value.batch[batch] || {}
 
-    // Les types où il y  a potentiellement des suppressions
+    // Les types où il y a potentiellement des suppressions
     const stock_types = completeTypes[batch].filter(
       (type) => (memory[type] || new Set()).size > 0
     )
     // Les types qui ont bougé dans le batch en cours
-    const new_types = Object.keys(reduced_value.batch[batch])
-    // On dedoublonne au besoin
-    const all_interesting_types = [...new Set([...stock_types, ...new_types])]
+    const new_types = Object.keys(reduced_value.batch[batch]) as (keyof BatchValue)[]
 
     // 1. On recupère les cles ajoutes et les cles supprimes
     // -----------------------------------------------------
@@ -84,8 +82,9 @@ export function reduce(
     type DataType = string
     const hashToAdd: Record<DataType, Set<DataHash>> = {}
 
-    all_interesting_types.forEach((type) => {
+    new_types.forEach((type) => {
       // Le type compact gère les clés supprimées
+      // Ce type compact existe si le batch en cours a déjà été compacté.
       if (type === "compact") {
         const compactDelete = reduced_value.batch[batch].compact?.delete
         if (compactDelete) {

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -73,7 +73,9 @@ export function reduce(
       (type) => (memory[type] || new Set()).size > 0
     )
     // Les types qui ont bougé dans le batch en cours
-    const new_types = Object.keys(reduced_value.batch[batch]) as (keyof BatchValue)[]
+    const new_types = Object.keys(
+      reduced_value.batch[batch]
+    ) as (keyof BatchValue)[]
 
     // 1. On recupère les cles ajoutes et les cles supprimes
     // -----------------------------------------------------

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -72,10 +72,6 @@ export function reduce(
     const stock_types = completeTypes[batch].filter(
       (type) => (memory[type] || new Set()).size > 0
     )
-    // Les types qui ont bougé dans le batch en cours
-    const new_types = Object.keys(
-      reduced_value.batch[batch]
-    ) as (keyof BatchValue)[]
 
     // 1. On recupère les cles ajoutes et les cles supprimes
     // -----------------------------------------------------
@@ -84,7 +80,11 @@ export function reduce(
     type DataType = string
     const hashToAdd: Record<DataType, Set<DataHash>> = {}
 
-    new_types.forEach((type) => {
+    // Itération sur les types qui ont potentiellement subi des modifications
+    // pour compléter hashToDelete et hashToAdd.
+    // Les suppressions de types complets / stock sont gérés dans le bloc suivant.
+    const currentBatch = reduced_value.batch[batch]
+    for (const type in currentBatch) {
       // Le type compact gère les clés supprimées
       // Ce type compact existe si le batch en cours a déjà été compacté.
       if (type === "compact") {
@@ -98,16 +98,14 @@ export function reduce(
           })
         }
       } else {
-        Object.keys(
-          reduced_value.batch[batch][
-            type as Exclude<keyof BatchValue, "compact">
-          ] || {}
-        ).forEach((hash) => {
-          hashToAdd[type] = hashToAdd[type] || new Set()
-          hashToAdd[type].add(hash)
-        })
+        Object.keys(currentBatch[type as keyof BatchValue] || {}).forEach(
+          (hash) => {
+            hashToAdd[type] = hashToAdd[type] || new Set()
+            hashToAdd[type].add(hash)
+          }
+        )
       }
-    })
+    }
 
     //
     // 2. On ajoute aux cles supprimees les types stocks de la memoire.
@@ -189,17 +187,13 @@ export function reduce(
     type AllValueTypesButCompact = Exclude<keyof BatchValue, "compact">
     const typesToAdd = Object.keys(hashToAdd) as AllValueTypesButCompact[]
     typesToAdd.forEach((type) => {
-      if (!new_types.includes(type)) {
-        delete reduced_value.batch[batch][type]
-      } else {
-        reduced_value.batch[batch][type] = [...hashToAdd[type]].reduce(
-          (typedBatchValues, hash) => ({
-            ...typedBatchValues,
-            [hash]: reduced_value.batch[batch][type]?.[hash],
-          }),
-          {}
-        )
-      }
+      reduced_value.batch[batch][type] = [...hashToAdd[type]].reduce(
+        (typedBatchValues, hash) => ({
+          ...typedBatchValues,
+          [hash]: reduced_value.batch[batch][type]?.[hash],
+        }),
+        {}
+      )
     })
 
     // 6. nettoyage

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -69,22 +69,13 @@ export function reduce(
     reduced_value.batch[batch] = reduced_value.batch[batch] || {}
 
     // Les types où il y  a potentiellement des suppressions
-    let stock_types = completeTypes[batch].filter(
+    const stock_types = completeTypes[batch].filter(
       (type) => (memory[type] || new Set()).size > 0
     )
     // Les types qui ont bougé dans le batch en cours
-    let new_types = Object.keys(reduced_value.batch[batch])
+    const new_types = Object.keys(reduced_value.batch[batch])
     // On dedoublonne au besoin
-    let all_interesting_types = [...new Set([...stock_types, ...new_types])]
-
-    // Filtrage selon les types effectivement importés
-    if (types.length > 0) {
-      stock_types = stock_types.filter((type) => types.includes(type))
-      new_types = new_types.filter((type) => types.includes(type))
-      all_interesting_types = all_interesting_types.filter((type) =>
-        types.includes(type)
-      )
-    }
+    const all_interesting_types = [...new Set([...stock_types, ...new_types])]
 
     // 1. On recupère les cles ajoutes et les cles supprimes
     // -----------------------------------------------------

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -98,12 +98,10 @@ export function reduce(
           })
         }
       } else {
-        Object.keys(currentBatch[type as keyof BatchValue] || {}).forEach(
-          (hash) => {
-            hashToAdd[type] = hashToAdd[type] || new Set()
-            hashToAdd[type].add(hash)
-          }
-        )
+        for (const hash in currentBatch[type as keyof BatchValue]) {
+          hashToAdd[type] = hashToAdd[type] || new Set()
+          hashToAdd[type].add(hash)
+        }
       }
     }
 

--- a/dbmongo/lib/engine/adminBatch.go
+++ b/dbmongo/lib/engine/adminBatch.go
@@ -194,7 +194,7 @@ func CheckBatch(batch AdminBatch, parsers []Parser) error {
 }
 
 // ProcessBatch traitement ad-hoc modifiable pour les besoins du développement
-func ProcessBatch(batchList []string, parsers []Parser, types []string) error {
+func ProcessBatch(batchList []string, parsers []Parser) error {
 
 	for _, v := range batchList {
 		batch, errBatch := GetBatch(v)
@@ -203,7 +203,7 @@ func ProcessBatch(batchList []string, parsers []Parser, types []string) error {
 		}
 		ImportBatch(batch, parsers)
 		time.Sleep(5 * time.Second) // TODO: trouver une façon de synchroniser l'insert des paquets
-		err := Compact(v, types)
+		err := Compact(v)
 		if err != nil {
 			return errors.New("Erreur de compactage: " + err.Error())
 		}

--- a/dbmongo/lib/engine/data.go
+++ b/dbmongo/lib/engine/data.go
@@ -111,7 +111,7 @@ func MRroutine(job *mgo.MapReduce, query bson.M, dbTemp string, collOrig string,
 }
 
 // Compact traite le compactage de la base RawData
-func Compact(batchKey string, types []string) error {
+func Compact(batchKey string) error {
 	// Détermination scope traitement
 	batches, _ := GetBatches()
 
@@ -149,7 +149,6 @@ func Compact(batchKey string, types []string) error {
 		Scope: bson.M{
 			"f":             functions,
 			"batches":       batchesID,
-			"types":         types,
 			"completeTypes": completeTypes,
 			"batchKey":      batchKey,
 			"serie_periode": misc.GenereSeriePeriode(batch.Params.DateDebut, batch.Params.DateFin),

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -419,7 +419,7 @@ function reduce(key, values) {
                 reducedBatch.compact.delete[type] = [...hashToDelete[type]];
             }
         });
-        const typesToAdd = Object.keys(hashToAdd).filter((type) => type !== "compact");
+        const typesToAdd = Object.keys(hashToAdd);
         typesToAdd.forEach((type) => {
             if (!new_types.includes(type)) {
                 delete reduced_value.batch[batch][type];

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -329,17 +329,11 @@ function reduce(key, values) {
         var _a;
         reduced_value.batch[batch] = reduced_value.batch[batch] || {};
         // Les types où il y  a potentiellement des suppressions
-        let stock_types = completeTypes[batch].filter((type) => (memory[type] || new Set()).size > 0);
+        const stock_types = completeTypes[batch].filter((type) => (memory[type] || new Set()).size > 0);
         // Les types qui ont bougé dans le batch en cours
-        let new_types = Object.keys(reduced_value.batch[batch]);
+        const new_types = Object.keys(reduced_value.batch[batch]);
         // On dedoublonne au besoin
-        let all_interesting_types = [...new Set([...stock_types, ...new_types])];
-        // Filtrage selon les types effectivement importés
-        if (types.length > 0) {
-            stock_types = stock_types.filter((type) => types.includes(type));
-            new_types = new_types.filter((type) => types.includes(type));
-            all_interesting_types = all_interesting_types.filter((type) => types.includes(type));
-        }
+        const all_interesting_types = [...new Set([...stock_types, ...new_types])];
         // 1. On recupère les cles ajoutes et les cles supprimes
         // -----------------------------------------------------
         const hashToDelete = {};

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -334,7 +334,9 @@ function reduce(key, values) {
         // -----------------------------------------------------
         const hashToDelete = {};
         const hashToAdd = {};
-        // Les types qui ont bougé dans le batch en cours
+        // Itération sur les types qui ont potentiellement subi des modifications
+        // pour compléter hashToDelete et hashToAdd.
+        // Les suppressions de types complets / stock sont gérés dans le bloc suivant.
         const currentBatch = reduced_value.batch[batch];
         for (const type in currentBatch) {
             // Le type compact gère les clés supprimées

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -326,18 +326,17 @@ function reduce(key, values) {
     // suivants.
     const modified_batches = batches.filter((batch) => batch >= batchKey);
     modified_batches.forEach((batch) => {
-        var _a;
+        var _a, _b;
         reduced_value.batch[batch] = reduced_value.batch[batch] || {};
         // Les types où il y a potentiellement des suppressions
         const stock_types = completeTypes[batch].filter((type) => (memory[type] || new Set()).size > 0);
-        // Les types qui ont bougé dans le batch en cours
-        const new_types = Object.keys(reduced_value.batch[batch]);
         // 1. On recupère les cles ajoutes et les cles supprimes
         // -----------------------------------------------------
         const hashToDelete = {};
         const hashToAdd = {};
-        new_types.forEach((type) => {
-            var _a;
+        // Les types qui ont bougé dans le batch en cours
+        const currentBatch = reduced_value.batch[batch];
+        for (const type in currentBatch) {
             // Le type compact gère les clés supprimées
             // Ce type compact existe si le batch en cours a déjà été compacté.
             if (type === "compact") {
@@ -352,12 +351,12 @@ function reduce(key, values) {
                 }
             }
             else {
-                Object.keys(reduced_value.batch[batch][type] || {}).forEach((hash) => {
+                Object.keys(currentBatch[type] || {}).forEach((hash) => {
                     hashToAdd[type] = hashToAdd[type] || new Set();
                     hashToAdd[type].add(hash);
                 });
             }
-        });
+        }
         //
         // 2. On ajoute aux cles supprimees les types stocks de la memoire.
         // ----------------------------------------------------------------
@@ -420,15 +419,10 @@ function reduce(key, values) {
         });
         const typesToAdd = Object.keys(hashToAdd);
         typesToAdd.forEach((type) => {
-            if (!new_types.includes(type)) {
-                delete reduced_value.batch[batch][type];
-            }
-            else {
-                reduced_value.batch[batch][type] = [...hashToAdd[type]].reduce((typedBatchValues, hash) => {
-                    var _a;
-                    return (Object.assign(Object.assign({}, typedBatchValues), { [hash]: (_a = reduced_value.batch[batch][type]) === null || _a === void 0 ? void 0 : _a[hash] }));
-                }, {});
-            }
+            reduced_value.batch[batch][type] = [...hashToAdd[type]].reduce((typedBatchValues, hash) => {
+                var _a;
+                return (Object.assign(Object.assign({}, typedBatchValues), { [hash]: (_a = reduced_value.batch[batch][type]) === null || _a === void 0 ? void 0 : _a[hash] }));
+            }, {});
         });
         // 6. nettoyage
         // ------------
@@ -441,7 +435,7 @@ function reduce(key, values) {
                 }
             });
             //hash à supprimer vides (compact.delete)
-            const compactDelete = (_a = reduced_value.batch[batch].compact) === null || _a === void 0 ? void 0 : _a.delete;
+            const compactDelete = (_b = reduced_value.batch[batch].compact) === null || _b === void 0 ? void 0 : _b.delete;
             if (compactDelete) {
                 Object.keys(compactDelete).forEach((type) => {
                     if (compactDelete[type].length === 0) {

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -328,19 +328,18 @@ function reduce(key, values) {
     modified_batches.forEach((batch) => {
         var _a;
         reduced_value.batch[batch] = reduced_value.batch[batch] || {};
-        // Les types où il y  a potentiellement des suppressions
+        // Les types où il y a potentiellement des suppressions
         const stock_types = completeTypes[batch].filter((type) => (memory[type] || new Set()).size > 0);
         // Les types qui ont bougé dans le batch en cours
         const new_types = Object.keys(reduced_value.batch[batch]);
-        // On dedoublonne au besoin
-        const all_interesting_types = [...new Set([...stock_types, ...new_types])];
         // 1. On recupère les cles ajoutes et les cles supprimes
         // -----------------------------------------------------
         const hashToDelete = {};
         const hashToAdd = {};
-        all_interesting_types.forEach((type) => {
+        new_types.forEach((type) => {
             var _a;
             // Le type compact gère les clés supprimées
+            // Ce type compact existe si le batch en cours a déjà été compacté.
             if (type === "compact") {
                 const compactDelete = (_a = reduced_value.batch[batch].compact) === null || _a === void 0 ? void 0 : _a.delete;
                 if (compactDelete) {

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -353,10 +353,10 @@ function reduce(key, values) {
                 }
             }
             else {
-                Object.keys(currentBatch[type] || {}).forEach((hash) => {
+                for (const hash in currentBatch[type]) {
                     hashToAdd[type] = hashToAdd[type] || new Set();
                     hashToAdd[type].add(hash);
-                });
+                }
             }
         }
         //


### PR DESCRIPTION
Effectué en pair coding avec Pierre.

## Problème

Tel qu'exprimé lors de la revue d'une précédente PR (https://github.com/signaux-faibles/opensignauxfaibles/pull/66/files/cc13e6f1c3ccca69a52ebf9d6a126ea1086264e8#r442061422): le paramètre `types` avait été introduit dans l'API `compact` pour un besoin ponctuel, et la complexité qu'il apporte pourrait augmenter le risque d'ajout de bugs.

## Changements apportés

- retrait du paramètre `types` dans le code Golang
- simplification de l'algorithme JS => retrait des variables `types`, `new_types` et `all_interesting_types` devenues inutiles

