### PR TITLE
tests(reduce.algo2): Test de non régression sur calcul de delai_deviation_remboursement

### DIFF
--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -26,7 +26,7 @@ type NAF = {
 
 type Scope = "etablissement" | "entreprise"
 
-// Données importées pour une entreprise ou établissement, sur une période donnée.
+// Données importées pour une entreprise ou établissement
 type CompanyDataValues = {
   key: SiretOrSiren
   scope: Scope

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -26,6 +26,7 @@ type NAF = {
 
 type Scope = "etablissement" | "entreprise"
 
+// Données importées pour une entreprise ou établissement, sur une période donnée.
 type CompanyDataValues = {
   key: SiretOrSiren
   scope: Scope

--- a/dbmongo/js/reduce.algo2/algo2_tests.ts
+++ b/dbmongo/js/reduce.algo2/algo2_tests.ts
@@ -125,7 +125,6 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
             },
           },
           debit: {},
-          /*
           dettes: {
             hash1: {
               periode: dateDebut,
@@ -137,13 +136,12 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
             hash2: {
               date_creation: dateDebut,
               date_echeance: new Date(
-                dateDebut.getTime() + 2 * 24 * 60 * 60 * 1000
-                ),
-                duree_delai: 2,
-                montant_echeancier: 100,
-              },
+                dateDebut.getTime() + 60 * 24 * 60 * 60 * 1000
+              ),
+              duree_delai: 60 * 24 * 60 * 60 * 1000,
+              montant_echeancier: 100,
             },
-            */
+          },
         },
       },
     } as CompanyDataValues,
@@ -166,6 +164,10 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
         "012345678901234": {
           cotisation: 100,
           cotisation_moy12m: 100,
+          delai_deviation_remboursement: -1.1574074074074074e-8,
+          delai_montant_echeancier: 100,
+          delai_nb_jours_restants: 60,
+          delai_nb_jours_total: 5184000000,
           effectif: null,
           etat_proc_collective: "in_bonis",
           interessante_urssaf: true,

--- a/dbmongo/js/reduce.algo2/algo2_tests.ts
+++ b/dbmongo/js/reduce.algo2/algo2_tests.ts
@@ -128,13 +128,6 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
             },
           },
           debit: {},
