### PR TITLE
fix(TS): Homogénéisation des types Données*, Entrée* et Sortie*

### DIFF
--- a/dbmongo/js/compact/ava_tests.ts
+++ b/dbmongo/js/compact/ava_tests.ts
@@ -14,7 +14,9 @@ const global = globalThis as any // eslint-disable-line @typescript-eslint/no-ex
 
 const ISODate = (date: string): Date => new Date(date)
 
-const removeRandomOrder = (reporderProp: { [key: string]: RepOrder }): void =>
+const removeRandomOrder = (reporderProp: {
+  [key: string]: EntréeRepOrder
+}): void =>
   Object.keys(reporderProp).forEach((period) => {
     delete reporderProp[period].random_order
   })

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -59,7 +59,7 @@ type BatchDataType = keyof BatchValue // => 'reporder' | 'effectif' | 'apconso' 
 // Définition des types de données
 
 type DonnéesRepOrder = {
-  reporder: Record<Periode, RepOrder>
+  reporder: Record<Periode, EntréeRepOrder>
 }
 
 type DonnéesCompact = {
@@ -67,7 +67,7 @@ type DonnéesCompact = {
 }
 
 type DonnéesEffectif = {
-  effectif: Record<DataHash, Effectif>
+  effectif: Record<DataHash, EntréeEffectif>
 }
 
 type DonnéesApConso = {
@@ -79,15 +79,15 @@ type DonnéesApDemande = {
 }
 
 type DonnéesCompte = {
-  compte: Record<DataHash, Compte>
+  compte: Record<DataHash, EntréeCompte>
 }
 
 type DonnéesInterim = {
-  interim: Record<Periode, Interim>
+  interim: Record<Periode, EntréeInterim>
 }
 
 type DonnéesDelai = {
-  delai: Record<DataHash, Delai>
+  delai: Record<DataHash, EntréeDelai>
 }
 
 type DonnéesDefaillances = {
@@ -105,15 +105,15 @@ type DonnéesCcsf = {
 }
 
 type DonnéesSirene = {
-  sirene: Record<string, Sirene> // TODO: utiliser un type plus précis que string
+  sirene: Record<string, EntréeSirene> // TODO: utiliser un type plus précis que string
 }
 
 type DonnéesSireneUL = {
-  sirene_ul: Record<string, SireneUL> // TODO: utiliser un type plus précis que string
+  sirene_ul: Record<string, EntréeSireneUL> // TODO: utiliser un type plus précis que string
 }
 
 type DonnéesEffectifEntreprise = {
-  effectif_ent: Record<DataHash, Effectif>
+  effectif_ent: Record<DataHash, EntréeEffectif>
 }
 
 type DonnéesBdf = {
@@ -139,25 +139,25 @@ type Événement = {
   date_effet: Date
 }
 
-type ApConso = {
+type EntréeApConso = {
   id_conso: string
   periode: Date
   heure_consomme: number
 }
 
-type ApDemande = {
+type EntréeApDemande = {
   id_demande: string
   periode: { start: Date; end: Date }
   hta: unknown
   motif_recours_se: unknown
 }
 
-type Compte = {
+type EntréeCompte = {
   periode: Date
   numero_compte: number
 }
 
-type Interim = {
+type EntréeInterim = {
   periode: Date
   etp: number
 }
@@ -168,20 +168,20 @@ type Periode = string // Date
 
 type SiretOrSiren = string
 
-type RepOrder = {
+type EntréeRepOrder = {
   random_order: number
   periode: Date
   siret: SiretOrSiren
 }
 
-type Effectif = {
+type EntréeEffectif = {
   numero_compte: string
   periode: Date
   effectif: number
 }
 
 // Valeurs attendues par delais(), pour chaque période. (cf dbmongo/lib/urssaf/delai.go)
-type Delai = {
+type EntréeDelai = {
   date_creation: Date
   date_echeance: Date
   duree_delai: number // nombre de jours entre date_creation et date_echeance
@@ -211,7 +211,7 @@ type Debit = {
 
 type Departement = string
 
-type Sirene = {
+type EntréeSirene = {
   ape: CodeAPE
   lattitude: number // TODO: une fois que les données auront été migrées, corriger l'orthographe de cette propriété (--> latitude)
   longitude: unknown
@@ -220,7 +220,7 @@ type Sirene = {
   date_creation: Date
 }
 
-type SireneUL = {
+type EntréeSireneUL = {
   raison_sociale: string
   nom_unite_legale: string
   nom_usage_unite_legale: string

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -20,8 +20,6 @@ type CodeNAF = string
 
 type Scope = "etablissement" | "entreprise"
 
-type BatchValues = Record<BatchKey, BatchValue>
-
 type CompanyDataValues = {
   key: SiretOrSiren
   scope: Scope
@@ -35,8 +33,37 @@ type CompanyDataValuesWithFlags = CompanyDataValues & {
   }
 }
 
+type BatchValues = Record<BatchKey, BatchValue>
+
+type BatchValue = Partial<
+  DonnéesRepOrder &
+    DonnéesCompact &
+    DonnéesEffectif &
+    DonnéesApConso &
+    DonnéesApDemande &
+    DonnéesCompte &
+    DonnéesInterim &
+    DonnéesDelai &
+    DonnéesDefaillances &
+    DonnéesCotisationsDettes &
+    DonnéesCcsf &
+    DonnéesSirene &
+    DonnéesSireneUL &
+    DonnéesEffectifEntreprise &
+    DonnéesBdf &
+    DonnéesDiane
+>
+
+type BatchDataType = keyof BatchValue // => 'reporder' | 'effectif' | 'apconso' | ...
+
+// Définition des types de données
+
 type DonnéesRepOrder = {
   reporder: Record<Periode, RepOrder>
+}
+
+type DonnéesCompact = {
+  compact: { delete: { [dataType: string]: DataHash[] } } // TODO: utiliser un type Record<~BatchDataType, DataHash[]>
 }
 
 type DonnéesEffectif = {
@@ -63,31 +90,41 @@ type DonnéesDelai = {
   delai: Record<DataHash, Delai>
 }
 
-type DonnéesCompact = {
-  compact: { delete: { [dataType: string]: DataHash[] } }
+type DonnéesDefaillances = {
+  altares: Record<DataHash, Événement>
+  procol: Record<DataHash, Événement>
 }
 
-type BatchValue = Partial<DonnéesRepOrder> &
-  Partial<DonnéesCompact> &
-  Partial<DonnéesEffectif> &
-  Partial<DonnéesApConso> &
-  Partial<DonnéesApDemande> &
-  Partial<DonnéesCompte> &
-  Partial<DonnéesInterim> &
-  Partial<DonnéesDelai> &
-  Partial<DonnéesDefaillances> &
-  Partial<DonnéesCotisationsDettes> &
-  Partial<DonnéesCcsf> &
-  Partial<DonnéesSirene> &
-  Partial<DonnéesSireneUL> &
-  Partial<DonnéesEffectifEntreprise> &
-  Partial<DonnéesBdf> &
-  Partial<DonnéesDiane>
+type DonnéesCotisationsDettes = {
+  cotisation: Record<string, Cotisation> // TODO: utiliser un type plus précis que string
+  debit: Record<string, Debit> // TODO: utiliser un type plus précis que string
+}
 
-// TODO: remove redundant Partial
-// TODO: check for redundant type defs
+type DonnéesCcsf = {
+  ccsf: Record<DataHash, { date_traitement: Date }>
+}
 
-type BatchDataType = keyof BatchValue
+type DonnéesSirene = {
+  sirene: Record<string, Sirene> // TODO: utiliser un type plus précis que string
+}
+
+type DonnéesSireneUL = {
+  sirene_ul: Record<string, SireneUL> // TODO: utiliser un type plus précis que string
+}
+
+type DonnéesEffectifEntreprise = {
+  effectif_ent: Record<DataHash, Effectif>
+}
+
+type DonnéesBdf = {
+  bdf: Record<DataHash, EntréeBdf>
+}
+
+type DonnéesDiane = {
+  diane: Record<DataHash, EntréeDiane>
+}
+
+// Détail des types de données
 
 type AltaresCode = string
 
@@ -100,11 +137,6 @@ type Événement = {
   action_procol: Action
   stade_procol: Stade
   date_effet: Date
-}
-
-type DonnéesDefaillances = {
-  altares: Record<DataHash, Événement>
-  procol: Record<DataHash, Événement>
 }
 
 type ApConso = {
@@ -177,15 +209,6 @@ type Debit = {
   montant_majorations: number
 }
 
-type DonnéesCotisationsDettes = {
-  cotisation: Record<string, Cotisation>
-  debit: Record<string, Debit>
-}
-
-type DonnéesCcsf = {
-  ccsf: Record<DataHash, { date_traitement: Date }>
-}
-
 type Departement = string
 
 type Sirene = {
@@ -195,10 +218,6 @@ type Sirene = {
   departement: Departement
   raison_sociale: string
   date_creation: Date
-}
-
-type DonnéesSirene = {
-  sirene: Record<string, Sirene>
 }
 
 type SireneUL = {
@@ -213,24 +232,10 @@ type SireneUL = {
   date_creation: Date
 }
 
-type DonnéesSireneUL = {
-  sirene_ul: Record<string, SireneUL>
-}
-
-type EffectifEntreprise = Record<DataHash, Effectif>
-
-type DonnéesEffectifEntreprise = {
-  effectif_ent: EffectifEntreprise
-}
-
 type EntréeBdf = {
   arrete_bilan_bdf: Date
   annee_bdf: number
   exercice_bdf: number
-}
-
-type DonnéesBdf = {
-  bdf: Record<DataHash, EntréeBdf>
 }
 
 type EntréeDiane = {
@@ -243,8 +248,4 @@ type EntréeDiane = {
   produit_exceptionnel: number
   charge_exceptionnelle: number
   charges_financieres: number
-}
-
-type DonnéesDiane = {
-  diane: Record<DataHash, EntréeDiane>
 }

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -20,12 +20,7 @@ type CodeNAF = string
 
 type Scope = "etablissement" | "entreprise"
 
-type ReduceIndexFlags = {
-  algo1: boolean
-  algo2: boolean
-}
-
-type BatchValues = { [batchKey: string]: BatchValue }
+type BatchValues = Record<BatchKey, BatchValue>
 
 type CompanyDataValues = {
   key: SiretOrSiren
@@ -34,19 +29,53 @@ type CompanyDataValues = {
 }
 
 type CompanyDataValuesWithFlags = CompanyDataValues & {
-  index: ReduceIndexFlags
+  index: {
+    algo1: boolean
+    algo2: boolean
+  }
 }
 
-type BatchValue = {
-  reporder?: { [periode: string]: RepOrder }
-  compact?: { delete: { [dataType: string]: DataHash[] } }
-  effectif?: { [dataHash: string]: Effectif }
-  apconso?: Record<DataHash, ApConso>
-  apdemande?: Record<DataHash, ApDemande>
-  compte?: Record<DataHash, Compte>
-  interim?: Record<Periode, Interim>
-  delai?: Record<DataHash, Delai>
-} & Partial<DonnéesDefaillances> &
+type DonnéesRepOrder = {
+  reporder: Record<Periode, RepOrder>
+}
+
+type DonnéesEffectif = {
+  effectif: Record<DataHash, Effectif>
+}
+
+type DonnéesApConso = {
+  apconso: Record<DataHash, ApConso>
+}
+
+type DonnéesApDemande = {
+  apdemande: Record<DataHash, ApDemande>
+}
+
+type DonnéesCompte = {
+  compte: Record<DataHash, Compte>
+}
+
+type DonnéesInterim = {
+  interim: Record<Periode, Interim>
+}
+
+type DonnéesDelai = {
+  delai: Record<DataHash, Delai>
+}
+
+type DonnéesCompact = {
+  compact: { delete: { [dataType: string]: DataHash[] } }
+}
+
+type BatchValue = Partial<DonnéesRepOrder> &
+  Partial<DonnéesCompact> &
+  Partial<DonnéesEffectif> &
+  Partial<DonnéesApConso> &
+  Partial<DonnéesApDemande> &
+  Partial<DonnéesCompte> &
+  Partial<DonnéesInterim> &
+  Partial<DonnéesDelai> &
+  Partial<DonnéesDefaillances> &
   Partial<DonnéesCotisationsDettes> &
   Partial<DonnéesCcsf> &
   Partial<DonnéesSirene> &
@@ -54,6 +83,9 @@ type BatchValue = {
   Partial<DonnéesEffectifEntreprise> &
   Partial<DonnéesBdf> &
   Partial<DonnéesDiane>
+
+// TODO: remove redundant Partial
+// TODO: check for redundant type defs
 
 type BatchDataType = keyof BatchValue
 

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -45,7 +45,8 @@ type BatchValue = Partial<
     DonnéesInterim &
     DonnéesDelai &
     DonnéesDefaillances &
-    DonnéesCotisationsDettes &
+    DonnéesCotisation &
+    DonnéesDebit &
     DonnéesCcsf &
     DonnéesSirene &
     DonnéesSireneUL &
@@ -91,13 +92,16 @@ type DonnéesDelai = {
 }
 
 type DonnéesDefaillances = {
-  altares: Record<DataHash, Événement>
-  procol: Record<DataHash, Événement>
+  altares: Record<DataHash, EntréeDefaillances>
+  procol: Record<DataHash, EntréeDefaillances>
 }
 
-type DonnéesCotisationsDettes = {
-  cotisation: Record<string, Cotisation> // TODO: utiliser un type plus précis que string
-  debit: Record<string, Debit> // TODO: utiliser un type plus précis que string
+type DonnéesCotisation = {
+  cotisation: Record<string, EntréeCotisation> // TODO: utiliser un type plus précis que string
+}
+
+type DonnéesDebit = {
+  debit: Record<string, EntréeDebit> // TODO: utiliser un type plus précis que string
 }
 
 type DonnéesCcsf = {
@@ -132,7 +136,7 @@ type Action = "liquidation" | "redressement" | "sauvegarde"
 
 type Stade = "abandon_procedure" | "fin_procedure" | "plan_continuation"
 
-type Événement = {
+type EntréeDefaillances = {
   code_evenement: AltaresCode
   action_procol: Action
   stade_procol: Stade
@@ -192,12 +196,12 @@ type CurrentDataState = { [key: string]: Set<DataHash> }
 
 type DebitHash = string
 
-type Cotisation = {
+type EntréeCotisation = {
   periode: { start: Date; end: Date }
   du: number
 }
 
-type Debit = {
+type EntréeDebit = {
   periode: { start: Date; end: Date }
   numero_ecart_negatif: unknown
   numero_compte: unknown

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -71,11 +71,11 @@ type DonnéesEffectif = {
 }
 
 type DonnéesApConso = {
-  apconso: Record<DataHash, ApConso>
+  apconso: Record<DataHash, EntréeApConso>
 }
 
 type DonnéesApDemande = {
-  apdemande: Record<DataHash, ApDemande>
+  apdemande: Record<DataHash, EntréeApDemande>
 }
 
 type DonnéesCompte = {

--- a/dbmongo/js/public/effectifs.d.ts
+++ b/dbmongo/js/public/effectifs.d.ts
@@ -1,5 +1,5 @@
 export function effectifs(v: {
-  effectif: Effectif
+  effectif: EntréeEffectif
 }): {
   periode: Periode
   effectif: number

--- a/dbmongo/js/reduce.algo2/apart.ts
+++ b/dbmongo/js/reduce.algo2/apart.ts
@@ -6,7 +6,7 @@ type Hash = string
 
 type Timestamp = string
 
-type Output = {
+type SortieAPart = {
   apart_heures_autorisees: unknown
   apart_heures_consommees: number
   apart_motif_recours: ApDemande["motif_recours_se"]
@@ -16,10 +16,10 @@ type Output = {
 export function apart(
   apconso: Record<ApConsoHash, ApConso>,
   apdemande: Record<Hash, ApDemande>
-): Record<Timestamp, Output> {
+): Record<Timestamp, SortieAPart> {
   "use strict"
 
-  const output_apart: Record<Timestamp, Output> = {}
+  const output_apart: Record<Timestamp, SortieAPart> = {}
 
   // Mapping (pour l'instant vide) du hash de la demande avec les hash des consos correspondantes
   const apart = Object.keys(apdemande).reduce((apart, hash) => {

--- a/dbmongo/js/reduce.algo2/apart.ts
+++ b/dbmongo/js/reduce.algo2/apart.ts
@@ -9,13 +9,13 @@ type Timestamp = string
 type SortieAPart = {
   apart_heures_autorisees: unknown
   apart_heures_consommees: number
-  apart_motif_recours: ApDemande["motif_recours_se"]
+  apart_motif_recours: EntréeApDemande["motif_recours_se"]
   apart_heures_consommees_cumulees: number
 }
 
 export function apart(
-  apconso: Record<ApConsoHash, ApConso>,
-  apdemande: Record<Hash, ApDemande>
+  apconso: Record<ApConsoHash, EntréeApConso>,
+  apdemande: Record<Hash, EntréeApDemande>
 ): Record<Timestamp, SortieAPart> {
   "use strict"
 

--- a/dbmongo/js/reduce.algo2/ccsf.ts
+++ b/dbmongo/js/reduce.algo2/ccsf.ts
@@ -2,13 +2,13 @@ type Input = {
   periode: Date
 }
 
-export type Output = {
+export type SortieCcsf = {
   date_ccsf: unknown
 }
 
 export function ccsf(
   v: DonnéesCcsf,
-  output_array: (Input & Partial<Output>)[]
+  output_array: (Input & Partial<SortieCcsf>)[]
 ): void {
   "use strict"
 

--- a/dbmongo/js/reduce.algo2/ccsf.ts
+++ b/dbmongo/js/reduce.algo2/ccsf.ts
@@ -1,5 +1,3 @@
-type V = DonnéesCcsf
-
 type Input = {
   periode: Date
 }
@@ -8,7 +6,10 @@ export type Output = {
   date_ccsf: unknown
 }
 
-export function ccsf(v: V, output_array: (Input & Partial<Output>)[]): void {
+export function ccsf(
+  v: DonnéesCcsf,
+  output_array: (Input & Partial<Output>)[]
+): void {
   "use strict"
 
   const ccsfHashes = Object.keys(v.ccsf || {})

--- a/dbmongo/js/reduce.algo2/compte.ts
+++ b/dbmongo/js/reduce.algo2/compte.ts
@@ -1,12 +1,6 @@
 import "../globals.ts"
 
-type Hash = string
-
-export type V = {
-  compte: Record<Hash, Compte>
-}
-
-type Periode = number
+type Periode = number // TODO: réutiliser le type Periode global ?
 
 type TypeEnSortie = Record<
   Periode,
@@ -15,7 +9,7 @@ type TypeEnSortie = Record<
   }
 >
 
-export function compte(v: V): TypeEnSortie {
+export function compte(v: DonnéesCompte): TypeEnSortie {
   "use strict"
   const output_compte: TypeEnSortie = {}
 

--- a/dbmongo/js/reduce.algo2/compte.ts
+++ b/dbmongo/js/reduce.algo2/compte.ts
@@ -2,16 +2,16 @@ import "../globals.ts"
 
 type Periode = number // TODO: réutiliser le type Periode global ?
 
-type TypeEnSortie = Record<
+type SortieCompte = Record<
   Periode,
   {
     compte_urssaf: unknown
   }
 >
 
-export function compte(v: DonnéesCompte): TypeEnSortie {
+export function compte(v: DonnéesCompte): SortieCompte {
   "use strict"
-  const output_compte: TypeEnSortie = {}
+  const output_compte: SortieCompte = {}
 
   //  var offset_compte = 3
   Object.keys(v.compte).forEach((hash) => {

--- a/dbmongo/js/reduce.algo2/cotisation.ts
+++ b/dbmongo/js/reduce.algo2/cotisation.ts
@@ -8,7 +8,7 @@ type Input = {
   montant_part_ouvriere?: number
 }
 
-export type Output = {
+export type SortieCotisation = {
   montant_pp_array: number[]
   montant_po_array: number[]
   cotisation_moy12m: number
@@ -20,8 +20,8 @@ export type Output = {
 }
 
 export function cotisation(
-  output_indexed: { [k: string]: Input & Partial<Output> },
-  output_array: (Input & Partial<Output>)[]
+  output_indexed: { [k: string]: Input & Partial<SortieCotisation> },
+  output_array: (Input & Partial<SortieCotisation>)[]
 ): void {
   "use strict"
   const f = { generatePeriodSerie, dateAddMonth } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO

--- a/dbmongo/js/reduce.algo2/cotisationsdettes.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes.ts
@@ -17,7 +17,7 @@ type Dette = {
   montant_majorations: Debit["montant_majorations"]
 }
 
-type Output = {
+type SortieCotisationsDettes = {
   interessante_urssaf: boolean
   cotisation: number
   montant_part_ouvriere: number
@@ -29,7 +29,7 @@ type Output = {
 export function cotisationsdettes(
   v: DonnéesCotisationsDettes,
   periodes: Periode[]
-): Record<number, Output> {
+): Record<number, SortieCotisationsDettes> {
   "use strict"
 
   const f = { generatePeriodSerie, dateAddMonth, compareDebit } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
@@ -38,7 +38,7 @@ export function cotisationsdettes(
   // Permet de s'aligner avec le calendrier de fourniture des données
   const last_treatment_day = 20
 
-  const output_cotisationsdettes: Record<Periode, Output> = {}
+  const output_cotisationsdettes: Record<Periode, SortieCotisationsDettes> = {}
 
   // TODO Cotisations avec un mois de retard ? Bizarre, plus maintenant que l'export se fait le 20
   // var offset_cotisation = 1

--- a/dbmongo/js/reduce.algo2/cotisationsdettes.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes.ts
@@ -6,15 +6,15 @@ declare const date_fin: number
 
 type EcartNegatif = {
   hash: string
-  numero_historique: Debit["numero_historique"]
-  date_traitement: Debit["date_traitement"]
+  numero_historique: EntréeDebit["numero_historique"]
+  date_traitement: EntréeDebit["date_traitement"]
 }
 
 type Dette = {
-  periode: Debit["periode"]["start"]
-  part_ouvriere: Debit["part_ouvriere"]
-  part_patronale: Debit["part_patronale"]
-  montant_majorations: Debit["montant_majorations"]
+  periode: EntréeDebit["periode"]["start"]
+  part_ouvriere: EntréeDebit["part_ouvriere"]
+  part_patronale: EntréeDebit["part_patronale"]
+  montant_majorations: EntréeDebit["montant_majorations"]
 }
 
 type SortieCotisationsDettes = {
@@ -27,7 +27,7 @@ type SortieCotisationsDettes = {
 }
 
 export function cotisationsdettes(
-  v: DonnéesCotisationsDettes,
+  v: DonnéesCotisation & DonnéesDebit,
   periodes: Periode[]
 ): Record<number, SortieCotisationsDettes> {
   "use strict"

--- a/dbmongo/js/reduce.algo2/cotisationsdettes.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes.ts
@@ -17,8 +17,6 @@ type Dette = {
   montant_majorations: Debit["montant_majorations"]
 }
 
-type V = DonnéesCotisationsDettes
-
 type Output = {
   interessante_urssaf: boolean
   cotisation: number
@@ -29,7 +27,7 @@ type Output = {
 }
 
 export function cotisationsdettes(
-  v: V,
+  v: DonnéesCotisationsDettes,
   periodes: Periode[]
 ): Record<number, Output> {
   "use strict"

--- a/dbmongo/js/reduce.algo2/dealWithProcols.ts
+++ b/dbmongo/js/reduce.algo2/dealWithProcols.ts
@@ -8,7 +8,7 @@ type OutputEvent = {
   date_proc_col: Date
 }
 
-export type Output = {
+export type SortieProcols = {
   etat_proc_collective: unknown
   date_proc_collective: unknown
   tag_failure: boolean
@@ -18,7 +18,7 @@ export function dealWithProcols(
   data_source: { [hash: string]: InputEvent },
   altar_or_procol: "altares" | "procol",
   output_indexed: {
-    [time: string]: Partial<Output>
+    [time: string]: Partial<SortieProcols>
   }
 ): void {
   "use strict"

--- a/dbmongo/js/reduce.algo2/dealWithProcols.ts
+++ b/dbmongo/js/reduce.algo2/dealWithProcols.ts
@@ -1,7 +1,7 @@
 import { altaresToHuman, AltaresToHumanRes } from "../common/altaresToHuman"
 import { procolToHuman, ProcolToHumanRes } from "./procolToHuman"
 
-export type InputEvent = Événement
+export type InputEvent = EntréeDefaillances
 
 type OutputEvent = {
   etat: AltaresToHumanRes

--- a/dbmongo/js/reduce.algo2/defaillances.ts
+++ b/dbmongo/js/reduce.algo2/defaillances.ts
@@ -1,12 +1,10 @@
 import * as f from "./dealWithProcols"
 import { Output as ProcolOutput } from "./dealWithProcols"
 
-type V = DonnéesDefaillances
-
 export type Output = ProcolOutput
 
 export function defaillances(
-  v: V,
+  v: DonnéesDefaillances,
   output_indexed: Record<Periode, Partial<Output>>
 ): void {
   "use strict"

--- a/dbmongo/js/reduce.algo2/defaillances.ts
+++ b/dbmongo/js/reduce.algo2/defaillances.ts
@@ -1,11 +1,11 @@
 import * as f from "./dealWithProcols"
-import { Output as ProcolOutput } from "./dealWithProcols"
+import { SortieProcols } from "./dealWithProcols"
 
-export type Output = ProcolOutput
+export type SortieDefaillances = SortieProcols
 
 export function defaillances(
   v: DonnéesDefaillances,
-  output_indexed: Record<Periode, Partial<Output>>
+  output_indexed: Record<Periode, Partial<SortieDefaillances>>
 ): void {
   "use strict"
   f.dealWithProcols(v.altares, "altares", output_indexed)

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -18,7 +18,7 @@ export type DelaiComputedValues = {
   montant_echeancier: number // exprimé en euros
 }
 
-export type V = { delai: ParPériode<Delai> }
+export type V = { delai: ParPériode<Delai> } // TODO: définir ce type dans global.ts ?
 
 export function delais(
   v: V,

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -18,7 +18,7 @@ export type DelaiComputedValues = {
   montant_echeancier: number // exprimé en euros
 }
 
-export type V = { delai: ParPériode<Delai> } // TODO: définir ce type dans global.ts ?
+export type V = { delai: ParPériode<EntréeDelai> } // TODO: définir ce type dans global.ts ?
 
 export function delais(
   v: V,

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -17,7 +17,7 @@ const nbDays = (firstDate: Date, secondDate: Date): number => {
   )
 }
 
-const makeDelai = (firstDate: Date, secondDate: Date): Delai => ({
+const makeDelai = (firstDate: Date, secondDate: Date): EntréeDelai => ({
   date_creation: firstDate,
   date_echeance: secondDate,
   duree_delai: nbDays(firstDate, secondDate),
@@ -36,7 +36,7 @@ const testProperty = (
   debits?: DebitComputedValues
 ): ParPériode<DelaiComputedValues> => {
   const delaiTest = makeDelai(new Date("2014-01-03"), new Date("2014-04-05"))
-  const delaiMap: ParPériode<Delai> = {
+  const delaiMap: ParPériode<EntréeDelai> = {
     abc: delaiTest,
   }
   const output_indexed: ParPériode<DebitComputedValues> = {}
@@ -85,7 +85,7 @@ test("la propriété ratio_dette_delai représente la déviation du remboursemen
 
 test("un délai en dehors de la période d'intérêt est ignorée", (t) => {
   const delaiTest = makeDelai(new Date("2013-01-03"), new Date("2013-03-05"))
-  const delaiMap: ParPériode<Delai> = {
+  const delaiMap: ParPériode<EntréeDelai> = {
     abc: delaiTest,
   }
   const donnéesParPériode: ParPériode<DebitComputedValues> = {}

--- a/dbmongo/js/reduce.algo2/effectifs.ts
+++ b/dbmongo/js/reduce.algo2/effectifs.ts
@@ -10,7 +10,7 @@ type ValeurEffectif = number
 
 type SortieEffectifs = Record<Time, Record<EffectifName, ValeurEffectif | null>>
 
-type EffectifEntreprise = Record<DataHash, Effectif>
+type EffectifEntreprise = Record<DataHash, EntréeEffectif>
 
 export function effectifs(
   effobj: EffectifEntreprise,

--- a/dbmongo/js/reduce.algo2/effectifs.ts
+++ b/dbmongo/js/reduce.algo2/effectifs.ts
@@ -10,6 +10,8 @@ type ValeurEffectif = number
 
 type Output = Record<Time, Record<EffectifName, ValeurEffectif | null>>
 
+type EffectifEntreprise = Record<DataHash, Effectif>
+
 export function effectifs(
   effobj: EffectifEntreprise,
   periodes: string[],

--- a/dbmongo/js/reduce.algo2/effectifs.ts
+++ b/dbmongo/js/reduce.algo2/effectifs.ts
@@ -8,7 +8,7 @@ type EffectifName = string
 
 type ValeurEffectif = number
 
-type Output = Record<Time, Record<EffectifName, ValeurEffectif | null>>
+type SortieEffectifs = Record<Time, Record<EffectifName, ValeurEffectif | null>>
 
 type EffectifEntreprise = Record<DataHash, Effectif>
 
@@ -16,10 +16,10 @@ export function effectifs(
   effobj: EffectifEntreprise,
   periodes: string[],
   effectif_name: EffectifName
-): Output {
+): SortieEffectifs {
   "use strict"
 
-  const output_effectif: Output = {}
+  const output_effectif: SortieEffectifs = {}
 
   // Construction d'une map[time] = effectif à cette periode
   const map_effectif = Object.keys(effobj).reduce((m, hash) => {

--- a/dbmongo/js/reduce.algo2/finalize.ts
+++ b/dbmongo/js/reduce.algo2/finalize.ts
@@ -19,9 +19,7 @@ type Clé = {
   type: unknown
 }
 
-export type V = Record<SiretOrSiren, EntrepriseEnEntrée> & {
-  entreprise?: EntrepriseEnEntrée
-}
+export type V = Record<SiretOrSiren | "entreprise", EntrepriseEnEntrée> // TODO: donner un nom plus explicite au type
 
 type Output = unknown[] | { incomplete: true } | undefined
 

--- a/dbmongo/js/reduce.algo2/finalize.ts
+++ b/dbmongo/js/reduce.algo2/finalize.ts
@@ -21,11 +21,11 @@ type Clé = {
 
 export type V = Record<SiretOrSiren | "entreprise", EntrepriseEnEntrée> // TODO: donner un nom plus explicite au type
 
-type Output = unknown[] | { incomplete: true } | undefined
+type SortieFinalize = unknown[] | { incomplete: true } | undefined
 
 declare function print(str: string): void
 
-export function finalize(k: Clé, v: V): Output {
+export function finalize(k: Clé, v: V): SortieFinalize {
   "use strict"
   const maxBsonSize = 16777216
   const bsonsize = // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/dbmongo/js/reduce.algo2/flatten.ts
+++ b/dbmongo/js/reduce.algo2/flatten.ts
@@ -1,4 +1,5 @@
 export type V = {
+  // TODO: donner un nom plus explicite au type
   key: SiretOrSiren
   scope: Scope
   batch: BatchValues

--- a/dbmongo/js/reduce.algo2/interim.ts
+++ b/dbmongo/js/reduce.algo2/interim.ts
@@ -4,7 +4,7 @@ type Input = {
   effectif: number | null
 }
 
-type Output = {
+type SortieInterim = {
   interim_proportion: number
   [interim_ratio_past_: string]: number // TODO: éviter la création dynamique de propriétés
 }
@@ -12,14 +12,14 @@ type Output = {
 export function interim(
   interim: Record<string, Interim>,
   output_indexed: Record<string, Input>
-): Record<string, Output> {
+): Record<string, SortieInterim> {
   "use strict"
   const output_effectif = output_indexed
   // let periodes = Object.keys(output_indexed)
   // output_indexed devra être remplacé par output_effectif, et ne contenir que les données d'effectif.
   // periodes sera passé en argument.
 
-  const output_interim: Record<string, Output> = {}
+  const output_interim: Record<string, SortieInterim> = {}
 
   //  var offset_interim = 3
 

--- a/dbmongo/js/reduce.algo2/interim.ts
+++ b/dbmongo/js/reduce.algo2/interim.ts
@@ -10,7 +10,7 @@ type SortieInterim = {
 }
 
 export function interim(
-  interim: Record<string, Interim>,
+  interim: Record<string, EntréeInterim>,
   output_indexed: Record<string, Input>
 ): Record<string, SortieInterim> {
   "use strict"

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -131,7 +131,7 @@ export function map(this: {
 
       if (v.cotisation && v.debit) {
         const output_cotisationsdettes = f.cotisationsdettes(
-          v as DonnéesCotisationsDettes,
+          v as DonnéesCotisation & DonnéesDebit,
           periodes
         )
         f.add(output_cotisationsdettes, output_indexed)

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -15,7 +15,7 @@ import { sirene } from "./sirene"
 import { populateNafAndApe, NAF } from "./populateNafAndApe"
 import { cotisation } from "./cotisation"
 import { cibleApprentissage } from "./cibleApprentissage"
-import { sirene_ul, Output as SireneULOutput } from "./sirene_ul"
+import { sirene_ul, SortieSireneUL } from "./sirene_ul"
 import { dateAddMonth } from "./dateAddMonth"
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { poidsFrng } from "./poidsFrng"
@@ -65,8 +65,8 @@ export function map(this: {
 
   if (v.scope === "etablissement") {
     const [
-      output_array, // [ OutputValue ], in chronological order
-      output_indexed, // { Periode -> OutputValue }
+      output_array, // DonnéesAgrégées[] dans l'ordre chronologique
+      output_indexed, // { Periode -> DonnéesAgrégées }
     ] = f.outputs(v, serie_periode)
 
     // Les periodes qui nous interessent, triées
@@ -171,13 +171,15 @@ export function map(this: {
       type Input = {
         periode: Date
       }
-      type Output = Input &
-        Partial<SireneULOutput> &
+      type SortieMapEntreprise = Input &
+        Partial<SortieSireneUL> &
         Partial<EntréeBdf> &
         Partial<EntréeDiane> &
         Record<string, unknown> // for *_past_* props of bdf. // TODO: try to be more specific
 
-      const output_array: Output[] = serie_periode.map(function (e) {
+      const output_array: SortieMapEntreprise[] = serie_periode.map(function (
+        e
+      ) {
         return {
           siren: v.key,
           periode: e,
@@ -191,7 +193,7 @@ export function map(this: {
       let output_indexed = output_array.reduce(function (periode, val) {
         periode[val.periode.getTime()] = val
         return periode
-      }, {} as Record<Periode, Output>)
+      }, {} as Record<Periode, SortieMapEntreprise>)
 
       if (v.sirene_ul) {
         f.sirene_ul(v as DonnéesSireneUL, output_array)
@@ -212,7 +214,7 @@ export function map(this: {
       output_indexed = output_array.reduce(function (periode, val) {
         periode[val.periode.getTime()] = val
         return periode
-      }, {} as Record<Periode, Output>)
+      }, {} as Record<Periode, SortieMapEntreprise>)
 
       v.bdf = v.bdf || {}
       v.diane = v.diane || {}

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -2,7 +2,7 @@ import "../globals"
 import { flatten, V as FlattenedEntreprise } from "./flatten"
 import { outputs } from "./outputs"
 import { apart } from "./apart"
-import { compte, V as CompteInput } from "./compte"
+import { compte } from "./compte"
 import { effectifs } from "./effectifs"
 import { interim } from "./interim"
 import { add } from "./add"
@@ -98,7 +98,7 @@ export function map(this: {
 
     if (includes["all"]) {
       if (v.compte) {
-        const output_compte = f.compte(v as CompteInput)
+        const output_compte = f.compte(v as DonnéesCompte)
         f.add(output_compte, output_indexed)
       }
 

--- a/dbmongo/js/reduce.algo2/outputs.ts
+++ b/dbmongo/js/reduce.algo2/outputs.ts
@@ -1,10 +1,9 @@
 import { DebitComputedValues } from "./delais"
-import { Output as DefaillancesOutput } from "./defaillances"
-import { Output as CcsfOutput } from "./ccsf"
-import { Output as SireneOutput } from "./sirene"
-import { Output as NafOutput } from "./populateNafAndApe"
-import { Output as CotisationOutput } from "./cotisation"
-// import { Output as DealWithProcolsOutput } from "./dealWithProcols"
+import { SortieDefaillances } from "./defaillances"
+import { SortieCcsf } from "./ccsf"
+import { SortieSirene } from "./sirene"
+import { SortieNAF } from "./populateNafAndApe"
+import { SortieCotisation } from "./cotisation"
 
 type DonnéesAgrégées = {
   siret: SiretOrSiren
@@ -14,13 +13,13 @@ type DonnéesAgrégées = {
   interessante_urssaf: true
   outcome: false
 } & DebitComputedValues &
-  Partial<DefaillancesOutput> &
-  Partial<CcsfOutput> &
-  Partial<SireneOutput> &
-  Partial<NafOutput> &
-  Partial<CotisationOutput>
+  Partial<SortieDefaillances> &
+  Partial<SortieCcsf> &
+  Partial<SortieSirene> &
+  Partial<SortieNAF> &
+  Partial<SortieCotisation>
 
-type IndexedOutput = Record<Periode, DonnéesAgrégées>
+type IndexDonnéesAgrégées = Record<Periode, DonnéesAgrégées>
 
 /**
  * Appelé par `map()` pour chaque entreprise/établissement, `outputs()` retourne
@@ -31,7 +30,7 @@ type IndexedOutput = Record<Periode, DonnéesAgrégées>
 export function outputs(
   v: { key: SiretOrSiren },
   serie_periode: Date[]
-): [DonnéesAgrégées[], IndexedOutput] {
+): [DonnéesAgrégées[], IndexDonnéesAgrégées] {
   "use strict"
   const output_array: DonnéesAgrégées[] = serie_periode.map(function (e) {
     return {
@@ -47,7 +46,7 @@ export function outputs(
   const output_indexed = output_array.reduce(function (periodes, val) {
     periodes[val.periode.getTime()] = val
     return periodes
-  }, {} as IndexedOutput)
+  }, {} as IndexDonnéesAgrégées)
 
   return [output_array, output_indexed]
 }

--- a/dbmongo/js/reduce.algo2/populateNafAndApe.ts
+++ b/dbmongo/js/reduce.algo2/populateNafAndApe.ts
@@ -6,7 +6,7 @@ type Input = {
   code_ape: CodeAPE
 }
 
-export type Output = {
+export type SortieNAF = {
   code_naf: CodeNAF
   libelle_naf: string
   code_ape_niveau2: CodeAPENiveau2
@@ -28,7 +28,7 @@ export type NAF = {
 }
 
 export function populateNafAndApe(
-  output_indexed: { [k: string]: Partial<Input> & Partial<Output> },
+  output_indexed: { [k: string]: Partial<Input> & Partial<SortieNAF> },
   naf: NAF
 ): void {
   "use strict"

--- a/dbmongo/js/reduce.algo2/repeatable.ts
+++ b/dbmongo/js/reduce.algo2/repeatable.ts
@@ -1,5 +1,5 @@
 export function repeatable(
-  rep: Record<Periode, RepOrder>
+  rep: Record<Periode, EntréeRepOrder>
 ): Record<Periode, { random_order: number }> {
   "use strict"
   const output_repeatable = {} as Record<string, { random_order: number }>

--- a/dbmongo/js/reduce.algo2/sirene.ts
+++ b/dbmongo/js/reduce.algo2/sirene.ts
@@ -1,7 +1,5 @@
 import * as f from "../common/region"
 
-type V = DonnéesSirene
-
 type Input = {
   periode: Date
   siret: SiretOrSiren
@@ -19,7 +17,10 @@ export type Output = {
   age: number | null // en années
 }
 
-export function sirene(v: V, output_array: (Input & Partial<Output>)[]): void {
+export function sirene(
+  v: DonnéesSirene,
+  output_array: (Input & Partial<Output>)[]
+): void {
   "use strict"
   const sireneHashes = Object.keys(v.sirene || {})
 

--- a/dbmongo/js/reduce.algo2/sirene.ts
+++ b/dbmongo/js/reduce.algo2/sirene.ts
@@ -5,7 +5,7 @@ type Input = {
   siret: SiretOrSiren
 }
 
-export type Output = {
+export type SortieSirene = {
   siren: SiretOrSiren
   latitude: unknown
   longitude: unknown
@@ -19,7 +19,7 @@ export type Output = {
 
 export function sirene(
   v: DonnéesSirene,
-  output_array: (Input & Partial<Output>)[]
+  output_array: (Input & Partial<SortieSirene>)[]
 ): void {
   "use strict"
   const sireneHashes = Object.keys(v.sirene || {})

--- a/dbmongo/js/reduce.algo2/sirene_ul.ts
+++ b/dbmongo/js/reduce.algo2/sirene_ul.ts
@@ -1,7 +1,5 @@
 import * as f from "../common/raison_sociale"
 
-type V = DonnéesSireneUL
-
 type Input = {
   periode: Date
 }
@@ -14,7 +12,7 @@ export type Output = {
 }
 
 export function sirene_ul(
-  v: V,
+  v: DonnéesSireneUL,
   output_array: (Input & Partial<Output>)[]
 ): void {
   "use strict"

--- a/dbmongo/js/reduce.algo2/sirene_ul.ts
+++ b/dbmongo/js/reduce.algo2/sirene_ul.ts
@@ -4,7 +4,7 @@ type Input = {
   periode: Date
 }
 
-export type Output = {
+export type SortieSireneUL = {
   raison_sociale: unknown
   statut_juridique: unknown
   date_creation_entreprise: number | null // année
@@ -13,7 +13,7 @@ export type Output = {
 
 export function sirene_ul(
   v: DonnéesSireneUL,
-  output_array: (Input & Partial<Output>)[]
+  output_array: (Input & Partial<SortieSireneUL>)[]
 ): void {
   "use strict"
   const sireneHashes = Object.keys(v.sirene_ul || {})

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1740,7 +1740,7 @@ function map() {
     }
     const v = f.flatten(this.value, actual_batch);
     if (v.scope === "etablissement") {
-        const [output_array, // [ OutputValue ], in chronological order
+        const [output_array, // DonnéesAgrégées[] dans l'ordre chronologique
         output_indexed,] = f.outputs(v, serie_periode);
         // Les periodes qui nous interessent, triées
         const periodes = Object.keys(output_indexed).sort((a, b) => a >= b ? 1 : 0);


### PR DESCRIPTION
Uniformisation des types de `reduce.algo2`:
  - extraire types `DonnéesXxx` et `EntréeXxx` puis les employer dans la définition de `BatchValue`, cf https://github.com/signaux-faibles/opensignauxfaibles/pull/78#discussion_r444970708
  - renommer types de sortie de chaque fonction en `SortieXxx`, cf https://github.com/signaux-faibles/opensignauxfaibles/pull/78#discussion_r444885053

Prochaine étape: je propose de travailler sur les TODOs introduits par cette PR, et nous traiterons ensemble ceux pour lesquels je n'aurai pas trouvé de solution satisfaisante.
