### PR TITLE
fix(TS): Erreur d'importation de Ava rapportée par IDE

### DIFF
--- a/dbmongo/js/tsconfig.json
+++ b/dbmongo/js/tsconfig.json
@@ -45,7 +45,7 @@
     "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */


### PR DESCRIPTION
Problème: nos éditeurs de code (nvim et vscode) rapportaient une erreur d'importation à la ligne `import test from "ava"` présente dans tous nos tests.

Solution: dire à TypeScript que ce genre d'importations sont des modules Node.js, pour qu'il puisse trouver les types associés dans `node_modules`.