-          dettes: {
-            hash1: {
-              periode: dateDebut,
-              part_ouvriere: 100,
-              part_patronale: 0,
-            },
-          },
           delai: {
             hash2: {
               date_creation: dateDebut,

--- a/dbmongo/js/reduce.algo2/algo2_tests.ts
+++ b/dbmongo/js/reduce.algo2/algo2_tests.ts
@@ -108,7 +108,7 @@ function sortObject(object: any): any {
   return sortedObj
 }
 
-test("delai_deviation_remboursement est calculé si un délai de règlement de cotisations sociales a été demandé", (t: ExecutionContext) => {
+test("delai_deviation_remboursement est calculé à partir d'un débit et d'une demande de délai de règlement de cotisations sociales", (t: ExecutionContext) => {
   const dateDebut = new Date("2018-01-01")
   const datePlusUnMois = new Date("2018-02-01")
   initGlobalParams(dateDebut, datePlusUnMois)
@@ -122,9 +122,23 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
       batch: {
         "1905": {
           cotisation: {},
-          debit: {},
+          debit: {
+            hashDette: {
+              periode: {
+                start: dateDebut,
+                end: datePlusUnMois,
+              },
+              numero_ecart_negatif: 1,
+              numero_historique: 2,
+              numero_compte: "",
+              date_traitement: dateDebut,
+              debit_suivant: "",
+              part_ouvriere: 60,
+              part_patronale: 0,
+            },
+          },
           delai: {
-            hash: {
+            hashDelai: {
               date_creation: dateDebut,
               date_echeance: new Date(
                 dateDebut.getTime() + duréeDelai * DAY_IN_MS
@@ -147,5 +161,5 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
   t.deepEqual(Object.keys(values[0][0].value), [siret])
   const finalCompanyData = values[0][0].value[siret]
   t.is(typeof finalCompanyData.delai_deviation_remboursement, "number")
-  t.is(finalCompanyData.delai_deviation_remboursement, -1)
+  t.is(finalCompanyData.delai_deviation_remboursement, -0.4)
 })

--- a/dbmongo/js/reduce.algo2/algo2_tests.ts
+++ b/dbmongo/js/reduce.algo2/algo2_tests.ts
@@ -112,7 +112,7 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
   const dateDebut = new Date("2018-01-01")
   const datePlusUnMois = new Date("2018-02-01")
   initGlobalParams(dateDebut, datePlusUnMois)
-  const siret = "012345678901234"
+  const siret = "12345678901234"
   const duréeDelai = 60 // en jours
   const input = {
     _id: siret,

--- a/dbmongo/js/reduce.algo2/algo2_tests.ts
+++ b/dbmongo/js/reduce.algo2/algo2_tests.ts
@@ -9,6 +9,8 @@ import { objects as testCases } from "../test/data/objects"
 import { naf as nafValues } from "../test/data/naf"
 import { reducer, invertedReducer } from "../test/helpers/reducers"
 
+const DAY_IN_MS = 24 * 60 * 60 * 1000
+
 // Paramètres globaux utilisés par "reduce.algo2"
 declare let emit: unknown // called by map()
 declare let naf: NAF
@@ -110,11 +112,12 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
   const dateDebut = new Date("2018-01-01")
   const datePlusUnMois = new Date("2018-02-01")
   initGlobalParams(dateDebut, datePlusUnMois)
-
+  const siret = "012345678901234"
+  const duréeDelai = 60 // en jours
   const input = {
-    _id: "012345678901234",
+    _id: siret,
     value: {
-      key: "012345678901234",
+      key: siret,
       scope: "etablissement" as Scope,
       batch: {
         "1905": {
@@ -136,9 +139,9 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
             hash2: {
               date_creation: dateDebut,
               date_echeance: new Date(
-                dateDebut.getTime() + 60 * 24 * 60 * 60 * 1000
+                dateDebut.getTime() + duréeDelai * DAY_IN_MS
               ),
-              duree_delai: 60 * 24 * 60 * 60 * 1000,
+              duree_delai: duréeDelai,
               montant_echeancier: 100,
             },
           },
@@ -152,34 +155,8 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
 
   const values = objectValues(pool)
   t.is(values.length, 1)
-  t.deepEqual(values[0], [
-    {
-      key: {
-        batch: "1905",
-        periode: dateDebut,
-        siren: "012345678",
-        type: "other",
-      },
-      value: {
-        "012345678901234": {
-          cotisation: 100,
-          cotisation_moy12m: 100,
-          delai_deviation_remboursement: -1.1574074074074074e-8,
-          delai_montant_echeancier: 100,
-          delai_nb_jours_restants: 60,
-          delai_nb_jours_total: 5184000000,
-          effectif: null,
-          etat_proc_collective: "in_bonis",
-          interessante_urssaf: true,
-          montant_part_ouvriere: 0,
-          montant_part_patronale: 0,
-          outcome: false,
-          periode: dateDebut,
-          ratio_dette: 0,
-          ratio_dette_moy12m: 0,
-          siret: "012345678901234",
-        },
-      },
-    },
-  ])
+  t.is(values[0].length, 1)
+  t.deepEqual(Object.keys(values[0][0].value), [siret])
+  const finalCompanyData = values[0][0].value[siret]
+  t.is(typeof finalCompanyData.delai_deviation_remboursement, "number")
 })

--- a/dbmongo/js/reduce.algo2/algo2_tests.ts
+++ b/dbmongo/js/reduce.algo2/algo2_tests.ts
@@ -121,15 +121,10 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
       scope: "etablissement" as Scope,
       batch: {
         "1905": {
-          cotisation: {
-            hash0: {
-              periode: { start: dateDebut, end: datePlusUnMois },
-              du: 100,
-            },
-          },
+          cotisation: {},
           debit: {},
           delai: {
-            hash2: {
+            hash: {
               date_creation: dateDebut,
               date_echeance: new Date(
                 dateDebut.getTime() + duréeDelai * DAY_IN_MS
@@ -140,7 +135,7 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
           },
         },
       },
-    } as CompanyDataValues,
+    },
   }
 
   const pool = setupMapCollector()
@@ -152,4 +147,5 @@ test("delai_deviation_remboursement est calculé si un délai de règlement de c
   t.deepEqual(Object.keys(values[0][0].value), [siret])
   const finalCompanyData = values[0][0].value[siret]
   t.is(typeof finalCompanyData.delai_deviation_remboursement, "number")
+  t.is(finalCompanyData.delai_deviation_remboursement, -1)
 })

--- a/dbmongo/js/reduce.algo2/flatten.ts
+++ b/dbmongo/js/reduce.algo2/flatten.ts
@@ -1,11 +1,4 @@
-export type V = {
-  // TODO: donner un nom plus explicite au type
-  key: SiretOrSiren
-  scope: Scope
-  batch: BatchValues
-}
-
-export type Flattened = {
+export type FlattenedImportedData = {
   key: SiretOrSiren
   scope: Scope
 } & Partial<BatchValue>
@@ -19,7 +12,10 @@ export type Flattened = {
  * - il supprime les clés `compact.delete` des *Batches* en entrées;
  * - il agrège les propriétés apportées par chaque *Batch*, dans l'ordre chrono.
  */
-export function flatten(v: V, actual_batch: string): Flattened {
+export function flatten(
+  v: CompanyDataValues,
+  actual_batch: string
+): FlattenedImportedData {
   "use strict"
   const res = Object.keys(v.batch || {})
     .sort()
@@ -48,7 +44,7 @@ export function flatten(v: V, actual_batch: string): Flattened {
         })
         return m
       },
-      { key: v.key, scope: v.scope } as Flattened
+      { key: v.key, scope: v.scope } as FlattenedImportedData
     )
 
   return res

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -1,5 +1,5 @@
 import "../globals"
-import { flatten, V as FlattenedEntreprise } from "./flatten"
+import { flatten } from "./flatten"
 import { outputs } from "./outputs"
 import { apart } from "./apart"
 import { compte } from "./compte"
@@ -40,7 +40,7 @@ declare const serie_periode: Date[]
  */
 export function map(this: {
   _id: SiretOrSiren
-  value: FlattenedEntreprise
+  value: CompanyDataValues
 }): void {
   "use strict"
   /* DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO */ const f = {


### PR DESCRIPTION
Lors de l'implémentation du correctif #93, nous n'avions pas ajouté de test mettant en lumière le fait que la variable `delai_deviation_remboursement` n'était pas calculée comme prévu, lorsque qu'une dette avec demande de délai était fournie.

Le but de cette PR est de fournir ce test. Celui-ci passe sur la version actuelle de `master`, mais pas avant la fusion de PR #93.

Bonus: retrait d'un type redondant + renommage d'un type ambigu.

## Comment tester

1. Revenir au commit https://github.com/signaux-faibles/opensignauxfaibles/commit/a0007680bc8046d16575b72df0b78351124ad44b (avant fusion de PR #93)
2. Remplacer `js/reduce.algo2/algo2_tests.ts` par la version apportée dans cette PR
3. Exécuter `$ npx ava reduce.algo2/algo2_tests.ts` => le test devrait échouer

Résultat:
![image](https://user-images.githubusercontent.com/531781/87054943-ff2c3880-c203-11ea-9938-6ee702e5c79b.png)
