### PR TITLE
fix(scripts): Remplacer `sed -i ''` par `perl -pi'' -e`

### DIFF
--- a/test-api.sh
+++ b/test-api.sh
@@ -29,13 +29,8 @@ cd dbmongo
 go build
 [ -f config.toml ] && mv config.toml config.backup.toml
 cp config-sample.toml config.toml
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' "s,/foo/bar/data-raw,${DATA_DIR}," config.toml
-  sed -i '' 's,naf/.*\.csv,dummy.csv,' config.toml
-else
-  sed -i "s,/foo/bar/data-raw,${DATA_DIR}," config.toml
-  sed -i 's,naf/.*\.csv,dummy.csv,' config.toml
-fi
+perl -pi'' -e "s,/foo/bar/data-raw,${DATA_DIR}," config.toml
+perl -pi'' -e 's,naf/.*\.csv,dummy.csv,' config.toml
 
 echo ""
 echo "📄 Inserting test data..."


### PR DESCRIPTION
...car les flags de `sed` ne sont pas compatibles entre Linux et Darwin/macOS => `test-api.sh` l'employait différemment en fonction de l'environnement d'exécution.