### PR TITLE
fix(compact): Renommage paramètre batch / batchKey --> fromBatchKey

### DIFF
--- a/dbmongo/data.go
+++ b/dbmongo/data.go
@@ -78,14 +78,14 @@ func publicHandler(c *gin.Context) {
 
 func compactHandler(c *gin.Context) {
 	var params struct {
-		BatchKey string `json:"batch"`
+		FromBatchKey string `json:"fromBatchKey"`
 	}
 	err := c.ShouldBind(&params)
 	if err != nil {
 		c.JSON(400, err.Error())
 	}
 
-	err = engine.Compact(params.BatchKey)
+	err = engine.Compact(params.FromBatchKey)
 	if err != nil {
 		c.JSON(500, err.Error())
 		return

--- a/dbmongo/js/compact/ava_tests.ts
+++ b/dbmongo/js/compact/ava_tests.ts
@@ -36,13 +36,13 @@ const runMongoMap = (
 // test data inspired by test-api.sh
 const siret: SiretOrSiren = "01234567891011"
 const scope: Scope = "etablissement"
-const batchKey = "1910"
+const fromBatchKey = "1910"
 const dates = [
   ISODate("2015-12-01T00:00:00.000+0000"),
   ISODate("2016-01-01T00:00:00.000+0000"),
 ]
 const batch: BatchValues = {
-  [batchKey]: {},
+  [fromBatchKey]: {},
 }
 
 const importedData = {
@@ -70,7 +70,7 @@ const expectedReduceResults = {
 
 const expectedFinalizeResultValue = {
   batch: {
-    [batchKey]: {
+    [fromBatchKey]: {
       reporder: dates.reduce(
         (reporder, date) => ({
           ...reporder,
@@ -110,7 +110,7 @@ test.serial(
     const global = globalThis as any // eslint-disable-line @typescript-eslint/no-explicit-any
     global.serie_periode = dates // used by complete_reporder(), which is called by finalize()
     const finalizeResult = finalize(siret, expectedReduceResults)
-    const { reporder } = finalizeResult.batch[batchKey]
+    const { reporder } = finalizeResult.batch[fromBatchKey]
     t.is(typeof reporder, "object")
     // reporder contient une propriété par periode
     t.is(Object.keys(reporder || {}).length, dates.length)

--- a/dbmongo/js/compact/compactBatch.ts
+++ b/dbmongo/js/compact/compactBatch.ts
@@ -17,10 +17,10 @@ declare const completeTypes: Record<BatchKey, DataType[]>
 export function compactBatch(
   currentBatch: BatchValue,
   memory: CurrentDataState,
-  batchKey: string
+  fromBatchKey: string
 ): BatchValue {
   // Les types où il y a potentiellement des suppressions
-  const stockTypes = completeTypes[batchKey].filter(
+  const stockTypes = completeTypes[fromBatchKey].filter(
     (type) => (memory[type] || new Set()).size > 0
   )
 

--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -4,7 +4,7 @@ import * as f from "./currentState"
 
 // Paramètres globaux utilisés par "compact"
 declare const batches: BatchKey[]
-declare const batchKey: BatchKey
+declare const fromBatchKey: BatchKey
 
 // Entrée: données d'entreprises venant de ImportedData, regroupées par entreprise ou établissement.
 // Sortie: un objet fusionné par entreprise ou établissement, contenant les données historiques et les données importées, à destination de la collection RawData.
@@ -58,14 +58,14 @@ export function reduce(
   const memoryBatches: BatchValue[] = Object.keys(
     naivelyMergedCompanyData.batch
   )
-    .filter((batch) => batch < batchKey)
+    .filter((batch) => batch < fromBatchKey)
     .sort()
     .reduce((m: BatchValue[], batch: string) => {
       m.push(naivelyMergedCompanyData.batch[batch])
       return m
     }, [])
 
-  // Memory conserve les données aplaties de tous les batches jusqu'à batchKey
+  // Memory conserve les données aplaties de tous les batches jusqu'à fromBatchKey
   // puis sera enrichie au fur et à mesure du traitement des batches suivants.
   const memory = f.currentState(memoryBatches)
 
@@ -75,18 +75,18 @@ export function reduce(
     batch: {},
   }
 
-  // Copie telle quelle des batches jusqu'à batchKey.
+  // Copie telle quelle des batches jusqu'à fromBatchKey.
   Object.keys(naivelyMergedCompanyData.batch)
-    .filter((batch) => batch < batchKey)
+    .filter((batch) => batch < fromBatchKey)
     .forEach((batch) => {
       reducedValue.batch[batch] = naivelyMergedCompanyData.batch[batch]
     })
 
-  // On itère sur chaque batch à partir de batchKey pour les compacter.
+  // On itère sur chaque batch à partir de fromBatchKey pour les compacter.
   // Il est possible qu'il y ait moins de batch en sortie que le nombre traité
   // dans la boucle, si ces batchs n'apportent aucune information nouvelle.
   batches
-    .filter((batch) => batch >= batchKey)
+    .filter((batch) => batch >= fromBatchKey)
     .forEach((batch) => {
       const currentBatch = naivelyMergedCompanyData.batch[batch]
       const compactedBatch = compactBatch(currentBatch, memory, batch)

--- a/dbmongo/js/compact/reduce_test.js
+++ b/dbmongo/js/compact/reduce_test.js
@@ -5,7 +5,7 @@ const test_cases = [
     ////////////////////////////////////////////////////////
     test_case_name: "Exemple1: complete type deletion",
     completeTypes: { "1902": ["apconso"] },
-    batchKey: "1902",
+    fromBatchKey: "1902",
     types: "",
     batches: ["1901", "1902"],
     reduce_key: "123",
@@ -69,7 +69,7 @@ const test_cases = [
     ////////////////////////////////////////////////////////
     test_case_name: "Exemple2: order independence",
     completeTypes: { "1902": ["apconso"] },
-    batchKey: "1902",
+    fromBatchKey: "1902",
     types: "",
     batches: ["1901", "1902"],
     reduce_key: "123",
@@ -136,7 +136,7 @@ const test_cases = [
       "1901": ["apconso"],
       "1902": ["apconso"],
     },
-    batchKey: "1901",
+    fromBatchKey: "1901",
     types: "",
     batches: ["1812", "1901", "1902"],
     reduce_key: "123",
@@ -223,7 +223,7 @@ const test_cases = [
     ////////////////////////////////////////////////////////
     test_case_name: "Exemple4: added after removed same key",
     completeTypes: { "1901": ["apconso"] },
-    batchKey: "1901",
+    fromBatchKey: "1901",
     types: "",
     batches: ["1812", "1901"],
     reduce_key: "123",
@@ -275,7 +275,7 @@ const test_cases = [
     ////////////////////////////////////////////////////////
     test_case_name: "Exemple5: deletion without complete types",
     completeTypes: { "1901": ["apconso"] },
-    batchKey: "1901",
+    fromBatchKey: "1901",
     types: "",
     batches: ["1812", "1901"],
     reduce_key: "123",
@@ -327,7 +327,7 @@ const test_cases = [
     ////////////////////////////////////////////////////////
     test_case_name: "Exemple6: only one batch",
     completeTypes: { "1901": [] },
-    batchKey: "1901",
+    fromBatchKey: "1901",
     types: "",
     batches: ["1901"],
     reduce_key: "123",
@@ -381,7 +381,7 @@ const jsParams = this // => all properties of this object will become global. TO
 
 const test_results = test_cases.map(function (tc, id) {
   jsParams.completeTypes = tc.completeTypes
-  jsParams.batchKey = tc.batchKey
+  jsParams.fromBatchKey = tc.fromBatchKey
   jsParams.types = tc.types
   jsParams.batches = tc.batches
   var actual = reduce(tc.reduce_key, tc.reduce_values)

--- a/dbmongo/lib/engine/data.go
+++ b/dbmongo/lib/engine/data.go
@@ -111,7 +111,7 @@ func MRroutine(job *mgo.MapReduce, query bson.M, dbTemp string, collOrig string,
 }
 
 // Compact traite le compactage de la base RawData
-func Compact(batchKey string) error {
+func Compact(fromBatchKey string) error {
 	// Détermination scope traitement
 	batches, _ := GetBatches()
 
@@ -123,7 +123,7 @@ func Compact(batchKey string) error {
 	}
 	found := -1
 	for ind, batchID := range batchesID {
-		if batchID == batchKey {
+		if batchID == fromBatchKey {
 			found = ind
 			break
 		}
@@ -131,7 +131,7 @@ func Compact(batchKey string) error {
 	// Si le numéro de batch n'est pas valide, erreur
 	var batch AdminBatch
 	if found == -1 {
-		return errors.New("Le batch " + batchKey + "n'a pas été trouvé")
+		return errors.New("Le batch " + fromBatchKey + "n'a pas été trouvé")
 	}
 	batch = batches[found]
 
@@ -150,7 +150,7 @@ func Compact(batchKey string) error {
 			"f":             functions,
 			"batches":       batchesID,
 			"completeTypes": completeTypes,
-			"batchKey":      batchKey,
+			"fromBatchKey":  fromBatchKey,
 			"serie_periode": misc.GenereSeriePeriode(batch.Params.DateDebut, batch.Params.DateFin),
 		},
 	}

--- a/test-api.sh
+++ b/test-api.sh
@@ -84,7 +84,7 @@ echo ""
 echo "⚙️ Computing Features and Public collections thru dbmongo API..."
 ./dbmongo &
 sleep 2 # give some time for dbmongo to start
-http --ignore-stdin :5000/api/data/compact batch=1910
+http --ignore-stdin :5000/api/data/compact fromBatchKey=1910
 http --ignore-stdin :5000/api/data/reduce algo=algo2 batch=1910 key=012345678
 http --ignore-stdin :5000/api/data/public batch=1910 key=012345678
 


### PR DESCRIPTION
Problèmes:
- Pierre et moi aurions aimé renommer nos variables locales d'itération `batch` en `batchKey`, pour améliorer la lisibilité du code JS/TS de `compact`;
- Or, `batchKey` est le nom de la variable globale passée à nos fonctions par l'API `compact`, transmise par le paramètre d'API `batch=xxx`.
- Enfin, il s'avère que nous pourrions être plus précis dans le nommage de ce paramètre, pour non seulement décrire la nature de sa valeur (batch key) mais aussi l'impact de cette valeur sur le processus de traitement de données. (`from` indiquant que le compactage sera effectué *à partir* de ce batch key)

Solution: renommer la variable globale `batchKey` et le paramètre API `batch` correspondant en `fromBatchKey`.
