### PR TITLE
fix(reduce.algo2): Calcul des montants de cotisations avant appel à delais()

### DIFF
--- a/dbmongo/js/reduce.algo2/cotisationsdettes.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes.ts
@@ -18,22 +18,25 @@ type Dette = {
   montant_majorations: EntréeDebit["montant_majorations"]
 }
 
-export type SortieCotisationsDettes = {
-  interessante_urssaf: boolean // true: si l'entreprise n'a pas eu de débit (dette) sur les 6 derniers mois
-  cotisation: number // montant (€) des mensualités de règlement des cotisations sociales
-  montant_part_ouvriere: number // montant (€) de la dette imputable au réglement des cotisatisations sociales des employés
+type CotisationsDettesPassees = {
   montant_part_ouvriere_past_1: number
   montant_part_ouvriere_past_2: number
   montant_part_ouvriere_past_3: number
   montant_part_ouvriere_past_6: number
   montant_part_ouvriere_past_12: number
-  montant_part_patronale: number // montant (€) de la dette imputable au réglement des cotisatisations sociales des dirigeants
   montant_part_patronale_past_1: number
   montant_part_patronale_past_2: number
   montant_part_patronale_past_3: number
   montant_part_patronale_past_6: number
   montant_part_patronale_past_12: number
 }
+
+export type SortieCotisationsDettes = {
+  interessante_urssaf: boolean // true: si l'entreprise n'a pas eu de débit (dette) sur les 6 derniers mois
+  cotisation: number // montant (€) des mensualités de règlement des cotisations sociales
+  montant_part_ouvriere: number // montant (€) de la dette imputable au réglement des cotisatisations sociales des employés
+  montant_part_patronale: number // montant (€) de la dette imputable au réglement des cotisatisations sociales des dirigeants
+} & CotisationsDettesPassees
 
 /**
  * Calcule les variables liées aux cotisations sociales et dettes sur ces
@@ -206,14 +209,17 @@ export function cotisationsdettes(
     )
     val = Object.assign(val, montant_dette)
 
-    const past_month_offsets = [1, 2, 3, 6, 12]
+    const past_month_offsets = [1, 2, 3, 6, 12] // Penser à mettre à jour le type CotisationsDettesPassees pour tout changement
     const time_d = new Date(parseInt(time))
 
     past_month_offsets.forEach((offset) => {
       const time_offset = f.dateAddMonth(time_d, offset)
-      const variable_name_part_ouvriere = "montant_part_ouvriere_past_" + offset
+
+      const variable_name_part_ouvriere = ("montant_part_ouvriere_past_" +
+        offset) as keyof CotisationsDettesPassees
       const variable_name_part_patronale = ("montant_part_patronale_past_" +
-        offset) as keyof SortieCotisationsDettes
+        offset) as keyof CotisationsDettesPassees
+
       output_cotisationsdettes[time_offset.getTime()] =
         output_cotisationsdettes[time_offset.getTime()] || {}
       const val_offset = output_cotisationsdettes[time_offset.getTime()]

--- a/dbmongo/js/reduce.algo2/cotisationsdettes.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes.ts
@@ -22,9 +22,17 @@ export type SortieCotisationsDettes = {
   interessante_urssaf: boolean // true: si l'entreprise n'a pas eu de débit (dette) sur les 6 derniers mois
   cotisation: number // montant (€) des mensualités de règlement des cotisations sociales
   montant_part_ouvriere: number // montant (€) de la dette imputable au réglement des cotisatisations sociales des employés
+  montant_part_ouvriere_past_1: number
+  montant_part_ouvriere_past_2: number
+  montant_part_ouvriere_past_3: number
+  montant_part_ouvriere_past_6: number
+  montant_part_ouvriere_past_12: number
   montant_part_patronale: number // montant (€) de la dette imputable au réglement des cotisatisations sociales des dirigeants
-} & {
-  [other: string]: number // ⚠️ ex: montant_part_ouvriere_past_* // TODO: éviter les clés dynamiques
+  montant_part_patronale_past_1: number
+  montant_part_patronale_past_2: number
+  montant_part_patronale_past_3: number
+  montant_part_patronale_past_6: number
+  montant_part_patronale_past_12: number
 }
 
 /**
@@ -204,8 +212,8 @@ export function cotisationsdettes(
     past_month_offsets.forEach((offset) => {
       const time_offset = f.dateAddMonth(time_d, offset)
       const variable_name_part_ouvriere = "montant_part_ouvriere_past_" + offset
-      const variable_name_part_patronale =
-        "montant_part_patronale_past_" + offset
+      const variable_name_part_patronale = ("montant_part_patronale_past_" +
+        offset) as keyof SortieCotisationsDettes
       output_cotisationsdettes[time_offset.getTime()] =
         output_cotisationsdettes[time_offset.getTime()] || {}
       const val_offset = output_cotisationsdettes[time_offset.getTime()]

--- a/dbmongo/js/reduce.algo2/cotisationsdettes.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes.ts
@@ -19,14 +19,18 @@ type Dette = {
 }
 
 type SortieCotisationsDettes = {
-  interessante_urssaf: boolean
-  cotisation: number
-  montant_part_ouvriere: number
-  montant_part_patronale: number
+  interessante_urssaf: boolean // true: si l'entreprise n'a pas eu de débit (dette) sur les 6 derniers mois
+  cotisation: number // montant (€) des mensualités de règlement des cotisations sociales
+  montant_part_ouvriere: number // montant (€) de la dette imputable au réglement des cotisatisations sociales des employés
+  montant_part_patronale: number // montant (€) de la dette imputable au réglement des cotisatisations sociales des dirigeants
 } & {
   [other: string]: number // ⚠️ ex: montant_part_ouvriere_past_* // TODO: éviter les clés dynamiques
 }
 
+/**
+ * Calcule les variables liées aux cotisations sociales et dettes sur ces
+ * cotisations.
+ */
 export function cotisationsdettes(
   v: DonnéesCotisation & DonnéesDebit,
   periodes: Periode[]

--- a/dbmongo/js/reduce.algo2/cotisationsdettes.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes.ts
@@ -18,7 +18,7 @@ type Dette = {
   montant_majorations: EntréeDebit["montant_majorations"]
 }
 
-type SortieCotisationsDettes = {
+export type SortieCotisationsDettes = {
   interessante_urssaf: boolean // true: si l'entreprise n'a pas eu de débit (dette) sur les 6 derniers mois
   cotisation: number // montant (€) des mensualités de règlement des cotisations sociales
   montant_part_ouvriere: number // montant (€) de la dette imputable au réglement des cotisatisations sociales des employés

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -62,37 +62,37 @@ export function delais(
       )
     )
     // Création d'un tableau de timestamps à raison de 1 par mois.
-    const pastYearTimes = f
+    f
       .generatePeriodSerie(date_creation, date_echeance)
       .map((date) => date.getTime())
       .filter((time) => sériePériode.map((date) => date.getTime()).includes(time))
         // TODO: ne pas convertir sériePériode à chaque fois
-    pastYearTimes.map(function (time: number) {
-      const debutDeMois = new Date(time)
-      const remainingDays = nbDays(debutDeMois, delai.date_echeance)
-      const inputAtTime = debitParPériode[time]
-      const outputAtTime: DelaiComputedValues = {
-        delai_nb_jours_restants: remainingDays,
-        delai_nb_jours_total: delai.duree_delai,
-        delai_montant_echeancier: delai.montant_echeancier,
-      }
-      if (
-        delai.duree_delai > 0 &&
-        inputAtTime !== undefined &&
-        inputAtTime.montant_part_patronale !== undefined &&
-        inputAtTime.montant_part_ouvriere !== undefined
-      ) {
-        const detteActuelle =
-          inputAtTime.montant_part_patronale +
-          inputAtTime.montant_part_ouvriere
-        const detteHypothétiqueRemboursementLinéaire =
-          (delai.montant_echeancier * remainingDays) / delai.duree_delai
-        outputAtTime.delai_deviation_remboursement =
-          (detteActuelle - detteHypothétiqueRemboursementLinéaire) /
-          delai.montant_echeancier
-      }
-      donnéesSupplémentairesParPériode[time] = outputAtTime
-    })
+      .map(function (time: number) {
+        const debutDeMois = new Date(time)
+        const remainingDays = nbDays(debutDeMois, delai.date_echeance)
+        const inputAtTime = debitParPériode[time]
+        const outputAtTime: DelaiComputedValues = {
+          delai_nb_jours_restants: remainingDays,
+          delai_nb_jours_total: delai.duree_delai,
+          delai_montant_echeancier: delai.montant_echeancier,
+        }
+        if (
+          delai.duree_delai > 0 &&
+          inputAtTime !== undefined &&
+          inputAtTime.montant_part_patronale !== undefined &&
+          inputAtTime.montant_part_ouvriere !== undefined
+        ) {
+          const detteActuelle =
+            inputAtTime.montant_part_patronale +
+            inputAtTime.montant_part_ouvriere
+          const detteHypothétiqueRemboursementLinéaire =
+            (delai.montant_echeancier * remainingDays) / delai.duree_delai
+          outputAtTime.delai_deviation_remboursement =
+            (detteActuelle - detteHypothétiqueRemboursementLinéaire) /
+            delai.montant_echeancier
+        }
+        donnéesSupplémentairesParPériode[time] = outputAtTime
+      })
   })
   return donnéesSupplémentairesParPériode
 }

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -31,7 +31,8 @@ export type DelaiComputedValues = {
  */
 export function delais(
   v: DonnéesDelai,
-  debitParPériode: DeepReadonly<ParPériode<DebitComputedValues>>
+  debitParPériode: DeepReadonly<ParPériode<DebitComputedValues>>,
+  sériePériode: Date[]
 ): ParPériode<DelaiComputedValues> {
   "use strict"
   const donnéesSupplémentairesParPériode: ParPériode<DelaiComputedValues> = {}
@@ -63,14 +64,11 @@ export function delais(
     // Création d'un tableau de timestamps à raison de 1 par mois.
     const pastYearTimes = f
       .generatePeriodSerie(date_creation, date_echeance)
-      .map(function (date: Date) {
-        return date.getTime()
-      })
-    pastYearTimes.map(function (time: number) {
-      if (time in debitParPériode) {
+    pastYearTimes.map(function (time: Date) {
+      if (sériePériode.includes(time)) {
         const debutDeMois = new Date(time)
         const remainingDays = nbDays(debutDeMois, delai.date_echeance)
-        const inputAtTime = debitParPériode[time]
+        const inputAtTime = debitParPériode[time.getTime()]
         const outputAtTime: DelaiComputedValues = {
           delai_nb_jours_restants: remainingDays,
           delai_nb_jours_total: delai.duree_delai,
@@ -90,7 +88,7 @@ export function delais(
             (detteActuelle - detteHypothétiqueRemboursementLinéaire) /
             delai.montant_echeancier
         }
-        donnéesSupplémentairesParPériode[time] = outputAtTime
+        donnéesSupplémentairesParPériode[time.getTime()] = outputAtTime
       }
     })
   })

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -64,11 +64,13 @@ export function delais(
     // Création d'un tableau de timestamps à raison de 1 par mois.
     const pastYearTimes = f
       .generatePeriodSerie(date_creation, date_echeance)
-    pastYearTimes.map(function (time: Date) {
-      if (sériePériode.includes(time)) {
+      .map((date) => date.getTime())
+    pastYearTimes.map(function (time: number) {
+      if (sériePériode.map((date) => date.getTime()).includes(time)) {
+        // TODO: ne pas convertir sériePériode à chaque fois
         const debutDeMois = new Date(time)
         const remainingDays = nbDays(debutDeMois, delai.date_echeance)
-        const inputAtTime = debitParPériode[time.getTime()]
+        const inputAtTime = debitParPériode[time]
         const outputAtTime: DelaiComputedValues = {
           delai_nb_jours_restants: remainingDays,
           delai_nb_jours_total: delai.duree_delai,
@@ -88,7 +90,7 @@ export function delais(
             (detteActuelle - detteHypothétiqueRemboursementLinéaire) /
             delai.montant_echeancier
         }
-        donnéesSupplémentairesParPériode[time.getTime()] = outputAtTime
+        donnéesSupplémentairesParPériode[time] = outputAtTime
       }
     })
   })

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -5,8 +5,8 @@ type DeepReadonly<T> = Readonly<T> // pas vraiment, mais espoire que TS le suppo
 
 // Valeurs attendues pour chaque période, lors de l'appel à delais()
 export type DebitComputedValues = {
-  montant_part_patronale?: number
-  montant_part_ouvriere?: number
+  montant_part_patronale: number
+  montant_part_ouvriere: number
 }
 
 // Valeurs retournées par delais(), pour chaque période

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -36,8 +36,12 @@ export function delais(
 ): ParPériode<DelaiComputedValues> {
   "use strict"
   const donnéesDélaiParPériode: ParPériode<DelaiComputedValues> = {}
-  Object.keys(v.delai).map(function (hash) {
+  Object.keys(v.delai).forEach(function (hash) {
     const delai = v.delai[hash]
+    if (delai.duree_delai <= 0) {
+      return
+    }
+
     // On arrondit les dates au premier jour du mois.
     const date_creation = new Date(
       Date.UTC(
@@ -78,7 +82,6 @@ export function delais(
           delai_montant_echeancier: delai.montant_echeancier,
         }
         if (
-          delai.duree_delai > 0 &&
           inputAtTime?.montant_part_patronale !== undefined &&
           inputAtTime?.montant_part_ouvriere !== undefined
         ) {

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -65,34 +65,33 @@ export function delais(
     const pastYearTimes = f
       .generatePeriodSerie(date_creation, date_echeance)
       .map((date) => date.getTime())
-    pastYearTimes.map(function (time: number) {
-      if (sériePériode.map((date) => date.getTime()).includes(time)) {
+      .filter((time) => sériePériode.map((date) => date.getTime()).includes(time))
         // TODO: ne pas convertir sériePériode à chaque fois
-        const debutDeMois = new Date(time)
-        const remainingDays = nbDays(debutDeMois, delai.date_echeance)
-        const inputAtTime = debitParPériode[time]
-        const outputAtTime: DelaiComputedValues = {
-          delai_nb_jours_restants: remainingDays,
-          delai_nb_jours_total: delai.duree_delai,
-          delai_montant_echeancier: delai.montant_echeancier,
-        }
-        if (
-          delai.duree_delai > 0 &&
-          inputAtTime !== undefined &&
-          inputAtTime.montant_part_patronale !== undefined &&
-          inputAtTime.montant_part_ouvriere !== undefined
-        ) {
-          const detteActuelle =
-            inputAtTime.montant_part_patronale +
-            inputAtTime.montant_part_ouvriere
-          const detteHypothétiqueRemboursementLinéaire =
-            (delai.montant_echeancier * remainingDays) / delai.duree_delai
-          outputAtTime.delai_deviation_remboursement =
-            (detteActuelle - detteHypothétiqueRemboursementLinéaire) /
-            delai.montant_echeancier
-        }
-        donnéesSupplémentairesParPériode[time] = outputAtTime
+    pastYearTimes.map(function (time: number) {
+      const debutDeMois = new Date(time)
+      const remainingDays = nbDays(debutDeMois, delai.date_echeance)
+      const inputAtTime = debitParPériode[time]
+      const outputAtTime: DelaiComputedValues = {
+        delai_nb_jours_restants: remainingDays,
+        delai_nb_jours_total: delai.duree_delai,
+        delai_montant_echeancier: delai.montant_echeancier,
       }
+      if (
+        delai.duree_delai > 0 &&
+        inputAtTime !== undefined &&
+        inputAtTime.montant_part_patronale !== undefined &&
+        inputAtTime.montant_part_ouvriere !== undefined
+      ) {
+        const detteActuelle =
+          inputAtTime.montant_part_patronale +
+          inputAtTime.montant_part_ouvriere
+        const detteHypothétiqueRemboursementLinéaire =
+          (delai.montant_echeancier * remainingDays) / delai.duree_delai
+        outputAtTime.delai_deviation_remboursement =
+          (detteActuelle - detteHypothétiqueRemboursementLinéaire) /
+          delai.montant_echeancier
+      }
+      donnéesSupplémentairesParPériode[time] = outputAtTime
     })
   })
   return donnéesSupplémentairesParPériode

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -11,12 +11,24 @@ export type DebitComputedValues = {
 
 // Valeurs retournées par delais(), pour chaque période
 export type DelaiComputedValues = {
-  delai_nb_jours_restants: number
+  // valeurs fournies, reportées par delais() dans chaque période:
   delai_nb_jours_total: number // nombre de jours entre date_creation et date_echeance
-  delai_deviation_remboursement?: number
   delai_montant_echeancier: number // exprimé en euros
+  // valeurs calculées par delais():
+  delai_nb_jours_restants: number
+  delai_deviation_remboursement?: number // ratio entre remboursement linéaire et effectif, à condition d'avoir le montant des parts ouvrière et patronale
 }
 
+/**
+ * Calcule pour chaque période le nombre de jours restants du délai accordé et
+ * un indicateur de la déviation par rapport à un remboursement linéaire du
+ * montant couvert par le délai. Un "délai" étant une demande accordée de délai
+ * de paiement des cotisations sociales, pour un certain montant
+ * (delai_montant_echeancier) et pendant une certaine période
+ * (delai_nb_jours_total).
+ * Contrat: cette fonction ne devrait être appelée que s'il y a eu au moins une
+ * demande de délai.
+ */
 export function delais(
   v: DonnéesDelai,
   debitParPériode: DeepReadonly<ParPériode<DebitComputedValues>>

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -79,9 +79,8 @@ export function delais(
         }
         if (
           delai.duree_delai > 0 &&
-          inputAtTime !== undefined &&
-          inputAtTime.montant_part_patronale !== undefined &&
-          inputAtTime.montant_part_ouvriere !== undefined
+          inputAtTime?.montant_part_patronale !== undefined &&
+          inputAtTime?.montant_part_ouvriere !== undefined
         ) {
           const detteActuelle =
             inputAtTime.montant_part_patronale +

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -35,7 +35,7 @@ export function delais(
   sériePériode: Date[]
 ): ParPériode<DelaiComputedValues> {
   "use strict"
-  const donnéesSupplémentairesParPériode: ParPériode<DelaiComputedValues> = {}
+  const donnéesDélaiParPériode: ParPériode<DelaiComputedValues> = {}
   Object.keys(v.delai).map(function (hash) {
     const delai = v.delai[hash]
     // On arrondit les dates au premier jour du mois.
@@ -62,11 +62,12 @@ export function delais(
       )
     )
     // Création d'un tableau de timestamps à raison de 1 par mois.
-    f
-      .generatePeriodSerie(date_creation, date_echeance)
+    f.generatePeriodSerie(date_creation, date_echeance)
       .map((date) => date.getTime())
-      .filter((time) => sériePériode.map((date) => date.getTime()).includes(time))
-        // TODO: ne pas convertir sériePériode à chaque fois
+      .filter((time) =>
+        sériePériode.map((date) => date.getTime()).includes(time)
+      )
+      // TODO: ne pas convertir sériePériode à chaque fois
       .map(function (time: number) {
         const debutDeMois = new Date(time)
         const remainingDays = nbDays(debutDeMois, delai.date_echeance)
@@ -91,8 +92,8 @@ export function delais(
             (detteActuelle - detteHypothétiqueRemboursementLinéaire) /
             delai.montant_echeancier
         }
-        donnéesSupplémentairesParPériode[time] = outputAtTime
+        donnéesDélaiParPériode[time] = outputAtTime
       })
   })
-  return donnéesSupplémentairesParPériode
+  return donnéesDélaiParPériode
 }

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -82,8 +82,8 @@ export function delais(
           delai_montant_echeancier: delai.montant_echeancier,
         }
         if (
-          inputAtTime?.montant_part_patronale !== undefined &&
-          inputAtTime?.montant_part_ouvriere !== undefined
+          typeof inputAtTime?.montant_part_patronale !== "undefined" &&
+          typeof inputAtTime?.montant_part_ouvriere !== "undefined"
         ) {
           const detteActuelle =
             inputAtTime.montant_part_patronale +

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -32,7 +32,7 @@ export type DelaiComputedValues = {
 export function delais(
   v: DonnéesDelai,
   debitParPériode: DeepReadonly<ParPériode<DebitComputedValues>>,
-  sériePériode: Date[]
+  intervalleTraitement: { premièreDate: Date; dernièreDate: Date }
 ): ParPériode<DelaiComputedValues> {
   "use strict"
   const donnéesDélaiParPériode: ParPériode<DelaiComputedValues> = {}
@@ -63,13 +63,13 @@ export function delais(
     )
     // Création d'un tableau de timestamps à raison de 1 par mois.
     f.generatePeriodSerie(date_creation, date_echeance)
-      .map((date) => date.getTime())
-      .filter((time) =>
-        sériePériode.map((date) => date.getTime()).includes(time)
+      .filter(
+        (date) =>
+          date >= intervalleTraitement.premièreDate &&
+          date <= intervalleTraitement.dernièreDate
       )
-      // TODO: ne pas convertir sériePériode à chaque fois
-      .map(function (time: number) {
-        const debutDeMois = new Date(time)
+      .map(function (debutDeMois) {
+        const time = debutDeMois.getTime()
         const remainingDays = nbDays(debutDeMois, delai.date_echeance)
         const inputAtTime = debitParPériode[time]
         const outputAtTime: DelaiComputedValues = {

--- a/dbmongo/js/reduce.algo2/delais.ts
+++ b/dbmongo/js/reduce.algo2/delais.ts
@@ -78,6 +78,7 @@ export function delais(
         }
         if (
           delai.duree_delai > 0 &&
+          inputAtTime !== undefined &&
           inputAtTime.montant_part_patronale !== undefined &&
           inputAtTime.montant_part_ouvriere !== undefined
         ) {

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -95,6 +95,10 @@ test("un délai en dehors de la période d'intérêt est ignorée", (t: Executio
   }
   const donnéesParPériode: ParPériode<DebitComputedValues> = {}
   donnéesParPériode[fevrier.getTime()] = makeDebitParPériode()
-  const périodesComplétées = delais({ delai: delaiMap }, donnéesParPériode, serie_periode)
+  const périodesComplétées = delais(
+    { delai: delaiMap },
+    donnéesParPériode,
+    serie_periode
+  )
   t.deepEqual(périodesComplétées, {})
 })

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -5,7 +5,6 @@ import { delais, DelaiComputedValues, DebitComputedValues } from "./delais"
 
 const fevrier = new Date("2014-02-01")
 const mars = new Date("2014-03-01")
-const serie_periode = [fevrier, mars]
 
 const makeDelai = (firstDate: Date, secondDate: Date): EntréeDelai => ({
   date_creation: firstDate,
@@ -34,7 +33,10 @@ const runDelais = (
     debitParPériode[fevrier.getTime()] = makeDebitParPériode(debits)
     debitParPériode[mars.getTime()] = makeDebitParPériode(debits)
   }
-  return delais({ delai: delaiMap }, debitParPériode, serie_periode)
+  return delais({ delai: delaiMap }, debitParPériode, {
+    premièreDate: fevrier,
+    dernièreDate: mars,
+  })
 }
 
 test("la propriété delai_nb_jours_restants représente le nombre de jours restants du délai", (t: ExecutionContext) => {
@@ -95,10 +97,9 @@ test("un délai en dehors de la période d'intérêt est ignorée", (t: Executio
   }
   const donnéesParPériode: ParPériode<DebitComputedValues> = {}
   donnéesParPériode[fevrier.getTime()] = makeDebitParPériode()
-  const périodesComplétées = delais(
-    { delai: delaiMap },
-    donnéesParPériode,
-    serie_periode
-  )
+  const périodesComplétées = delais({ delai: delaiMap }, donnéesParPériode, {
+    premièreDate: fevrier,
+    dernièreDate: mars,
+  })
   t.deepEqual(périodesComplétées, {})
 })

--- a/dbmongo/js/reduce.algo2/delais_tests.ts
+++ b/dbmongo/js/reduce.algo2/delais_tests.ts
@@ -5,6 +5,7 @@ import { delais, DelaiComputedValues, DebitComputedValues } from "./delais"
 
 const fevrier = new Date("2014-02-01")
 const mars = new Date("2014-03-01")
+const serie_periode = [fevrier, mars]
 
 const makeDelai = (firstDate: Date, secondDate: Date): EntréeDelai => ({
   date_creation: firstDate,
@@ -29,9 +30,11 @@ const runDelais = (
     abc: delaiTest,
   }
   const debitParPériode: ParPériode<DebitComputedValues> = {}
-  debitParPériode[fevrier.getTime()] = debits ? makeDebitParPériode(debits) : {}
-  debitParPériode[mars.getTime()] = debits ? makeDebitParPériode(debits) : {}
-  return delais({ delai: delaiMap }, debitParPériode)
+  if (debits) {
+    debitParPériode[fevrier.getTime()] = makeDebitParPériode(debits)
+    debitParPériode[mars.getTime()] = makeDebitParPériode(debits)
+  }
+  return delais({ delai: delaiMap }, debitParPériode, serie_periode)
 }
 
 test("la propriété delai_nb_jours_restants représente le nombre de jours restants du délai", (t: ExecutionContext) => {
@@ -92,6 +95,6 @@ test("un délai en dehors de la période d'intérêt est ignorée", (t: Executio
   }
   const donnéesParPériode: ParPériode<DebitComputedValues> = {}
   donnéesParPériode[fevrier.getTime()] = makeDebitParPériode()
-  const périodesComplétées = delais({ delai: delaiMap }, donnéesParPériode)
+  const périodesComplétées = delais({ delai: delaiMap }, donnéesParPériode, serie_periode)
   t.deepEqual(périodesComplétées, {})
 })

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -131,7 +131,8 @@ export function map(this: {
       if (v.delai) {
         const output_delai = f.delais(
           v as DonnéesDelai,
-          output_cotisationsdettes || {}
+          output_cotisationsdettes || {},
+          serie_periode
         )
         f.add(output_delai, output_indexed)
       }

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -119,10 +119,19 @@ export function map(this: {
         f.add(output_repeatable, output_indexed)
       }
 
+      let output_cotisationsdettes
+      if (v.cotisation && v.debit) {
+        output_cotisationsdettes = f.cotisationsdettes(
+          v as DonnéesCotisation & DonnéesDebit,
+          periodes
+        )
+        f.add(output_cotisationsdettes, output_indexed)
+      }
+
       if (v.delai) {
         const output_delai = f.delais(
           v as DonnéesDelai,
-          output_indexed // TODO: vérifier que les données débit sont déjà calculées
+          output_cotisationsdettes || {}
         )
         f.add(output_delai, output_indexed)
       }
@@ -132,14 +141,6 @@ export function map(this: {
 
       if (v.altares) {
         f.defaillances(v as DonnéesDefaillances, output_indexed)
-      }
-
-      if (v.cotisation && v.debit) {
-        const output_cotisationsdettes = f.cotisationsdettes(
-          v as DonnéesCotisation & DonnéesDebit,
-          periodes
-        )
-        f.add(output_cotisationsdettes, output_indexed)
       }
 
       if (v.ccsf) {

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -132,7 +132,10 @@ export function map(this: {
         const output_delai = f.delais(
           v as DonnéesDelai,
           output_cotisationsdettes || {},
-          serie_periode
+          {
+            premièreDate: serie_periode[0],
+            dernièreDate: serie_periode[serie_periode.length - 1],
+          }
         )
         f.add(output_delai, output_indexed)
       }

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -7,7 +7,7 @@ import { effectifs } from "./effectifs"
 import { interim } from "./interim"
 import { add } from "./add"
 import { repeatable } from "./repeatable"
-import { delais, DebitComputedValues } from "./delais"
+import { delais } from "./delais"
 import { defaillances } from "./defaillances"
 import { cotisationsdettes } from "./cotisationsdettes"
 import { ccsf } from "./ccsf"
@@ -122,7 +122,7 @@ export function map(this: {
       if (v.delai) {
         const output_delai = f.delais(
           v as DonnéesDelai,
-          output_indexed as ParPériode<DebitComputedValues> // TODO: vérifier que les données débit sont déjà calculées
+          output_indexed // TODO: vérifier que les données débit sont déjà calculées
         )
         f.add(output_delai, output_indexed)
       }

--- a/dbmongo/js/reduce.algo2/outputs.ts
+++ b/dbmongo/js/reduce.algo2/outputs.ts
@@ -1,4 +1,4 @@
-import { DebitComputedValues } from "./delais"
+import { SortieCotisationsDettes } from "./cotisationsdettes"
 import { SortieDefaillances } from "./defaillances"
 import { SortieCcsf } from "./ccsf"
 import { SortieSirene } from "./sirene"
@@ -12,7 +12,8 @@ type DonnéesAgrégées = {
   etat_proc_collective: "in_bonis" // ou ProcolToHumanRes ?
   interessante_urssaf: true
   outcome: false
-} & DebitComputedValues &
+} &
+  Partial<SortieCotisationsDettes> &
   Partial<SortieDefaillances> &
   Partial<SortieCcsf> &
   Partial<SortieSirene> &

--- a/dbmongo/js/reduce.algo2/outputs.ts
+++ b/dbmongo/js/reduce.algo2/outputs.ts
@@ -12,8 +12,7 @@ type DonnéesAgrégées = {
   etat_proc_collective: "in_bonis" // ou ProcolToHumanRes ?
   interessante_urssaf: true
   outcome: false
-} &
-  Partial<SortieCotisationsDettes> &
+} & Partial<SortieCotisationsDettes> &
   Partial<SortieDefaillances> &
   Partial<SortieCcsf> &
   Partial<SortieSirene> &

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1467,8 +1467,8 @@ function delais(v, debitParPériode, intervalleTraitement) {
                 delai_nb_jours_total: delai.duree_delai,
                 delai_montant_echeancier: delai.montant_echeancier,
             };
-            if ((inputAtTime === null || inputAtTime === void 0 ? void 0 : inputAtTime.montant_part_patronale) !== undefined &&
-                (inputAtTime === null || inputAtTime === void 0 ? void 0 : inputAtTime.montant_part_ouvriere) !== undefined) {
+            if (typeof (inputAtTime === null || inputAtTime === void 0 ? void 0 : inputAtTime.montant_part_patronale) !== "undefined" &&
+                typeof (inputAtTime === null || inputAtTime === void 0 ? void 0 : inputAtTime.montant_part_ouvriere) !== "undefined") {
                 const detteActuelle = inputAtTime.montant_part_patronale +
                     inputAtTime.montant_part_ouvriere;
                 const detteHypothétiqueRemboursementLinéaire = (delai.montant_echeancier * remainingDays) / delai.duree_delai;

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1465,9 +1465,8 @@ function delais(v, debitParPériode, intervalleTraitement) {
                 delai_montant_echeancier: delai.montant_echeancier,
             };
             if (delai.duree_delai > 0 &&
-                inputAtTime !== undefined &&
-                inputAtTime.montant_part_patronale !== undefined &&
-                inputAtTime.montant_part_ouvriere !== undefined) {
+                (inputAtTime === null || inputAtTime === void 0 ? void 0 : inputAtTime.montant_part_patronale) !== undefined &&
+                (inputAtTime === null || inputAtTime === void 0 ? void 0 : inputAtTime.montant_part_ouvriere) !== undefined) {
                 const detteActuelle = inputAtTime.montant_part_patronale +
                     inputAtTime.montant_part_ouvriere;
                 const detteHypothétiqueRemboursementLinéaire = (delai.montant_echeancier * remainingDays) / delai.duree_delai;

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1446,8 +1446,11 @@ function cotisationsdettes(v, periodes) {
 function delais(v, debitParPériode, intervalleTraitement) {
     "use strict";
     const donnéesDélaiParPériode = {};
-    Object.keys(v.delai).map(function (hash) {
+    Object.keys(v.delai).forEach(function (hash) {
         const delai = v.delai[hash];
+        if (delai.duree_delai <= 0) {
+            return;
+        }
         // On arrondit les dates au premier jour du mois.
         const date_creation = new Date(Date.UTC(delai.date_creation.getUTCFullYear(), delai.date_creation.getUTCMonth(), 1, 0, 0, 0, 0));
         const date_echeance = new Date(Date.UTC(delai.date_echeance.getUTCFullYear(), delai.date_echeance.getUTCMonth(), 1, 0, 0, 0, 0));
@@ -1464,8 +1467,7 @@ function delais(v, debitParPériode, intervalleTraitement) {
                 delai_nb_jours_total: delai.duree_delai,
                 delai_montant_echeancier: delai.montant_echeancier,
             };
-            if (delai.duree_delai > 0 &&
-                (inputAtTime === null || inputAtTime === void 0 ? void 0 : inputAtTime.montant_part_patronale) !== undefined &&
+            if ((inputAtTime === null || inputAtTime === void 0 ? void 0 : inputAtTime.montant_part_patronale) !== undefined &&
                 (inputAtTime === null || inputAtTime === void 0 ? void 0 : inputAtTime.montant_part_ouvriere) !== undefined) {
                 const detteActuelle = inputAtTime.montant_part_patronale +
                     inputAtTime.montant_part_ouvriere;

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1236,7 +1236,11 @@ db.getCollection("Features").createIndex({
             counter = 0;
     });
 }`,
-"cotisationsdettes": `function cotisationsdettes(v, periodes) {
+"cotisationsdettes": `/**
+ * Calcule les variables liées aux cotisations sociales et dettes sur ces
+ * cotisations.
+ */
+function cotisationsdettes(v, periodes) {
     "use strict";
 
     // Tous les débits traitées après ce jour du mois sont reportées à la période suivante
@@ -1427,7 +1431,17 @@ db.getCollection("Features").createIndex({
     f.dealWithProcols(v.altares, "altares", output_indexed);
     f.dealWithProcols(v.procol, "procol", output_indexed);
 }`,
-"delais": `function delais(v, debitParPériode) {
+"delais": `/**
+ * Calcule pour chaque période le nombre de jours restants du délai accordé et
+ * un indicateur de la déviation par rapport à un remboursement linéaire du
+ * montant couvert par le délai. Un "délai" étant une demande accordée de délai
+ * de paiement des cotisations sociales, pour un certain montant
+ * (delai_montant_echeancier) et pendant une certaine période
+ * (delai_nb_jours_total).
+ * Contrat: cette fonction ne devrait être appelée que s'il y a eu au moins une
+ * demande de délai.
+ */
+function delais(v, debitParPériode) {
     "use strict";
     const donnéesSupplémentairesParPériode = {};
     Object.keys(v.delai).map(function (hash) {


### PR DESCRIPTION
Changements effectués en pair avec Pierre:
- `montant_part_ouvriere` et `montant_part_patronale` ne sont désormais plus optionnels en entrée de `delais()`
- `map()` passe le retour de `cotisationsdettes()` + l'intervalle de traitement à `delais()`
- harmonisation du type `DonnéesAgrégées`
- documentation des fonctions modifiées et de leurs propriétés
- bonus: retrait de 3 `TODO`s + quelques optimisations de perf 🎉