### PR TITLE
fix(algo2): Passage des délais en jours

### DIFF
--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -4,6 +4,8 @@ declare function emit(key: unknown, value: unknown): void
 
 // Types partagés
 
+type ParPériode<T> = { [période: string]: T }
+
 type BatchKey = string
 
 type CodeAPE = string

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -1,4 +1,5 @@
 import * as f from "../common/generatePeriodSerie"
+import {nbDays} from "./nbDays"
 
 type DeepReadonly<T> = Readonly<T> // pas vraiment, mais espoire que TS le supporte prochainement
 
@@ -19,13 +20,6 @@ export type DelaiComputedValues = {
 }
 
 export type V = { delai: ParPériode<EntréeDelai> } // TODO: définir ce type dans global.ts ?
-
-const nbDays = (firstDate: Date, secondDate: Date): number => {
-  const oneDay = 24 * 60 * 60 * 1000 // hours*minutes*seconds*milliseconds
-  return Math.round(
-    Math.abs((firstDate.getTime() - secondDate.getTime()) / oneDay)
-  )
-}
 
 export function delais(
   v: V,

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -15,7 +15,7 @@ export type DelaiComputedValues = {
   delai_nb_jours_restants: number
   delai_nb_jours_total: number // nombre de jours entre date_creation et date_echeance
   ratio_dette_delai?: number
-  montant_echeancier: number // exprimé en euros
+  delai_montant_echeancier: number // exprimé en euros
 }
 
 export type V = { delai: ParPériode<EntréeDelai> } // TODO: définir ce type dans global.ts ?
@@ -68,7 +68,7 @@ export function delais(
         const outputAtTime: DelaiComputedValues = {
           delai_nb_jours_restants: remaining_months,
           delai_nb_jours_total: delai.duree_delai,
-          montant_echeancier: delai.montant_echeancier,
+          delai_montant_echeancier: delai.montant_echeancier,
         }
         if (
           delai.duree_delai > 0 &&

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -12,7 +12,7 @@ export type DebitComputedValues = {
 
 // Valeurs retournées par delais(), pour chaque période
 export type DelaiComputedValues = {
-  delai: number
+  delai_nb_jours_restants: number
   duree_delai: number // nombre de jours entre date_creation et date_echeance
   ratio_dette_delai?: number
   montant_echeancier: number // exprimé en euros
@@ -66,7 +66,7 @@ export function delais(
             (date_echeance.getUTCFullYear() - new Date(time).getUTCFullYear())
         const inputAtTime = donnéesActuellesParPériode[time]
         const outputAtTime: DelaiComputedValues = {
-          delai: remaining_months,
+          delai_nb_jours_restants: remaining_months,
           duree_delai: delai.duree_delai,
           montant_echeancier: delai.montant_echeancier,
         }

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -20,6 +20,13 @@ export type DelaiComputedValues = {
 
 export type V = { delai: ParPériode<EntréeDelai> } // TODO: définir ce type dans global.ts ?
 
+const nbDays = (firstDate: Date, secondDate: Date): number => {
+  const oneDay = 24 * 60 * 60 * 1000 // hours*minutes*seconds*milliseconds
+  return Math.round(
+    Math.abs((firstDate.getTime() - secondDate.getTime()) / oneDay)
+  )
+}
+
 export function delais(
   v: V,
   donnéesActuellesParPériode: DeepReadonly<ParPériode<DebitComputedValues>>
@@ -59,14 +66,11 @@ export function delais(
       })
     pastYearTimes.map(function (time: number) {
       if (time in donnéesActuellesParPériode) {
-        const remaining_months =
-          date_echeance.getUTCMonth() -
-          new Date(time).getUTCMonth() +
-          12 *
-            (date_echeance.getUTCFullYear() - new Date(time).getUTCFullYear())
+        const debutDeMois = new Date(time)
+        const remainingDays = nbDays(debutDeMois, delai.date_echeance)
         const inputAtTime = donnéesActuellesParPériode[time]
         const outputAtTime: DelaiComputedValues = {
-          delai_nb_jours_restants: remaining_months,
+          delai_nb_jours_restants: remainingDays,
           delai_nb_jours_total: delai.duree_delai,
           delai_montant_echeancier: delai.montant_echeancier,
         }
@@ -78,8 +82,7 @@ export function delais(
           outputAtTime.delai_deviation_remboursement =
             (inputAtTime.montant_part_patronale +
               inputAtTime.montant_part_ouvriere -
-              (delai.montant_echeancier * remaining_months * 30) /
-                delai.duree_delai) /
+              (delai.montant_echeancier * remainingDays) / delai.duree_delai) /
             delai.montant_echeancier
         }
         donnéesSupplémentairesParPériode[time] = outputAtTime

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -14,7 +14,7 @@ export type DebitComputedValues = {
 export type DelaiComputedValues = {
   delai_nb_jours_restants: number
   delai_nb_jours_total: number // nombre de jours entre date_creation et date_echeance
-  ratio_dette_delai?: number
+  delai_deviation_remboursement?: number
   delai_montant_echeancier: number // exprimé en euros
 }
 
@@ -75,7 +75,7 @@ export function delais(
           inputAtTime.montant_part_patronale !== undefined &&
           inputAtTime.montant_part_ouvriere !== undefined
         ) {
-          outputAtTime.ratio_dette_delai =
+          outputAtTime.delai_deviation_remboursement =
             (inputAtTime.montant_part_patronale +
               inputAtTime.montant_part_ouvriere -
               (delai.montant_echeancier * remaining_months * 30) /

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -1,5 +1,5 @@
 import * as f from "../common/generatePeriodSerie"
-import {nbDays} from "./nbDays"
+import { nbDays } from "./nbDays"
 
 type DeepReadonly<T> = Readonly<T> // pas vraiment, mais espoire que TS le supporte prochainement
 

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -79,10 +79,13 @@ export function delais(
           inputAtTime.montant_part_patronale !== undefined &&
           inputAtTime.montant_part_ouvriere !== undefined
         ) {
+          const detteActuelle =
+            inputAtTime.montant_part_patronale +
+            inputAtTime.montant_part_ouvriere
+          const detteHypothétiqueRemboursementLinéaire =
+            (delai.montant_echeancier * remainingDays) / delai.duree_delai
           outputAtTime.delai_deviation_remboursement =
-            (inputAtTime.montant_part_patronale +
-              inputAtTime.montant_part_ouvriere -
-              (delai.montant_echeancier * remainingDays) / delai.duree_delai) /
+            (detteActuelle - detteHypothétiqueRemboursementLinéaire) /
             delai.montant_echeancier
         }
         donnéesSupplémentairesParPériode[time] = outputAtTime

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -19,10 +19,8 @@ export type DelaiComputedValues = {
   delai_montant_echeancier: number // exprimé en euros
 }
 
-export type V = { delai: ParPériode<EntréeDelai> } // TODO: définir ce type dans global.ts ?
-
 export function delais(
-  v: V,
+  v: DonnéesDelai,
   donnéesActuellesParPériode: DeepReadonly<ParPériode<DebitComputedValues>>
 ): ParPériode<DelaiComputedValues> {
   "use strict"

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -3,8 +3,6 @@ import { nbDays } from "./nbDays"
 
 type DeepReadonly<T> = Readonly<T> // pas vraiment, mais espoire que TS le supporte prochainement
 
-export type ParPériode<T> = { [période: string]: T }
-
 // Valeurs attendues pour chaque période, lors de l'appel à delais()
 export type DebitComputedValues = {
   montant_part_patronale?: number
@@ -21,7 +19,7 @@ export type DelaiComputedValues = {
 
 export function delais(
   v: DonnéesDelai,
-  donnéesActuellesParPériode: DeepReadonly<ParPériode<DebitComputedValues>>
+  debitParPériode: DeepReadonly<ParPériode<DebitComputedValues>>
 ): ParPériode<DelaiComputedValues> {
   "use strict"
   const donnéesSupplémentairesParPériode: ParPériode<DelaiComputedValues> = {}
@@ -57,10 +55,10 @@ export function delais(
         return date.getTime()
       })
     pastYearTimes.map(function (time: number) {
-      if (time in donnéesActuellesParPériode) {
+      if (time in debitParPériode) {
         const debutDeMois = new Date(time)
         const remainingDays = nbDays(debutDeMois, delai.date_echeance)
-        const inputAtTime = donnéesActuellesParPériode[time]
+        const inputAtTime = debitParPériode[time]
         const outputAtTime: DelaiComputedValues = {
           delai_nb_jours_restants: remainingDays,
           delai_nb_jours_total: delai.duree_delai,

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -13,7 +13,7 @@ export type DebitComputedValues = {
 // Valeurs retournées par delais(), pour chaque période
 export type DelaiComputedValues = {
   delai_nb_jours_restants: number
-  duree_delai: number // nombre de jours entre date_creation et date_echeance
+  delai_nb_jours_total: number // nombre de jours entre date_creation et date_echeance
   ratio_dette_delai?: number
   montant_echeancier: number // exprimé en euros
 }
@@ -67,7 +67,7 @@ export function delais(
         const inputAtTime = donnéesActuellesParPériode[time]
         const outputAtTime: DelaiComputedValues = {
           delai_nb_jours_restants: remaining_months,
-          duree_delai: delai.duree_delai,
+          delai_nb_jours_total: delai.duree_delai,
           montant_echeancier: delai.montant_echeancier,
         }
         if (

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -45,10 +45,10 @@ const testProperty = (
   return delais({ delai: delaiMap }, output_indexed)
 }
 
-test("la propriété delai représente le nombre de mois complets restants du délai", (t) => {
+test("la propriété delai_nb_jours_restants représente le nombre de jours restants du délai", (t) => {
   const output_indexed = testProperty()
-  t.is(output_indexed[fevrier.getTime()]["delai"], 2)
-  t.is(output_indexed[mars.getTime()]["delai"], 1)
+  t.is(output_indexed[fevrier.getTime()]["delai_nb_jours_restants"], 2)
+  t.is(output_indexed[mars.getTime()]["delai_nb_jours_restants"], 1)
 })
 
 test("la propriété duree_delai représente la durée totale en jours du délai", (t) => {

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -1,12 +1,7 @@
 import test, { ExecutionContext } from "ava" // TODO: résoudre erreur dans ide
 import { nbDays } from "./nbDays"
 import "../globals"
-import {
-  delais,
-  DelaiComputedValues,
-  DebitComputedValues,
-  ParPériode,
-} from "./delais"
+import { delais, DelaiComputedValues, DebitComputedValues } from "./delais"
 
 const fevrier = new Date("2014-02-01")
 const mars = new Date("2014-03-01")

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -1,5 +1,5 @@
-import test, {ExecutionContext} from "ava" // TODO: résoudre erreur dans ide
-import {nbDays} from "./nbDays"
+import test, { ExecutionContext } from "ava" // TODO: résoudre erreur dans ide
+import { nbDays } from "./nbDays"
 import "../globals"
 import {
   delais,

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -65,49 +65,46 @@ test("la propriété delai_montant_echeancier représente le montant en euros de
   t.is(output_indexed[mars.getTime()]["delai_montant_echeancier"], 1000)
 })
 
-test("la propriété delai_deviation_remboursement représente:\n" +
-     "(dette actuelle - dette hypothétique en cas de remboursement linéaire) / dette initiale\n" +
-     "Elle représente la déviation par rapport à un remboursement linéaire de la dette " +
-     "en pourcentage de la dette initialement dû", (t) => {
-  const expectedFebruary = -0.052
-  const expectedMarch = 0.273
-  const debits = { montant_part_patronale: 600, montant_part_ouvriere: 0 }
-  const output_indexed = testProperty(debits)
-  const tolerance = 10e-3
-  const ratioFebruary = output_indexed[fevrier.getTime()]["delai_deviation_remboursement"]
-  const ratioMarch = output_indexed[mars.getTime()]["delai_deviation_remboursement"]
-  t.is(typeof ratioFebruary, "number")
-  t.is(typeof ratioMarch, "number")
-  if (typeof ratioFebruary === "number") {
-    t.true(Math.abs(ratioFebruary - expectedFebruary) < tolerance)
+test(
+  "la propriété delai_deviation_remboursement représente:\n" +
+    "(dette actuelle - dette hypothétique en cas de remboursement linéaire) / dette initiale\n" +
+    "Elle représente la déviation par rapport à un remboursement linéaire de la dette " +
+    "en pourcentage de la dette initialement dû",
+  (t) => {
+    const expectedFebruary = -0.052
+    const expectedMarch = 0.273
+    const debits = { montant_part_patronale: 600, montant_part_ouvriere: 0 }
+    const output_indexed = testProperty(debits)
+    const tolerance = 10e-3
+    const ratioFebruary =
+      output_indexed[fevrier.getTime()]["delai_deviation_remboursement"]
+    const ratioMarch =
+      output_indexed[mars.getTime()]["delai_deviation_remboursement"]
+    t.is(typeof ratioFebruary, "number")
+    t.is(typeof ratioMarch, "number")
+    if (typeof ratioFebruary === "number") {
+      t.true(Math.abs(ratioFebruary - expectedFebruary) < tolerance)
+    }
+    if (typeof ratioMarch === "number") {
+      t.true(Math.abs(ratioMarch - expectedMarch) < tolerance)
+    }
   }
-  if (typeof ratioMarch === "number") {
-    t.true(Math.abs(ratioMarch - expectedMarch) < tolerance)
-  }
-})
+)
 
 test("la propriété delai_deviation_remboursement n'est pas créée si la durée du délai est nulle", (t) => {
-  const expectedFebruary = -0.052
-  const expectedMarch = 0.273
   // const debits = { montant_part_patronale: 600, montant_part_ouvriere: 0 }
-  const delaiTest = makeDelai(new Date("2014-01-03"), new Date("2014-01-03"))
+  const delaiTest = makeDelai(new Date("2014-02-03"), new Date("2014-02-03"))
   const delaiMap: ParPériode<EntréeDelai> = {
     abc: delaiTest,
   }
-  let output_indexed: ParPériode<DelaiComputedValues> = {}
-  // output_indexed[fevrier.getTime()] = debits ? makeOutputIndexed(debits) : {}
-  output_indexed = delais({ delai: delaiMap }, output_indexed)
-  const tolerance = 10e-3
-  const ratioFebruary = output_indexed[fevrier.getTime()]["delai_deviation_remboursement"]
-  const ratioMarch = output_indexed[mars.getTime()]["delai_deviation_remboursement"]
-  t.is(typeof ratioFebruary, "number")
-  t.is(typeof ratioMarch, "number")
-  if (typeof ratioFebruary === "number") {
-    t.true(Math.abs(ratioFebruary - expectedFebruary) < tolerance)
+  const input_indexed: ParPériode<DebitComputedValues> = {
+    [fevrier.getTime()]: {},
   }
-  if (typeof ratioMarch === "number") {
-    t.true(Math.abs(ratioMarch - expectedMarch) < tolerance)
-  }
+  const output_indexed = delais({ delai: delaiMap }, input_indexed)
+  t.is(Object.keys(output_indexed).length, 1)
+  const ratioFebruary =
+    output_indexed[fevrier.getTime()]["delai_deviation_remboursement"]
+  t.is(typeof ratioFebruary, "undefined")
 })
 
 test("un délai en dehors de la période d'intérêt est ignorée", (t) => {

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -48,8 +48,14 @@ const testProperty = (
 
 test("la propriété delai_nb_jours_restants représente le nombre de jours restants du délai", (t) => {
   const output_indexed = testProperty()
-  t.is(output_indexed[fevrier.getTime()]["delai_nb_jours_restants"], 2)
-  t.is(output_indexed[mars.getTime()]["delai_nb_jours_restants"], 1)
+  t.is(
+    output_indexed[fevrier.getTime()]["delai_nb_jours_restants"],
+    nbDays(new Date("2014-02-01"), new Date("2014-04-05"))
+  )
+  t.is(
+    output_indexed[mars.getTime()]["delai_nb_jours_restants"],
+    nbDays(new Date("2014-03-01"), new Date("2014-04-05"))
+  )
 })
 
 test("la propriété delai_nb_jours_total représente la durée totale en jours du délai", (t) => {
@@ -71,8 +77,8 @@ test(
     "Elle représente la déviation par rapport à un remboursement linéaire de la dette " +
     "en pourcentage de la dette initialement dû",
   (t) => {
-    const expectedFebruary = -0.052
-    const expectedMarch = 0.273
+    const expectedFebruary = -0.0848
+    const expectedMarch = 0.22
     const debits = { montant_part_patronale: 600, montant_part_ouvriere: 0 }
     const output_indexed = testProperty(debits)
     const tolerance = 10e-3

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -51,11 +51,11 @@ test("la propriété delai_nb_jours_restants représente le nombre de jours rest
   t.is(output_indexed[mars.getTime()]["delai_nb_jours_restants"], 1)
 })
 
-test("la propriété duree_delai représente la durée totale en jours du délai", (t) => {
+test("la propriété delai_nb_jours_total représente la durée totale en jours du délai", (t) => {
   const dureeEnJours = nbDays(new Date("2014-01-03"), new Date("2014-04-05"))
   const output_indexed = testProperty()
-  t.is(output_indexed[fevrier.getTime()]["duree_delai"], dureeEnJours)
-  t.is(output_indexed[mars.getTime()]["duree_delai"], dureeEnJours)
+  t.is(output_indexed[fevrier.getTime()]["delai_nb_jours_total"], dureeEnJours)
+  t.is(output_indexed[mars.getTime()]["delai_nb_jours_total"], dureeEnJours)
 })
 
 test("la propriété montant_echeancier représente le montant en euros des cotisations sociales couvertes par le délai", (t) => {

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -1,4 +1,5 @@
-import test from "ava"
+import test, {ExecutionContext} from "ava" // TODO: résoudre erreur dans ide
+import {nbDays} from "./nbDays"
 import "../globals"
 import {
   delais,
@@ -9,13 +10,6 @@ import {
 
 const fevrier = new Date("2014-02-01")
 const mars = new Date("2014-03-01")
-
-const nbDays = (firstDate: Date, secondDate: Date): number => {
-  const oneDay = 24 * 60 * 60 * 1000 // hours*minutes*seconds*milliseconds
-  return Math.round(
-    Math.abs((firstDate.getTime() - secondDate.getTime()) / oneDay)
-  )
-}
 
 const makeDelai = (firstDate: Date, secondDate: Date): EntréeDelai => ({
   date_creation: firstDate,
@@ -46,7 +40,7 @@ const testProperty = (
   return delais({ delai: delaiMap }, output_indexed)
 }
 
-test("la propriété delai_nb_jours_restants représente le nombre de jours restants du délai", (t) => {
+test("la propriété delai_nb_jours_restants représente le nombre de jours restants du délai", (t: ExecutionContext) => {
   const output_indexed = testProperty()
   t.is(
     output_indexed[fevrier.getTime()]["delai_nb_jours_restants"],
@@ -58,14 +52,14 @@ test("la propriété delai_nb_jours_restants représente le nombre de jours rest
   )
 })
 
-test("la propriété delai_nb_jours_total représente la durée totale en jours du délai", (t) => {
+test("la propriété delai_nb_jours_total représente la durée totale en jours du délai", (t: ExecutionContext) => {
   const dureeEnJours = nbDays(new Date("2014-01-03"), new Date("2014-04-05"))
   const output_indexed = testProperty()
   t.is(output_indexed[fevrier.getTime()]["delai_nb_jours_total"], dureeEnJours)
   t.is(output_indexed[mars.getTime()]["delai_nb_jours_total"], dureeEnJours)
 })
 
-test("la propriété delai_montant_echeancier représente le montant en euros des cotisations sociales couvertes par le délai", (t) => {
+test("la propriété delai_montant_echeancier représente le montant en euros des cotisations sociales couvertes par le délai", (t: ExecutionContext) => {
   const output_indexed = testProperty()
   t.is(output_indexed[fevrier.getTime()]["delai_montant_echeancier"], 1000)
   t.is(output_indexed[mars.getTime()]["delai_montant_echeancier"], 1000)
@@ -76,7 +70,7 @@ test(
     "(dette actuelle - dette hypothétique en cas de remboursement linéaire) / dette initiale\n" +
     "Elle représente la déviation par rapport à un remboursement linéaire de la dette " +
     "en pourcentage de la dette initialement dû",
-  (t) => {
+  (t: ExecutionContext) => {
     const expectedFebruary = -0.0848
     const expectedMarch = 0.22
     const debits = { montant_part_patronale: 600, montant_part_ouvriere: 0 }
@@ -97,7 +91,7 @@ test(
   }
 )
 
-test("un délai en dehors de la période d'intérêt est ignorée", (t) => {
+test("un délai en dehors de la période d'intérêt est ignorée", (t: ExecutionContext) => {
   const delaiTest = makeDelai(new Date("2013-01-03"), new Date("2013-03-05"))
   const delaiMap: ParPériode<EntréeDelai> = {
     abc: delaiTest,

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -91,22 +91,6 @@ test(
   }
 )
 
-test("la propriété delai_deviation_remboursement n'est pas créée si la durée du délai est nulle", (t) => {
-  // const debits = { montant_part_patronale: 600, montant_part_ouvriere: 0 }
-  const delaiTest = makeDelai(new Date("2014-02-03"), new Date("2014-02-03"))
-  const delaiMap: ParPériode<EntréeDelai> = {
-    abc: delaiTest,
-  }
-  const input_indexed: ParPériode<DebitComputedValues> = {
-    [fevrier.getTime()]: {},
-  }
-  const output_indexed = delais({ delai: delaiMap }, input_indexed)
-  t.is(Object.keys(output_indexed).length, 1)
-  const ratioFebruary =
-    output_indexed[fevrier.getTime()]["delai_deviation_remboursement"]
-  t.is(typeof ratioFebruary, "undefined")
-})
-
 test("un délai en dehors de la période d'intérêt est ignorée", (t) => {
   const delaiTest = makeDelai(new Date("2013-01-03"), new Date("2013-03-05"))
   const delaiMap: ParPériode<EntréeDelai> = {
@@ -117,5 +101,3 @@ test("un délai en dehors de la période d'intérêt est ignorée", (t) => {
   const périodesComplétées = delais({ delai: delaiMap }, donnéesParPériode)
   t.deepEqual(périodesComplétées, {})
 })
-
-// TODO: ajouter des tests sur les cas limites: denominateurs nuls dans calcul de delai_deviation_remboursement

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -94,5 +94,4 @@ test("un délai en dehors de la période d'intérêt est ignorée", (t) => {
   t.deepEqual(périodesComplétées, {})
 })
 
-// TODO: ajouter des tests sur les autres propriétés retournées
-// TODO: ajouter des tests sur les cas limites => table-based testing
+// TODO: ajouter des tests sur les cas limites: denominateurs nuls dans calcul de ratio_dette_delai

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -64,15 +64,17 @@ test("la propriété delai_montant_echeancier représente le montant en euros de
   t.is(output_indexed[mars.getTime()]["delai_montant_echeancier"], 1000)
 })
 
-test("la propriété ratio_dette_delai représente la déviation du remboursement de la dette par rapport à un remboursement linéaire sur la durée du délai", (t) => {
-  // TODO: Inclure la formule dans la documentation de ce test
+test("la propriété delai_deviation_remboursement représente:\n" +
+     "(dette actuelle - dette hypothétique en cas de remboursement linéaire) / dette initiale\n" +
+     "Elle représente la déviation par rapport à un remboursement linéaire de la dette " +
+     "en pourcentage de la dette initialement dû", (t) => {
   const expectedFebruary = -0.052
   const expectedMarch = 0.273
   const debits = { montant_part_patronale: 600, montant_part_ouvriere: 0 }
   const output_indexed = testProperty(debits)
   const tolerance = 10e-3
-  const ratioFebruary = output_indexed[fevrier.getTime()]["ratio_dette_delai"]
-  const ratioMarch = output_indexed[mars.getTime()]["ratio_dette_delai"]
+  const ratioFebruary = output_indexed[fevrier.getTime()]["delai_deviation_remboursement"]
+  const ratioMarch = output_indexed[mars.getTime()]["delai_deviation_remboursement"]
   t.is(typeof ratioFebruary, "number")
   t.is(typeof ratioMarch, "number")
   if (typeof ratioFebruary === "number") {
@@ -94,4 +96,4 @@ test("un délai en dehors de la période d'intérêt est ignorée", (t) => {
   t.deepEqual(périodesComplétées, {})
 })
 
-// TODO: ajouter des tests sur les cas limites: denominateurs nuls dans calcul de ratio_dette_delai
+// TODO: ajouter des tests sur les cas limites: denominateurs nuls dans calcul de delai_deviation_remboursement

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -18,7 +18,7 @@ const makeDelai = (firstDate: Date, secondDate: Date): EntréeDelai => ({
   montant_echeancier: 1000,
 })
 
-const makeOutputIndexed = ({
+const makeDebitParPériode = ({
   montant_part_patronale = 0,
   montant_part_ouvriere = 0,
 } = {}): DebitComputedValues => ({
@@ -26,43 +26,42 @@ const makeOutputIndexed = ({
   montant_part_ouvriere,
 })
 
-// TODO: renommer cette fonction
-const testProperty = (
+const runDelais = (
   debits?: DebitComputedValues
 ): ParPériode<DelaiComputedValues> => {
   const delaiTest = makeDelai(new Date("2014-01-03"), new Date("2014-04-05"))
   const delaiMap: ParPériode<EntréeDelai> = {
     abc: delaiTest,
   }
-  const output_indexed: ParPériode<DebitComputedValues> = {}
-  output_indexed[fevrier.getTime()] = debits ? makeOutputIndexed(debits) : {}
-  output_indexed[mars.getTime()] = debits ? makeOutputIndexed(debits) : {}
-  return delais({ delai: delaiMap }, output_indexed)
+  const debitParPériode: ParPériode<DebitComputedValues> = {}
+  debitParPériode[fevrier.getTime()] = debits ? makeDebitParPériode(debits) : {}
+  debitParPériode[mars.getTime()] = debits ? makeDebitParPériode(debits) : {}
+  return delais({ delai: delaiMap }, debitParPériode)
 }
 
 test("la propriété delai_nb_jours_restants représente le nombre de jours restants du délai", (t: ExecutionContext) => {
-  const output_indexed = testProperty()
+  const outputDelai = runDelais()
   t.is(
-    output_indexed[fevrier.getTime()]["delai_nb_jours_restants"],
+    outputDelai[fevrier.getTime()]["delai_nb_jours_restants"],
     nbDays(new Date("2014-02-01"), new Date("2014-04-05"))
   )
   t.is(
-    output_indexed[mars.getTime()]["delai_nb_jours_restants"],
+    outputDelai[mars.getTime()]["delai_nb_jours_restants"],
     nbDays(new Date("2014-03-01"), new Date("2014-04-05"))
   )
 })
 
 test("la propriété delai_nb_jours_total représente la durée totale en jours du délai", (t: ExecutionContext) => {
   const dureeEnJours = nbDays(new Date("2014-01-03"), new Date("2014-04-05"))
-  const output_indexed = testProperty()
-  t.is(output_indexed[fevrier.getTime()]["delai_nb_jours_total"], dureeEnJours)
-  t.is(output_indexed[mars.getTime()]["delai_nb_jours_total"], dureeEnJours)
+  const outputDelai = runDelais()
+  t.is(outputDelai[fevrier.getTime()]["delai_nb_jours_total"], dureeEnJours)
+  t.is(outputDelai[mars.getTime()]["delai_nb_jours_total"], dureeEnJours)
 })
 
 test("la propriété delai_montant_echeancier représente le montant en euros des cotisations sociales couvertes par le délai", (t: ExecutionContext) => {
-  const output_indexed = testProperty()
-  t.is(output_indexed[fevrier.getTime()]["delai_montant_echeancier"], 1000)
-  t.is(output_indexed[mars.getTime()]["delai_montant_echeancier"], 1000)
+  const outputDelai = runDelais()
+  t.is(outputDelai[fevrier.getTime()]["delai_montant_echeancier"], 1000)
+  t.is(outputDelai[mars.getTime()]["delai_montant_echeancier"], 1000)
 })
 
 test(
@@ -74,12 +73,12 @@ test(
     const expectedFebruary = -0.0848
     const expectedMarch = 0.22
     const debits = { montant_part_patronale: 600, montant_part_ouvriere: 0 }
-    const output_indexed = testProperty(debits)
+    const outputDelai = runDelais(debits)
     const tolerance = 10e-3
     const ratioFebruary =
-      output_indexed[fevrier.getTime()]["delai_deviation_remboursement"]
+      outputDelai[fevrier.getTime()]["delai_deviation_remboursement"]
     const ratioMarch =
-      output_indexed[mars.getTime()]["delai_deviation_remboursement"]
+      outputDelai[mars.getTime()]["delai_deviation_remboursement"]
     t.is(typeof ratioFebruary, "number")
     t.is(typeof ratioMarch, "number")
     if (typeof ratioFebruary === "number") {
@@ -97,7 +96,7 @@ test("un délai en dehors de la période d'intérêt est ignorée", (t: Executio
     abc: delaiTest,
   }
   const donnéesParPériode: ParPériode<DebitComputedValues> = {}
-  donnéesParPériode[fevrier.getTime()] = makeOutputIndexed()
+  donnéesParPériode[fevrier.getTime()] = makeDebitParPériode()
   const périodesComplétées = delais({ delai: delaiMap }, donnéesParPériode)
   t.deepEqual(périodesComplétées, {})
 })

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -58,10 +58,10 @@ test("la propriété delai_nb_jours_total représente la durée totale en jours 
   t.is(output_indexed[mars.getTime()]["delai_nb_jours_total"], dureeEnJours)
 })
 
-test("la propriété montant_echeancier représente le montant en euros des cotisations sociales couvertes par le délai", (t) => {
+test("la propriété delai_montant_echeancier représente le montant en euros des cotisations sociales couvertes par le délai", (t) => {
   const output_indexed = testProperty()
-  t.is(output_indexed[fevrier.getTime()]["montant_echeancier"], 1000)
-  t.is(output_indexed[mars.getTime()]["montant_echeancier"], 1000)
+  t.is(output_indexed[fevrier.getTime()]["delai_montant_echeancier"], 1000)
+  t.is(output_indexed[mars.getTime()]["delai_montant_echeancier"], 1000)
 })
 
 test("la propriété ratio_dette_delai représente la déviation du remboursement de la dette par rapport à un remboursement linéaire sur la durée du délai", (t) => {

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -32,6 +32,7 @@ const makeOutputIndexed = ({
   montant_part_ouvriere,
 })
 
+// TODO: renommer cette fonction
 const testProperty = (
   debits?: DebitComputedValues
 ): ParPériode<DelaiComputedValues> => {
@@ -72,6 +73,30 @@ test("la propriété delai_deviation_remboursement représente:\n" +
   const expectedMarch = 0.273
   const debits = { montant_part_patronale: 600, montant_part_ouvriere: 0 }
   const output_indexed = testProperty(debits)
+  const tolerance = 10e-3
+  const ratioFebruary = output_indexed[fevrier.getTime()]["delai_deviation_remboursement"]
+  const ratioMarch = output_indexed[mars.getTime()]["delai_deviation_remboursement"]
+  t.is(typeof ratioFebruary, "number")
+  t.is(typeof ratioMarch, "number")
+  if (typeof ratioFebruary === "number") {
+    t.true(Math.abs(ratioFebruary - expectedFebruary) < tolerance)
+  }
+  if (typeof ratioMarch === "number") {
+    t.true(Math.abs(ratioMarch - expectedMarch) < tolerance)
+  }
+})
+
+test("la propriété delai_deviation_remboursement n'est pas créée si la durée du délai est nulle", (t) => {
+  const expectedFebruary = -0.052
+  const expectedMarch = 0.273
+  // const debits = { montant_part_patronale: 600, montant_part_ouvriere: 0 }
+  const delaiTest = makeDelai(new Date("2014-01-03"), new Date("2014-01-03"))
+  const delaiMap: ParPériode<EntréeDelai> = {
+    abc: delaiTest,
+  }
+  let output_indexed: ParPériode<DelaiComputedValues> = {}
+  // output_indexed[fevrier.getTime()] = debits ? makeOutputIndexed(debits) : {}
+  output_indexed = delais({ delai: delaiMap }, output_indexed)
   const tolerance = 10e-3
   const ratioFebruary = output_indexed[fevrier.getTime()]["delai_deviation_remboursement"]
   const ratioMarch = output_indexed[mars.getTime()]["delai_deviation_remboursement"]

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -7,7 +7,7 @@ import { effectifs } from "./effectifs"
 import { interim } from "./interim"
 import { add } from "./add"
 import { repeatable } from "./repeatable"
-import { delais, V as DelaisV } from "./delais"
+import { delais } from "./delais"
 import { defaillances } from "./defaillances"
 import { cotisationsdettes } from "./cotisationsdettes"
 import { ccsf } from "./ccsf"
@@ -120,7 +120,7 @@ export function map(this: {
       }
 
       if (v.delai) {
-        const output_delai = f.delais(v as DelaisV, output_indexed)
+        const output_delai = f.delais(v as DonnéesDelai, output_indexed)
         f.add(output_delai, output_indexed)
       }
 

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -7,7 +7,7 @@ import { effectifs } from "./effectifs"
 import { interim } from "./interim"
 import { add } from "./add"
 import { repeatable } from "./repeatable"
-import { delais } from "./delais"
+import { delais, DebitComputedValues } from "./delais"
 import { defaillances } from "./defaillances"
 import { cotisationsdettes } from "./cotisationsdettes"
 import { ccsf } from "./ccsf"
@@ -120,7 +120,10 @@ export function map(this: {
       }
 
       if (v.delai) {
-        const output_delai = f.delais(v as DonnéesDelai, output_indexed)
+        const output_delai = f.delais(
+          v as DonnéesDelai,
+          output_indexed as ParPériode<DebitComputedValues> // TODO: vérifier que les données débit sont déjà calculées
+        )
         f.add(output_delai, output_indexed)
       }
 

--- a/dbmongo/js/reduce.algo2/nbDays.ts
+++ b/dbmongo/js/reduce.algo2/nbDays.ts
@@ -1,0 +1,6 @@
+export const nbDays = (firstDate: Date, secondDate: Date): number => {
+  const oneDay = 24 * 60 * 60 * 1000 // hours*minutes*seconds*milliseconds
+  return Math.round(
+    Math.abs((firstDate.getTime() - secondDate.getTime()) / oneDay)
+  )
+}

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1827,7 +1827,8 @@ function map() {
                 f.add(output_repeatable, output_indexed);
             }
             if (v.delai) {
-                const output_delai = f.delais(v, output_indexed);
+                const output_delai = f.delais(v, output_indexed // TODO: vérifier que les données débit sont déjà calculées
+                );
                 f.add(output_delai, output_indexed);
             }
             v.altares = v.altares || {};

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1427,7 +1427,7 @@ db.getCollection("Features").createIndex({
     f.dealWithProcols(v.altares, "altares", output_indexed);
     f.dealWithProcols(v.procol, "procol", output_indexed);
 }`,
-"delais": `function delais(v, donnéesActuellesParPériode) {
+"delais": `function delais(v, debitParPériode) {
     "use strict";
     const donnéesSupplémentairesParPériode = {};
     Object.keys(v.delai).map(function (hash) {
@@ -1442,10 +1442,10 @@ db.getCollection("Features").createIndex({
             return date.getTime();
         });
         pastYearTimes.map(function (time) {
-            if (time in donnéesActuellesParPériode) {
+            if (time in debitParPériode) {
                 const debutDeMois = new Date(time);
                 const remainingDays = nbDays(debutDeMois, delai.date_echeance);
-                const inputAtTime = donnéesActuellesParPériode[time];
+                const inputAtTime = debitParPériode[time];
                 const outputAtTime = {
                     delai_nb_jours_restants: remainingDays,
                     delai_nb_jours_total: delai.duree_delai,


### PR DESCRIPTION
Effectué en pair coding avec @JazzyPierrot.

Propriétés renommées, en sortie d'algo2:

- `delai` --> `delai_nb_jours_restants`
- `duree_delai` --> `delai_nb_jours_total`
- `ratio_dette_delai` --> `delai_deviation_remboursement`
- `montant_echeancier` --> `delai_montant_echeancier`

=> Décision: nous allons désormais préfixer toutes les propriétés calculées à l'aide du nom de la fonction qui les a calculées.

Prochaines étapes: indiquées par des TODO dans le code + des commentaires sur le PR.