### PR TITLE
fix(reduce.algo2): Suite du refactoring de cotisationsdette + simplification des tris

### DIFF
--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -212,13 +212,13 @@ type EntréeCotisation = {
  * Représente un reste à payer (dette) sur cotisation sociale ou autre.
  */
 type EntréeDebit = {
-  periode: { start: Date; end: Date }
+  periode: { start: Date; end: Date } // Periode pour laquelle la cotisation était attendue
   numero_ecart_negatif: number // identifiant du débit pour une période donnée (comme une sorte de numéro de facture)
   numero_historique: number // identifiant d'un remboursement (partiel ou complet) d'un débit
   numero_compte: string // identifiant URSSAF d'établissement (équivalent du SIRET)
-  date_traitement: Date
+  date_traitement: Date // Date de constatation du débit (exemple: remboursement, majoration ou autre modification du montant)
   debit_suivant: DebitHash
-  // le montant est ventilé entre ces trois valeurs, exprimées en euros (€):
+  // le montant est ventilé entre ces deux valeurs, exprimées en euros (€):
   part_ouvriere: number
   part_patronale: number
 }

--- a/dbmongo/js/reduce.algo2/apart.ts
+++ b/dbmongo/js/reduce.algo2/apart.ts
@@ -87,8 +87,8 @@ export function apart(
   Object.keys(apart).forEach((k) => {
     if (apart[k].consommation.length > 0) {
       apart[k].consommation
-        .sort((a, b) =>
-          apconso[a].periode.getTime() >= apconso[b].periode.getTime() ? 1 : 0
+        .sort(
+          (a, b) => apconso[a].periode.getTime() - apconso[b].periode.getTime()
         )
         .forEach((h) => {
           const time = apconso[h].periode.getTime()

--- a/dbmongo/js/reduce.algo2/cotisation.ts
+++ b/dbmongo/js/reduce.algo2/cotisation.ts
@@ -97,4 +97,4 @@ export function cotisation(
     })
 }
 
-// TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts
+/* TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts */

--- a/dbmongo/js/reduce.algo2/cotisation.ts
+++ b/dbmongo/js/reduce.algo2/cotisation.ts
@@ -96,3 +96,5 @@ export function cotisation(
       } else counter = 0
     })
 }
+
+// TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts

--- a/dbmongo/js/reduce.algo2/cotisationsdettes.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes.ts
@@ -2,9 +2,6 @@ import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { dateAddMonth } from "./dateAddMonth"
 import { compareDebit } from "../common/compareDebit"
 
-// Paramètres globaux utilisés par "reduce.algo2"
-declare const date_fin: number
-
 type EcartNegatif = {
   hash: string
   numero_historique: EntréeDebit["numero_historique"]
@@ -43,7 +40,8 @@ export type SortieCotisationsDettes = {
  */
 export function cotisationsdettes(
   v: DonnéesCotisation & DonnéesDebit,
-  periodes: Timestamp[]
+  periodes: Timestamp[],
+  finPériode?: Date // correspond à la variable globale date_fin
 ): Record<number, SortieCotisationsDettes> {
   "use strict"
 
@@ -108,13 +106,13 @@ export function cotisationsdettes(
   const value_dette: Record<string, Dette[]> = {}
   // Pour chaque objet debit:
   // debit_traitement_debut => periode de traitement du débit
-  // debit_traitement_fin => periode de traitement du debit suivant, ou bien date_fin
+  // debit_traitement_fin => periode de traitement du debit suivant, ou bien finPériode
   // Entre ces deux dates, c'est cet objet qui est le plus à jour.
   Object.keys(v.debit).forEach(function (h) {
     const debit = v.debit[h]
 
     const debit_suivant = v.debit[debit.debit_suivant] || {
-      date_traitement: date_fin,
+      date_traitement: finPériode,
     }
 
     //Selon le jour du traitement, cela passe sur la période en cours ou sur la suivante.

--- a/dbmongo/js/reduce.algo2/cotisationsdettes.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes.ts
@@ -214,14 +214,14 @@ export function cotisationsdettes(
       }
     })
 
-    // TODO: apply same logic as above (map+filter) + re-use also in effectif and cotisations
-    const future_month_offsets = [0, 1, 2, 3, 4, 5]
     if (val.montant_part_ouvriere + val.montant_part_patronale > 0) {
-      future_month_offsets.forEach((offset) => {
-        const time_offset = f.dateAddMonth(new Date(time), offset).getTime()
-        sortieCotisationsDettes[time_offset] =
-          sortieCotisationsDettes[time_offset] || {}
-        sortieCotisationsDettes[time_offset].interessante_urssaf = false
+      const futureTimestamps = [0, 1, 2, 3, 4, 5]
+      futureTimestamps.forEach((offset) => {
+        const période = f.dateAddMonth(new Date(time), offset).getTime()
+        sortieCotisationsDettes[période] = {
+          ...sortieCotisationsDettes[période],
+          interessante_urssaf: false,
+        }
       })
     }
   })

--- a/dbmongo/js/reduce.algo2/cotisationsdettes.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes.ts
@@ -216,10 +216,14 @@ export function cotisationsdettes(
 
     if (val.montant_part_ouvriere + val.montant_part_patronale > 0) {
       const futureTimestamps = [0, 1, 2, 3, 4, 5]
-      futureTimestamps.forEach((offset) => {
-        const période = f.dateAddMonth(new Date(time), offset).getTime()
-        sortieCotisationsDettes[période] = {
-          ...sortieCotisationsDettes[période],
+        .map((offset) => ({
+          timestamp: f.dateAddMonth(new Date(time), offset).getTime(),
+        }))
+        .filter(({ timestamp }) => periodes.includes(timestamp))
+
+      futureTimestamps.forEach(({ timestamp }) => {
+        sortieCotisationsDettes[timestamp] = {
+          ...sortieCotisationsDettes[timestamp],
           interessante_urssaf: false,
         }
       })

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -74,32 +74,18 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
 
   const actual = cotisationsdettes(v, periode)
 
-  const expectedMontantPartOuvrière = Array(moisRemboursement).fill(100).concat(
-    Array(dureeEnMois - moisRemboursement).fill(0))
+  const expPartOuvrière = Array(moisRemboursement)
+    .fill(100)
+    .concat(Array(dureeEnMois - moisRemboursement).fill(0))
 
-  const expectedMontantPartPatronale = Array(moisRemboursement).fill(200).concat(
-    Array(dureeEnMois - moisRemboursement).fill(0))
+  const expectedMontantPartPatronale = Array(moisRemboursement)
+    .fill(200)
+    .concat(Array(dureeEnMois - moisRemboursement).fill(0))
 
-  const expectedMontantPartOuvrièrePast1 = décaler(
-    expectedMontantPartOuvrière,
-    1
-  )
-  const expectedMontantPartOuvrièrePast2 = décaler(
-    expectedMontantPartOuvrière,
-    2
-  )
-  const expectedMontantPartOuvrièrePast3 = décaler(
-    expectedMontantPartOuvrière,
-    3
-  )
-  const expectedMontantPartOuvrièrePast6 = décaler(
-    expectedMontantPartOuvrière,
-    6
-  )
-  const expectedMontantPartOuvrièrePast12 = décaler(
-    expectedMontantPartOuvrière,
-    12
-  )
+  const expectedMontantPartOuvrièrePast2 = décaler(expPartOuvrière, 2)
+  const expectedMontantPartOuvrièrePast3 = décaler(expPartOuvrière, 3)
+  const expectedMontantPartOuvrièrePast6 = décaler(expPartOuvrière, 6)
+  const expectedMontantPartOuvrièrePast12 = décaler(expPartOuvrière, 12)
   const expectedMontantPartPatronalePast1 = décaler(
     expectedMontantPartPatronale,
     1
@@ -121,6 +107,14 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
     12
   )
 
+  function dettePassée(
+    tableau: number[],
+    période: number,
+    décalageEnMois: number
+  ): number {
+    return décaler(tableau, décalageEnMois)[période]
+  }
+
   const expectedInteressanteUrssaf = Array(9)
     .fill(false)
     .concat(Array(4).fill(undefined))
@@ -129,9 +123,9 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
     t.log({ période }, actual[dateAddMonth(dateDebut, période).getTime()])
     const expected = {
       interessante_urssaf: expectedInteressanteUrssaf[période],
-      montant_part_ouvriere: expectedMontantPartOuvrière[période],
+      montant_part_ouvriere: expPartOuvrière[période],
       montant_part_patronale: expectedMontantPartPatronale[période],
-      montant_part_ouvriere_past_1: expectedMontantPartOuvrièrePast1[période],
+      montant_part_ouvriere_past_1: dettePassée(expPartOuvrière, période, 1),
       montant_part_patronale_past_1: expectedMontantPartPatronalePast1[période],
       montant_part_ouvriere_past_2: expectedMontantPartOuvrièrePast2[période],
       montant_part_patronale_past_2: expectedMontantPartPatronalePast2[période],

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -1,6 +1,6 @@
 import "../globals"
 import test, { ExecutionContext } from "ava"
-import { cotisationsdettes } from "./cotisationsdettes"
+import { cotisationsdettes, SortieCotisationsDettes } from "./cotisationsdettes"
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { dateAddMonth } from "./dateAddMonth"
 
@@ -53,52 +53,63 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
         numero_ecart_negatif: 1,
         numero_historique: 2,
       },
+      hash2: {
+        periode: { start: dateDebut, end: dateAddMonth(dateDebut, 1) },
+        part_ouvriere: 0,
+        part_patronale: 0,
+        date_traitement: dateAddMonth(dateDebut, 4),
+        debit_suivant: "",
+        numero_compte: "",
+        numero_ecart_negatif: 1,
+        numero_historique: 3,
+      },
     },
   }
 
   const actual = cotisationsdettes(v, periode)
 
   const montants = {
-    montant_part_ouvriere: 0,
-    montant_part_patronale: 0,
+    montant_part_ouvriere: 100,
+    montant_part_patronale: 200,
+    interessante_urssaf: false,
   }
 
   const montantsUnMois = {
     ...montants,
-    montant_part_ouvriere_past_1: 0,
-    montant_part_patronale_past_1: 0,
+    montant_part_ouvriere_past_1: 100,
+    montant_part_patronale_past_1: 200,
   }
 
   const montantsDeuxMois = {
     ...montantsUnMois,
-    montant_part_ouvriere_past_2: 0,
-    montant_part_patronale_past_2: 0,
+    montant_part_ouvriere_past_2: 100,
+    montant_part_patronale_past_2: 200,
   }
 
   const montantsTroisMois = {
     ...montantsDeuxMois,
-    montant_part_ouvriere_past_3: 0,
-    montant_part_patronale_past_3: 0,
+    montant_part_ouvriere_past_3: 100,
+    montant_part_patronale_past_3: 200,
   }
 
   const montantsSixMois = {
     ...montantsTroisMois,
-    montant_part_ouvriere_past_6: 0,
-    montant_part_patronale_past_6: 0,
+    montant_part_ouvriere_past_6: 100,
+    montant_part_patronale_past_6: 200,
   }
 
   const montantsDouzeMois = {
     ...montantsSixMois,
-    montant_part_ouvriere_past_12: 0,
-    montant_part_patronale_past_12: 0,
+    montant_part_ouvriere_past_12: 100,
+    montant_part_patronale_past_12: 200,
   }
 
   t.deepEqual(actual[dateAddMonth(dateDebut, 1).getTime()], montantsUnMois)
   t.deepEqual(actual[dateAddMonth(dateDebut, 2).getTime()], montantsDeuxMois)
   t.deepEqual(actual[dateAddMonth(dateDebut, 3).getTime()], montantsTroisMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 4).getTime()], montantsTroisMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 5).getTime()], montantsTroisMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 6).getTime()], montantsSixMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 4).getTime()], {...montantsTroisMois, montant_part_ouvriere: 0, montant_part_patronale: 0} as SortieCotisationsDettes)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 5).getTime()], {...montantsTroisMois, montant_part_ouvriere: 0, montant_part_patronale: 0} as SortieCotisationsDettes)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 6).getTime()], {...montantsSixMois, montant_part_ouvriere: 0, montant_part_patronale: 0} as SortieCotisationsDettes)
   t.deepEqual(actual[dateAddMonth(dateDebut, 7).getTime()], montantsSixMois)
   t.deepEqual(actual[dateAddMonth(dateDebut, 8).getTime()], montantsSixMois)
   t.deepEqual(actual[dateAddMonth(dateDebut, 9).getTime()], montantsSixMois)

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -166,11 +166,11 @@ test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dett
   t.false(actual[dateAddMonth(dateDebut, 5).getTime()].interessante_urssaf)
 
   t.is(
-    actual[dateAddMonth(dateDebut, 6).getTime()].interessante_urssaf,
-    undefined
+    typeof actual[dateAddMonth(dateDebut, 6).getTime()].interessante_urssaf,
+    "undefined"
   )
   t.is(
-    actual[dateAddMonth(dateDebut, 7).getTime()].interessante_urssaf,
-    undefined
+    typeof actual[dateAddMonth(dateDebut, 7).getTime()].interessante_urssaf,
+    "undefined"
   )
 })

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -1,6 +1,8 @@
 import "../globals"
 import test, { ExecutionContext } from "ava"
 import { cotisationsdettes } from "./cotisationsdettes"
+import { generatePeriodSerie } from "../common/generatePeriodSerie"
+import { dateAddMonth } from "./dateAddMonth"
 
 test("La variable cotisation représente les cotisations sociales dues à une période donnée", (t: ExecutionContext) => {
   const date = new Date("2018-01-01")
@@ -27,4 +29,72 @@ test("La variable cotisation représente les cotisations sociales dues à une p�
   }
 
   t.deepEqual(actual, expected)
+})
+
+test("Le montant de dette d'une période est rapporté dans les périodes suivantes", (t: ExecutionContext) => {
+  const dateDebut = new Date("2018-01-01")
+  const periode = generatePeriodSerie(
+    dateDebut,
+    dateAddMonth(dateDebut, 13)
+  ).map((date) => date.getTime())
+
+  const v: DonnéesCotisation & DonnéesDebit = {
+    cotisation: {
+      hash1: {
+        periode: { start: dateDebut, end: dateAddMonth(dateDebut, 1) },
+        du: 100,
+      },
+    },
+    debit: {},
+  }
+
+  const actual = cotisationsdettes(v, periode)
+
+  const montants = {
+    montant_part_ouvriere: 0,
+    montant_part_patronale: 0,
+  }
+
+  const montantsUnMois = {
+    ...montants,
+    montant_part_ouvriere_past_1: 0,
+    montant_part_patronale_past_1: 0,
+  }
+
+  const montantsDeuxMois = {
+    ...montantsUnMois,
+    montant_part_ouvriere_past_2: 0,
+    montant_part_patronale_past_2: 0,
+  }
+
+  const montantsTroisMois = {
+    ...montantsDeuxMois,
+    montant_part_ouvriere_past_3: 0,
+    montant_part_patronale_past_3: 0,
+  }
+
+  const montantsSixMois = {
+    ...montantsTroisMois,
+    montant_part_ouvriere_past_6: 0,
+    montant_part_patronale_past_6: 0,
+  }
+
+  const montantsDouzeMois = {
+    ...montantsSixMois,
+    montant_part_ouvriere_past_12: 0,
+    montant_part_patronale_past_12: 0,
+  }
+
+  t.deepEqual(actual[dateAddMonth(dateDebut, 1).getTime()], montantsUnMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 2).getTime()], montantsDeuxMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 3).getTime()], montantsTroisMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 4).getTime()], montantsTroisMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 5).getTime()], montantsTroisMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 6).getTime()], montantsSixMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 7).getTime()], montantsSixMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 8).getTime()], montantsSixMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 9).getTime()], montantsSixMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 10).getTime()], montantsSixMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 11).getTime()], montantsSixMois)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 12).getTime()], montantsDouzeMois)
 })

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -31,7 +31,7 @@ test("La variable cotisation représente les cotisations sociales dues à une p�
   t.deepEqual(actual, expected)
 })
 
-test("Le montant de dette d'une période est rapporté dans les périodes suivantes", (t: ExecutionContext) => {
+test(" Le montant de dette d'une période est rapporté dans les périodes suivantes", (t: ExecutionContext) => {
   const dateDebut = new Date("2018-01-01")
   const periode = generatePeriodSerie(
     dateDebut,

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -78,64 +78,38 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
     .fill(100)
     .concat(Array(dureeEnMois - moisRemboursement).fill(0))
 
-  const expectedMontantPartPatronale = Array(moisRemboursement)
+  const expPartPatronale = Array(moisRemboursement)
     .fill(200)
     .concat(Array(dureeEnMois - moisRemboursement).fill(0))
 
-  const expectedMontantPartOuvrièrePast2 = décaler(expPartOuvrière, 2)
-  const expectedMontantPartOuvrièrePast3 = décaler(expPartOuvrière, 3)
-  const expectedMontantPartOuvrièrePast6 = décaler(expPartOuvrière, 6)
-  const expectedMontantPartOuvrièrePast12 = décaler(expPartOuvrière, 12)
-  const expectedMontantPartPatronalePast1 = décaler(
-    expectedMontantPartPatronale,
-    1
-  )
-  const expectedMontantPartPatronalePast2 = décaler(
-    expectedMontantPartPatronale,
-    2
-  )
-  const expectedMontantPartPatronalePast3 = décaler(
-    expectedMontantPartPatronale,
-    3
-  )
-  const expectedMontantPartPatronalePast6 = décaler(
-    expectedMontantPartPatronale,
-    6
-  )
-  const expectedMontantPartPatronalePast12 = décaler(
-    expectedMontantPartPatronale,
-    12
-  )
-
   function dettePassée(
     tableau: number[],
-    période: number,
+    mois: number,
     décalageEnMois: number
   ): number {
-    return décaler(tableau, décalageEnMois)[période]
+    return décaler(tableau, décalageEnMois)[mois]
   }
 
   const expectedInteressanteUrssaf = Array(9)
     .fill(false)
     .concat(Array(4).fill(undefined))
 
-  for (let période = 0; période < 13; ++période) {
-    t.log({ période }, actual[dateAddMonth(dateDebut, période).getTime()])
+  for (let mois = 0; mois < 13; ++mois) {
+    t.log({ période: mois }, actual[dateAddMonth(dateDebut, mois).getTime()])
     const expected = {
-      interessante_urssaf: expectedInteressanteUrssaf[période],
-      montant_part_ouvriere: expPartOuvrière[période],
-      montant_part_patronale: expectedMontantPartPatronale[période],
-      montant_part_ouvriere_past_1: dettePassée(expPartOuvrière, période, 1),
-      montant_part_patronale_past_1: expectedMontantPartPatronalePast1[période],
-      montant_part_ouvriere_past_2: expectedMontantPartOuvrièrePast2[période],
-      montant_part_patronale_past_2: expectedMontantPartPatronalePast2[période],
-      montant_part_ouvriere_past_3: expectedMontantPartOuvrièrePast3[période],
-      montant_part_patronale_past_3: expectedMontantPartPatronalePast3[période],
-      montant_part_ouvriere_past_6: expectedMontantPartOuvrièrePast6[période],
-      montant_part_patronale_past_6: expectedMontantPartPatronalePast6[période],
-      montant_part_ouvriere_past_12: expectedMontantPartOuvrièrePast12[période],
-      montant_part_patronale_past_12:
-        expectedMontantPartPatronalePast12[période],
+      interessante_urssaf: expectedInteressanteUrssaf[mois],
+      montant_part_ouvriere: expPartOuvrière[mois],
+      montant_part_patronale: expPartPatronale[mois],
+      montant_part_ouvriere_past_1: dettePassée(expPartOuvrière, mois, 1),
+      montant_part_patronale_past_1: dettePassée(expPartPatronale, mois, 1),
+      montant_part_ouvriere_past_2: dettePassée(expPartOuvrière, mois, 2),
+      montant_part_patronale_past_2: dettePassée(expPartPatronale, mois, 2),
+      montant_part_ouvriere_past_3: dettePassée(expPartOuvrière, mois, 3),
+      montant_part_patronale_past_3: dettePassée(expPartPatronale, mois, 3),
+      montant_part_ouvriere_past_6: dettePassée(expPartOuvrière, mois, 6),
+      montant_part_patronale_past_6: dettePassée(expPartPatronale, mois, 6),
+      montant_part_ouvriere_past_12: dettePassée(expPartOuvrière, mois, 12),
+      montant_part_patronale_past_12: dettePassée(expPartPatronale, mois, 12),
     }
     Object.keys(expected).forEach((p) => {
       const prop = p as keyof typeof expected
@@ -143,7 +117,7 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
         delete expected[prop]
       }
     })
-    t.deepEqual(actual[dateAddMonth(dateDebut, période).getTime()], expected)
+    t.deepEqual(actual[dateAddMonth(dateDebut, mois).getTime()], expected)
   }
 })
 

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -4,14 +4,6 @@ import { cotisationsdettes } from "./cotisationsdettes"
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { dateAddMonth } from "./dateAddMonth"
 
-function dettePassée(
-  tableau: number[],
-  mois: number,
-  décalageEnMois: number
-): number | undefined {
-  return tableau[mois - décalageEnMois]
-}
-
 test("La variable cotisation représente les cotisations sociales dues à une période donnée", (t: ExecutionContext) => {
   const date = new Date("2018-01-01")
   const datePlusUnMois = new Date("2018-02-01")
@@ -96,16 +88,16 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
       interessante_urssaf: expectedInteressanteUrssaf[mois],
       montant_part_ouvriere: expPartOuvrière[mois],
       montant_part_patronale: expPartPatronale[mois],
-      montant_part_ouvriere_past_1: dettePassée(expPartOuvrière, mois, 1),
-      montant_part_patronale_past_1: dettePassée(expPartPatronale, mois, 1),
-      montant_part_ouvriere_past_2: dettePassée(expPartOuvrière, mois, 2),
-      montant_part_patronale_past_2: dettePassée(expPartPatronale, mois, 2),
-      montant_part_ouvriere_past_3: dettePassée(expPartOuvrière, mois, 3),
-      montant_part_patronale_past_3: dettePassée(expPartPatronale, mois, 3),
-      montant_part_ouvriere_past_6: dettePassée(expPartOuvrière, mois, 6),
-      montant_part_patronale_past_6: dettePassée(expPartPatronale, mois, 6),
-      montant_part_ouvriere_past_12: dettePassée(expPartOuvrière, mois, 12),
-      montant_part_patronale_past_12: dettePassée(expPartPatronale, mois, 12),
+      montant_part_ouvriere_past_1: expPartOuvrière[mois - 1],
+      montant_part_patronale_past_1: expPartPatronale[mois - 1],
+      montant_part_ouvriere_past_2: expPartOuvrière[mois - 2],
+      montant_part_patronale_past_2: expPartPatronale[mois - 2],
+      montant_part_ouvriere_past_3: expPartOuvrière[mois - 3],
+      montant_part_patronale_past_3: expPartPatronale[mois - 3],
+      montant_part_ouvriere_past_6: expPartOuvrière[mois - 6],
+      montant_part_patronale_past_6: expPartPatronale[mois - 6],
+      montant_part_ouvriere_past_12: expPartOuvrière[mois - 12],
+      montant_part_patronale_past_12: expPartPatronale[mois - 12],
     }
     Object.keys(expected).forEach((p) => {
       const prop = p as keyof typeof expected

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -1,6 +1,6 @@
 import "../globals"
 import test, { ExecutionContext } from "ava"
-import { cotisationsdettes, SortieCotisationsDettes } from "./cotisationsdettes"
+import { cotisationsdettes } from "./cotisationsdettes"
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { dateAddMonth } from "./dateAddMonth"
 
@@ -67,42 +67,6 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
   }
 
   const actual = cotisationsdettes(v, periode)
-
-  const montants = {
-    montant_part_ouvriere: 100,
-    montant_part_patronale: 200,
-    interessante_urssaf: false,
-  }
-
-  const montantsUnMois = {
-    ...montants,
-    montant_part_ouvriere_past_1: 100,
-    montant_part_patronale_past_1: 200,
-  }
-
-  const montantsDeuxMois = {
-    ...montantsUnMois,
-    montant_part_ouvriere_past_2: 100,
-    montant_part_patronale_past_2: 200,
-  }
-
-  const montantsTroisMois = {
-    ...montantsDeuxMois,
-    montant_part_ouvriere_past_3: 100,
-    montant_part_patronale_past_3: 200,
-  }
-
-  const montantsSixMois = {
-    ...montantsTroisMois,
-    montant_part_ouvriere_past_6: 100,
-    montant_part_patronale_past_6: 200,
-  }
-
-  const montantsDouzeMois = {
-    ...montantsSixMois,
-    montant_part_ouvriere_past_12: 100,
-    montant_part_patronale_past_12: 200,
-  }
 
   const expectedMontantPartOuvrière = [
     100,
@@ -212,30 +176,30 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
     t.deepEqual(actual[dateAddMonth(dateDebut, période).getTime()], expected)
   }
 
-  t.deepEqual(actual[dateAddMonth(dateDebut, 1).getTime()], montantsUnMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 2).getTime()], montantsDeuxMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 3).getTime()], montantsTroisMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 4).getTime()], {
-    ...montantsTroisMois,
-    montant_part_ouvriere: 0,
-    montant_part_patronale: 0,
-  } as SortieCotisationsDettes)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 5).getTime()], {
-    ...montantsTroisMois,
-    montant_part_ouvriere: 0,
-    montant_part_patronale: 0,
-  } as SortieCotisationsDettes)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 6).getTime()], {
-    ...montantsSixMois,
-    montant_part_ouvriere: 0,
-    montant_part_patronale: 0,
-  } as SortieCotisationsDettes)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 7).getTime()], montantsSixMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 8).getTime()], montantsSixMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 9).getTime()], montantsSixMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 10).getTime()], montantsSixMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 11).getTime()], montantsSixMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 12).getTime()], montantsDouzeMois)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 1).getTime()], montantsUnMois)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 2).getTime()], montantsDeuxMois)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 3).getTime()], montantsTroisMois)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 4).getTime()], {
+  //   ...montantsTroisMois,
+  //   montant_part_ouvriere: 0,
+  //   montant_part_patronale: 0,
+  // } as SortieCotisationsDettes)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 5).getTime()], {
+  //   ...montantsTroisMois,
+  //   montant_part_ouvriere: 0,
+  //   montant_part_patronale: 0,
+  // } as SortieCotisationsDettes)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 6).getTime()], {
+  //   ...montantsSixMois,
+  //   montant_part_ouvriere: 0,
+  //   montant_part_patronale: 0,
+  // } as SortieCotisationsDettes)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 7).getTime()], montantsSixMois)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 8).getTime()], montantsSixMois)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 9).getTime()], montantsSixMois)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 10).getTime()], montantsSixMois)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 11).getTime()], montantsSixMois)
+  // t.deepEqual(actual[dateAddMonth(dateDebut, 12).getTime()], montantsDouzeMois)
 })
 
 test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dette) sur les 6 derniers mois", (t: ExecutionContext) => {

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -31,21 +31,29 @@ test("La variable cotisation représente les cotisations sociales dues à une p�
   t.deepEqual(actual, expected)
 })
 
-test("Le montant de dette d'une période est rapporté dans les périodes suivantes", (t: ExecutionContext) => {
+test.only("Le montant de dette d'une période est reporté dans les périodes suivantes", (t: ExecutionContext) => {
   const dateDebut = new Date("2018-01-01")
-  const periode = generatePeriodSerie(
-    dateDebut,
-    dateAddMonth(dateDebut, 13)
-  ).map((date) => date.getTime())
+  const dateFin = dateAddMonth(dateDebut, 13)
+  const periode = generatePeriodSerie(dateDebut, dateFin).map((date) =>
+    date.getTime()
+  )
+
+  ;(globalThis as any).date_fin = dateFin // TODO: transformer ce parametre en parametre local de fonction
 
   const v: DonnéesCotisation & DonnéesDebit = {
-    cotisation: {
+    cotisation: {},
+    debit: {
       hash1: {
         periode: { start: dateDebut, end: dateAddMonth(dateDebut, 1) },
-        du: 100,
+        part_ouvriere: 100,
+        part_patronale: 200,
+        date_traitement: dateDebut,
+        debit_suivant: "",
+        numero_compte: "",
+        numero_ecart_negatif: 1,
+        numero_historique: 2,
       },
     },
-    debit: {},
   }
 
   const actual = cotisationsdettes(v, periode)

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -104,12 +104,132 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
     montant_part_patronale_past_12: 200,
   }
 
+  const expectedMontantPartOuvrière = [
+    100,
+    100,
+    100,
+    100,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  ]
+
+  const expectedMontantPartPatronale = [
+    200,
+    200,
+    200,
+    200,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+  ]
+
+  function décaler(tableau: number[], décalage: number): number[] {
+    return Array(décalage).fill(undefined).concat(tableau).slice(0, -décalage)
+  }
+
+  const expectedMontantPartOuvrièrePast1 = décaler(
+    expectedMontantPartOuvrière,
+    1
+  )
+  const expectedMontantPartOuvrièrePast2 = décaler(
+    expectedMontantPartOuvrière,
+    2
+  )
+  const expectedMontantPartOuvrièrePast3 = décaler(
+    expectedMontantPartOuvrière,
+    3
+  )
+  const expectedMontantPartOuvrièrePast6 = décaler(
+    expectedMontantPartOuvrière,
+    6
+  )
+  const expectedMontantPartOuvrièrePast12 = décaler(
+    expectedMontantPartOuvrière,
+    12
+  )
+  const expectedMontantPartPatronalePast1 = décaler(
+    expectedMontantPartPatronale,
+    1
+  )
+  const expectedMontantPartPatronalePast2 = décaler(
+    expectedMontantPartPatronale,
+    2
+  )
+  const expectedMontantPartPatronalePast3 = décaler(
+    expectedMontantPartPatronale,
+    3
+  )
+  const expectedMontantPartPatronalePast6 = décaler(
+    expectedMontantPartPatronale,
+    6
+  )
+  const expectedMontantPartPatronalePast12 = décaler(
+    expectedMontantPartPatronale,
+    12
+  )
+
+  const expectedInteressanteUrssaf = Array(9)
+    .fill(false)
+    .concat(Array(4).fill(undefined))
+
+  for (let période = 0; période < 13; ++période) {
+    t.log({ période }, actual[dateAddMonth(dateDebut, période).getTime()])
+    const expected = {
+      interessante_urssaf: expectedInteressanteUrssaf[période],
+      montant_part_ouvriere: expectedMontantPartOuvrière[période],
+      montant_part_patronale: expectedMontantPartPatronale[période],
+      montant_part_ouvriere_past_1: expectedMontantPartOuvrièrePast1[période],
+      montant_part_patronale_past_1: expectedMontantPartPatronalePast1[période],
+      montant_part_ouvriere_past_2: expectedMontantPartOuvrièrePast2[période],
+      montant_part_patronale_past_2: expectedMontantPartPatronalePast2[période],
+      montant_part_ouvriere_past_3: expectedMontantPartOuvrièrePast3[période],
+      montant_part_patronale_past_3: expectedMontantPartPatronalePast3[période],
+      montant_part_ouvriere_past_6: expectedMontantPartOuvrièrePast6[période],
+      montant_part_patronale_past_6: expectedMontantPartPatronalePast6[période],
+      montant_part_ouvriere_past_12: expectedMontantPartOuvrièrePast12[période],
+      montant_part_patronale_past_12:
+        expectedMontantPartPatronalePast12[période],
+    }
+    Object.keys(expected).forEach((p) => {
+      const prop = p as keyof typeof expected
+      if (typeof expected[prop] === "undefined") {
+        delete expected[prop]
+      }
+    })
+    t.deepEqual(actual[dateAddMonth(dateDebut, période).getTime()], expected)
+  }
+
   t.deepEqual(actual[dateAddMonth(dateDebut, 1).getTime()], montantsUnMois)
   t.deepEqual(actual[dateAddMonth(dateDebut, 2).getTime()], montantsDeuxMois)
   t.deepEqual(actual[dateAddMonth(dateDebut, 3).getTime()], montantsTroisMois)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 4).getTime()], {...montantsTroisMois, montant_part_ouvriere: 0, montant_part_patronale: 0} as SortieCotisationsDettes)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 5).getTime()], {...montantsTroisMois, montant_part_ouvriere: 0, montant_part_patronale: 0} as SortieCotisationsDettes)
-  t.deepEqual(actual[dateAddMonth(dateDebut, 6).getTime()], {...montantsSixMois, montant_part_ouvriere: 0, montant_part_patronale: 0} as SortieCotisationsDettes)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 4).getTime()], {
+    ...montantsTroisMois,
+    montant_part_ouvriere: 0,
+    montant_part_patronale: 0,
+  } as SortieCotisationsDettes)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 5).getTime()], {
+    ...montantsTroisMois,
+    montant_part_ouvriere: 0,
+    montant_part_patronale: 0,
+  } as SortieCotisationsDettes)
+  t.deepEqual(actual[dateAddMonth(dateDebut, 6).getTime()], {
+    ...montantsSixMois,
+    montant_part_ouvriere: 0,
+    montant_part_patronale: 0,
+  } as SortieCotisationsDettes)
   t.deepEqual(actual[dateAddMonth(dateDebut, 7).getTime()], montantsSixMois)
   t.deepEqual(actual[dateAddMonth(dateDebut, 8).getTime()], montantsSixMois)
   t.deepEqual(actual[dateAddMonth(dateDebut, 9).getTime()], montantsSixMois)

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -4,8 +4,12 @@ import { cotisationsdettes } from "./cotisationsdettes"
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { dateAddMonth } from "./dateAddMonth"
 
-function décaler(tableau: number[], décalage: number): number[] {
-  return Array(décalage).fill(undefined).concat(tableau).slice(0, -décalage)
+function dettePassée(
+  tableau: number[],
+  mois: number,
+  décalageEnMois: number
+): number | undefined {
+  return tableau[mois - décalageEnMois]
 }
 
 test("La variable cotisation représente les cotisations sociales dues à une période donnée", (t: ExecutionContext) => {
@@ -81,14 +85,6 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
   const expPartPatronale = Array(moisRemboursement)
     .fill(200)
     .concat(Array(dureeEnMois - moisRemboursement).fill(0))
-
-  function dettePassée(
-    tableau: number[],
-    mois: number,
-    décalageEnMois: number
-  ): number {
-    return décaler(tableau, décalageEnMois)[mois]
-  }
 
   const expectedInteressanteUrssaf = Array(9)
     .fill(false)

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -31,7 +31,7 @@ test("La variable cotisation représente les cotisations sociales dues à une p�
   t.deepEqual(actual, expected)
 })
 
-test(" Le montant de dette d'une période est rapporté dans les périodes suivantes", (t: ExecutionContext) => {
+test("Le montant de dette d'une période est rapporté dans les périodes suivantes", (t: ExecutionContext) => {
   const dateDebut = new Date("2018-01-01")
   const periode = generatePeriodSerie(
     dateDebut,

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -42,13 +42,15 @@ test("Le montant de dette d'une période est reporté dans les périodes suivant
   ;(globalThis as any).date_fin = dateFin // TODO: transformer ce parametre en parametre local de fonction
 
   const moisRemboursement = 4
+  const partOuvrière = 100
+  const partPatronale = 200
   const v: DonnéesCotisation & DonnéesDebit = {
     cotisation: {},
     debit: {
       hash1: {
         periode: { start: dateDebut, end: dateAddMonth(dateDebut, 1) },
-        part_ouvriere: 100,
-        part_patronale: 200,
+        part_ouvriere: partOuvrière,
+        part_patronale: partPatronale,
         date_traitement: dateDebut,
         debit_suivant: "",
         numero_compte: "",
@@ -71,11 +73,11 @@ test("Le montant de dette d'une période est reporté dans les périodes suivant
   const actual = cotisationsdettes(v, periode)
 
   const expPartOuvrière = Array(moisRemboursement)
-    .fill(100)
+    .fill(partOuvrière)
     .concat(Array(dureeEnMois - moisRemboursement).fill(0))
 
   const expPartPatronale = Array(moisRemboursement)
-    .fill(200)
+    .fill(partPatronale)
     .concat(Array(dureeEnMois - moisRemboursement).fill(0))
 
   const expectedInteressanteUrssaf = Array(9)

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -1,23 +1,22 @@
 import "../globals"
 import test, { ExecutionContext } from "ava"
-import { cotisationsdettes, SortieCotisationsDettes } from "./cotisationsdettes"
+import { cotisationsdettes } from "./cotisationsdettes"
 
 test("La variable cotisation représente les cotisations sociales dues à une période donnée", (t: ExecutionContext) => {
   const date = new Date("2018-01-01")
   const datePlusUnMois = new Date("2018-02-01")
-  const periode = { start: date, end: datePlusUnMois }
+
   const v: DonnéesCotisation & DonnéesDebit = {
     cotisation: {
       hash1: {
-        periode,
+        periode: { start: date, end: datePlusUnMois },
         du: 100,
       },
     },
     debit: {},
   }
-  const actual: Record<number, SortieCotisationsDettes> = cotisationsdettes(v, [
-    date.getTime(),
-  ])
+
+  const actual = cotisationsdettes(v, [date.getTime()])
 
   const expected = {
     [date.getTime()]: {

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -31,7 +31,7 @@ test("La variable cotisation représente les cotisations sociales dues à une p�
   t.deepEqual(actual, expected)
 })
 
-test.only("Le montant de dette d'une période est reporté dans les périodes suivantes", (t: ExecutionContext) => {
+test("Le montant de dette d'une période est reporté dans les périodes suivantes", (t: ExecutionContext) => {
   const dureeEnMois = 13
   const dateDebut = new Date("2018-01-01")
   const dateFin = dateAddMonth(dateDebut, dureeEnMois)
@@ -109,6 +109,7 @@ test.only("Le montant de dette d'une période est reporté dans les périodes su
   }
 })
 
+// TODO: comportement surprenant avec debut_suivant, le test passe a moitié avec valeur non nulle mais echoue avec chaine vide
 test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dette) sur les 6 derniers mois", (t: ExecutionContext) => {
   const dateDebut = new Date("2018-01-01")
   const periode = generatePeriodSerie(
@@ -126,8 +127,8 @@ test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dett
       },
     },
     debit: {
-      // tentative de répartition du montant de la dette (part ouvrière: 100%)
-      [dateDebut.getTime()]: {
+      // dette initiale
+      hash1: {
         periode: {
           start: dateDebut,
           end: dateAddMonth(dateDebut, 1),
@@ -140,14 +141,14 @@ test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dett
         part_ouvriere: 60,
         part_patronale: 0,
       },
-      // tentative de remboursement la dette
-      [dateAddMonth(dateDebut, 1).getTime()]: {
+      // remboursement la dette
+      hash2: {
         periode: {
-          start: dateAddMonth(dateDebut, 1),
-          end: dateAddMonth(dateDebut, 2),
+          start: dateDebut,
+          end: dateAddMonth(dateDebut, 1),
         },
         numero_ecart_negatif: 1,
-        numero_historique: 2,
+        numero_historique: 3,
         numero_compte: "3",
         date_traitement: dateAddMonth(dateDebut, 1),
         debit_suivant: "",
@@ -155,26 +156,20 @@ test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dett
         part_patronale: 0,
       },
     },
-    /*
-    dettes: {
-      hash1: {
-        periode: dateDebut,
-        part_ouvriere: 30,
-        part_patronale: 0,
-      },
-    },
-    */
   }
 
   const actual = cotisationsdettes(v, periode)
 
   t.log(actual)
 
-  t.true(actual[dateAddMonth(dateDebut, 7).getTime()].interessante_urssaf)
-
   for (const month of [0, 1, 2, 3, 4, 5, 6]) {
     t.false(
       actual[dateAddMonth(dateDebut, month).getTime()].interessante_urssaf
     )
   }
+
+  t.is(
+    actual[dateAddMonth(dateDebut, 7).getTime()].interessante_urssaf,
+    undefined
+  )
 })

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -45,8 +45,6 @@ test("Le montant de dette d'une période est reporté dans les périodes suivant
     date.getTime()
   )
 
-  ;(globalThis as any).date_fin = dateFin // TODO: transformer ce parametre en parametre local de fonction
-
   const moisRemboursement = 4
   const partOuvrière = 100
   const partPatronale = 200
@@ -76,7 +74,7 @@ test("Le montant de dette d'une période est reporté dans les périodes suivant
     },
   }
 
-  const output = cotisationsdettes(v, periode)
+  const output = cotisationsdettes(v, periode, dateFin)
 
   const expPartOuvrière = Array(moisRemboursement)
     .fill(partOuvrière)
@@ -110,12 +108,10 @@ test("Le montant de dette d'une période est reporté dans les périodes suivant
 
 test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dette) sur les 6 derniers mois", (t: ExecutionContext) => {
   const dateDebut = new Date("2018-01-01")
-  const periode = generatePeriodSerie(
-    dateDebut,
-    dateAddMonth(dateDebut, 8)
-  ).map((date) => date.getTime())
-
-  ;(globalThis as any).date_fin = dateAddMonth(dateDebut, 8) // utilisé par cotisationsdettes lors du traitement des débits
+  const dateFin = dateAddMonth(dateDebut, 8) // utilisé par cotisationsdettes lors du traitement des débits
+  const periode = generatePeriodSerie(dateDebut, dateFin).map((date) =>
+    date.getTime()
+  )
 
   const v = {
     cotisation: {
@@ -156,7 +152,7 @@ test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dett
     },
   }
 
-  const actual = cotisationsdettes(v, periode)
+  const actual = cotisationsdettes(v, periode, dateFin)
 
   t.false(actual[dateAddMonth(dateDebut, 0).getTime()].interessante_urssaf)
   t.false(actual[dateAddMonth(dateDebut, 1).getTime()].interessante_urssaf)

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -111,7 +111,6 @@ test("Le montant de dette d'une période est reporté dans les périodes suivant
   }
 })
 
-// TODO: comportement surprenant avec debut_suivant, le test passe a moitié avec valeur non nulle mais echoue avec chaine vide
 test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dette) sur les 6 derniers mois", (t: ExecutionContext) => {
   const dateDebut = new Date("2018-01-01")
   const periode = generatePeriodSerie(
@@ -130,7 +129,7 @@ test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dett
     },
     debit: {
       // dette initiale
-      hash1: {
+      hashDetteInitiale: {
         periode: {
           start: dateDebut,
           end: dateAddMonth(dateDebut, 1),
@@ -139,12 +138,12 @@ test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dett
         numero_historique: 2,
         numero_compte: "3",
         date_traitement: dateDebut,
-        debit_suivant: dateAddMonth(dateDebut, 1).toString(),
+        debit_suivant: "hashRemboursement",
         part_ouvriere: 60,
         part_patronale: 0,
       },
       // remboursement la dette
-      hash2: {
+      hashRemboursement: {
         periode: {
           start: dateDebut,
           end: dateAddMonth(dateDebut, 1),

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -129,7 +129,7 @@ test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dett
         },
         numero_ecart_negatif: 1,
         numero_historique: 2,
-        numero_compte: "3",
+        numero_compte: "",
         date_traitement: dateDebut,
         debit_suivant: "hashRemboursement",
         part_ouvriere: 60,
@@ -141,9 +141,9 @@ test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dett
           start: dateDebut,
           end: dateAddMonth(dateDebut, 1),
         },
-        numero_ecart_negatif: 1,
-        numero_historique: 3,
-        numero_compte: "3",
+        numero_ecart_negatif: 1, // même valeur que pour le débit précédent
+        numero_historique: 3, // incrémentation depuis le débit précédent
+        numero_compte: "",
         date_traitement: dateAddMonth(dateDebut, 1),
         debit_suivant: "",
         part_ouvriere: 0,

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -161,14 +161,17 @@ test("interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dett
 
   const actual = cotisationsdettes(v, periode)
 
-  t.log(actual)
+  t.false(actual[dateAddMonth(dateDebut, 0).getTime()].interessante_urssaf)
+  t.false(actual[dateAddMonth(dateDebut, 1).getTime()].interessante_urssaf)
+  t.false(actual[dateAddMonth(dateDebut, 2).getTime()].interessante_urssaf)
+  t.false(actual[dateAddMonth(dateDebut, 3).getTime()].interessante_urssaf)
+  t.false(actual[dateAddMonth(dateDebut, 4).getTime()].interessante_urssaf)
+  t.false(actual[dateAddMonth(dateDebut, 5).getTime()].interessante_urssaf)
 
-  for (const month of [0, 1, 2, 3, 4, 5, 6]) {
-    t.false(
-      actual[dateAddMonth(dateDebut, month).getTime()].interessante_urssaf
+  t.is(
+    actual[dateAddMonth(dateDebut, 6).getTime()].interessante_urssaf,
+    undefined
     )
-  }
-
   t.is(
     actual[dateAddMonth(dateDebut, 7).getTime()].interessante_urssaf,
     undefined

--- a/dbmongo/js/reduce.algo2/dealWithProcols.ts
+++ b/dbmongo/js/reduce.algo2/dealWithProcols.ts
@@ -42,7 +42,7 @@ export function dealWithProcols(
       return events
     }, [] as OutputEvent[])
     .sort((a, b) => {
-      return a.date_proc_col.getTime() > b.date_proc_col.getTime() ? 1 : 0
+      return a.date_proc_col.getTime() - b.date_proc_col.getTime()
     })
 
   codes.forEach((event) => {

--- a/dbmongo/js/reduce.algo2/effectifs.ts
+++ b/dbmongo/js/reduce.algo2/effectifs.ts
@@ -86,3 +86,5 @@ export function effectifs(
   })
   return output_effectif
 }
+
+// TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts

--- a/dbmongo/js/reduce.algo2/effectifs.ts
+++ b/dbmongo/js/reduce.algo2/effectifs.ts
@@ -87,4 +87,4 @@ export function effectifs(
   return output_effectif
 }
 
-// TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts
+/* TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts */

--- a/dbmongo/js/reduce.algo2/effectifs.ts
+++ b/dbmongo/js/reduce.algo2/effectifs.ts
@@ -39,7 +39,7 @@ export function effectifs(
   const last_period_offset = f.dateAddMonth(last_period, offset_effectif + 1)
   // 2- Cette période est-elle disponible ?
 
-  const available = map_effectif[last_period_offset.getTime()] ? 1 : 0
+  const available = last_period_offset.getTime() in map_effectif
 
   //pour chaque periode (elles sont triees dans l'ordre croissant)
   periodes.reduce((accu, time) => {

--- a/dbmongo/js/reduce.algo2/lookAhead.ts
+++ b/dbmongo/js/reduce.algo2/lookAhead.ts
@@ -14,20 +14,12 @@ export function lookAhead(
   // demander: que va-t-il se passer) ou dans le future (past = false on
   // pourra se demander que s'est-il passé
 
-  /* eslint-disable */
-  var sorting_fun = function (a: any, b: any): any {
-    return a >= b ? 1 : -1 // TODO: normally, a sorting comparator should return a number, possibly including zero. => the TS version of the test has failed until we added `? 1 : -1` here
-  }
-  if (past) {
-    sorting_fun = function (a: any, b: any): any {
-      return a <= b ? 1 : -1 // TODO: normally, a sorting comparator should return a number, possibly including zero. => the TS version of the test has failed until we added `? 1 : -1` here
-    }
-  }
-  /* eslint-enable */
+  const chronologic = (a: string, b: string) => (a > b ? 1 : -1)
+  const reverse = (a: string, b: string) => (b > a ? 1 : -1)
 
   let counter = -1
   const output = Object.keys(data)
-    .sort(sorting_fun)
+    .sort(past ? reverse : chronologic)
     .reduce(function (m, period) {
       // Si on a déjà détecté quelque chose, on compte le nombre de périodes
       if (counter >= 0) counter = counter + 1

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -73,7 +73,7 @@ export function map(this: {
 
     // Les periodes qui nous interessent, triées
     const periodes = Object.keys(output_indexed)
-      .sort((a, b) => (a >= b ? 1 : 0))
+      .sort()
       .map((timestamp) => parseInt(timestamp))
 
     if (includes["apart"] || includes["all"]) {
@@ -210,7 +210,7 @@ export function map(this: {
       }
 
       const periodes = Object.keys(output_indexed)
-        .sort((a, b) => (a >= b ? 1 : 0))
+        .sort()
         .map((timestamp) => parseInt(timestamp))
       if (v.effectif_ent) {
         const output_effectif_ent = f.effectifs(

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -27,6 +27,7 @@ declare const naf: NAF
 declare const actual_batch: BatchKey
 declare const includes: Record<"all" | "apart", boolean>
 declare const serie_periode: Date[]
+declare const date_fin: Date
 
 /**
  * `map()` est appelée pour chaque entreprise/établissement.
@@ -123,7 +124,8 @@ export function map(this: {
       if (v.cotisation && v.debit) {
         output_cotisationsdettes = f.cotisationsdettes(
           v as DonnéesCotisation & DonnéesDebit,
-          periodes
+          periodes,
+          date_fin
         )
         f.add(output_cotisationsdettes, output_indexed)
       }

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1495,7 +1495,7 @@ function delais(v, debitParPériode, intervalleTraitement) {
     const last_period = new Date(periodes[periodes.length - 1]);
     const last_period_offset = f.dateAddMonth(last_period, offset_effectif + 1);
     // 2- Cette période est-elle disponible ?
-    const available = map_effectif[last_period_offset.getTime()] ? 1 : 0;
+    const available = last_period_offset.getTime() in map_effectif;
     //pour chaque periode (elles sont triees dans l'ordre croissant)
     periodes.reduce((accu, time) => {
         // si disponible on reporte l'effectif tel quel, sinon, on recupère l'accu

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1791,7 +1791,7 @@ function map() {
         output_indexed,] = f.outputs(v, serie_periode);
         // Les periodes qui nous interessent, triées
         const periodes = Object.keys(output_indexed)
-            .sort((a, b) => (a >= b ? 1 : 0))
+            .sort()
             .map((timestamp) => parseInt(timestamp));
         if (includes["apart"] || includes["all"]) {
             if (v.apconso && v.apdemande) {
@@ -1884,7 +1884,7 @@ function map() {
                 f.sirene_ul(v, output_array);
             }
             const periodes = Object.keys(output_indexed)
-                .sort((a, b) => (a >= b ? 1 : 0))
+                .sort()
                 .map((timestamp) => parseInt(timestamp));
             if (v.effectif_ent) {
                 const output_effectif_ent = f.effectifs(v.effectif_ent, periodes, "effectif_ent");

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1229,7 +1229,8 @@ db.getCollection("Features").createIndex({
         else
             counter = 0;
     });
-}`,
+}
+// TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts`,
 "cotisationsdettes": `/**
  * Calcule les variables liées aux cotisations sociales et dettes sur ces
  * cotisations.
@@ -1357,14 +1358,11 @@ function cotisationsdettes(v, periodes, finPériode // correspond à la variable
         futureTimestamps.forEach(({ offset, timestamp }) => {
             sortieCotisationsDettes[timestamp] = Object.assign(Object.assign({}, sortieCotisationsDettes[timestamp]), { ["montant_part_ouvriere_past_" + offset]: val.montant_part_ouvriere, ["montant_part_patronale_past_" + offset]: val.montant_part_patronale });
         });
-        // TODO: apply same logic as above (map+filter) + re-use also in effectif and cotisations
-        const future_month_offsets = [0, 1, 2, 3, 4, 5];
         if (val.montant_part_ouvriere + val.montant_part_patronale > 0) {
-            future_month_offsets.forEach((offset) => {
-                const time_offset = f.dateAddMonth(new Date(time), offset).getTime();
-                sortieCotisationsDettes[time_offset] =
-                    sortieCotisationsDettes[time_offset] || {};
-                sortieCotisationsDettes[time_offset].interessante_urssaf = false;
+            const futureTimestamps = [0, 1, 2, 3, 4, 5];
+            futureTimestamps.forEach((offset) => {
+                const période = f.dateAddMonth(new Date(time), offset).getTime();
+                sortieCotisationsDettes[période] = Object.assign(Object.assign({}, sortieCotisationsDettes[période]), { interessante_urssaf: false });
             });
         }
     });
@@ -1531,7 +1529,8 @@ function delais(v, debitParPériode, intervalleTraitement) {
         }
     });
     return output_effectif;
-}`,
+}
+// TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts`,
 "finalize": `function finalize(k, v) {
     "use strict";
     const maxBsonSize = 16777216;

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1234,7 +1234,8 @@ db.getCollection("Features").createIndex({
  * Calcule les variables liées aux cotisations sociales et dettes sur ces
  * cotisations.
  */
-function cotisationsdettes(v, periodes) {
+function cotisationsdettes(v, periodes, finPériode // correspond à la variable globale date_fin
+) {
     "use strict";
 
     // Tous les débits traitées après ce jour du mois sont reportées à la période suivante
@@ -1284,12 +1285,12 @@ function cotisationsdettes(v, periodes) {
     const value_dette = {};
     // Pour chaque objet debit:
     // debit_traitement_debut => periode de traitement du débit
-    // debit_traitement_fin => periode de traitement du debit suivant, ou bien date_fin
+    // debit_traitement_fin => periode de traitement du debit suivant, ou bien finPériode
     // Entre ces deux dates, c'est cet objet qui est le plus à jour.
     Object.keys(v.debit).forEach(function (h) {
         const debit = v.debit[h];
         const debit_suivant = v.debit[debit.debit_suivant] || {
-            date_traitement: date_fin,
+            date_traitement: finPériode,
         };
         //Selon le jour du traitement, cela passe sur la période en cours ou sur la suivante.
         const jour_traitement = debit.date_traitement.getUTCDate();
@@ -1819,7 +1820,7 @@ function map() {
             }
             let output_cotisationsdettes;
             if (v.cotisation && v.debit) {
-                output_cotisationsdettes = f.cotisationsdettes(v, periodes);
+                output_cotisationsdettes = f.cotisationsdettes(v, periodes, date_fin);
                 f.add(output_cotisationsdettes, output_indexed);
             }
             if (v.delai) {

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1359,10 +1359,13 @@ function cotisationsdettes(v, periodes, finPériode // correspond à la variable
             sortieCotisationsDettes[timestamp] = Object.assign(Object.assign({}, sortieCotisationsDettes[timestamp]), { ["montant_part_ouvriere_past_" + offset]: val.montant_part_ouvriere, ["montant_part_patronale_past_" + offset]: val.montant_part_patronale });
         });
         if (val.montant_part_ouvriere + val.montant_part_patronale > 0) {
-            const futureTimestamps = [0, 1, 2, 3, 4, 5];
-            futureTimestamps.forEach((offset) => {
-                const période = f.dateAddMonth(new Date(time), offset).getTime();
-                sortieCotisationsDettes[période] = Object.assign(Object.assign({}, sortieCotisationsDettes[période]), { interessante_urssaf: false });
+            const futureTimestamps = [0, 1, 2, 3, 4, 5]
+                .map((offset) => ({
+                timestamp: f.dateAddMonth(new Date(time), offset).getTime(),
+            }))
+                .filter(({ timestamp }) => periodes.includes(timestamp));
+            futureTimestamps.forEach(({ timestamp }) => {
+                sortieCotisationsDettes[timestamp] = Object.assign(Object.assign({}, sortieCotisationsDettes[timestamp]), { interessante_urssaf: false });
             });
         }
     });

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1078,7 +1078,7 @@ db.getCollection("Features").createIndex({
     Object.keys(apart).forEach((k) => {
         if (apart[k].consommation.length > 0) {
             apart[k].consommation
-                .sort((a, b) => apconso[a].periode.getTime() >= apconso[b].periode.getTime() ? 1 : 0)
+                .sort((a, b) => apconso[a].periode.getTime() - apconso[b].periode.getTime())
                 .forEach((h) => {
                 const time = apconso[h].periode.getTime();
                 output_apart[time] = output_apart[time] || {};
@@ -1394,7 +1394,7 @@ function cotisationsdettes(v, periodes) {
         return events;
     }, [])
         .sort((a, b) => {
-        return a.date_proc_col.getTime() > b.date_proc_col.getTime() ? 1 : 0;
+        return a.date_proc_col.getTime() - b.date_proc_col.getTime();
     });
     codes.forEach((event) => {
         const periode_effet = new Date(Date.UTC(event.date_proc_col.getFullYear(), event.date_proc_col.getUTCMonth(), 1, 0, 0, 0, 0));

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1728,19 +1728,11 @@ function flatten(v, actual_batch) {
     // Est-ce que l'évènement se répercute dans le passé (past = true on pourra se
     // demander: que va-t-il se passer) ou dans le future (past = false on
     // pourra se demander que s'est-il passé
-    /* eslint-disable */
-    var sorting_fun = function (a, b) {
-        return a >= b ? 1 : -1; // TODO: normally, a sorting comparator should return a number, possibly including zero. => the TS version of the test has failed until we added ` + "`" + `? 1 : -1` + "`" + ` here
-    };
-    if (past) {
-        sorting_fun = function (a, b) {
-            return a <= b ? 1 : -1; // TODO: normally, a sorting comparator should return a number, possibly including zero. => the TS version of the test has failed until we added ` + "`" + `? 1 : -1` + "`" + ` here
-        };
-    }
-    /* eslint-enable */
+    const chronologic = (a, b) => (a > b ? 1 : -1);
+    const reverse = (a, b) => (b > a ? 1 : -1);
     let counter = -1;
     const output = Object.keys(data)
-        .sort(sorting_fun)
+        .sort(past ? reverse : chronologic)
         .reduce(function (m, period) {
         // Si on a déjà détecté quelque chose, on compte le nombre de périodes
         if (counter >= 0)

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1230,7 +1230,7 @@ db.getCollection("Features").createIndex({
             counter = 0;
     });
 }
-// TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts`,
+/* TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts */`,
 "cotisationsdettes": `/**
  * Calcule les variables liées aux cotisations sociales et dettes sur ces
  * cotisations.
@@ -1530,7 +1530,7 @@ function delais(v, debitParPériode, intervalleTraitement) {
     });
     return output_effectif;
 }
-// TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts`,
+/* TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts */`,
 "finalize": `function finalize(k, v) {
     "use strict";
     const maxBsonSize = 16777216;


### PR DESCRIPTION
Cette PR fait suite à PR #94.

## Changements apportés

- [x] Simplification des tris (cf [explications](https://stackoverflow.com/a/13171179/592254))
- [x] Ajout d'un test "Le montant de dette d'une période est rapporté dans les périodes suivantes"
- [x] Ajout d'un test "interessante_urssaf est vrai quand l'entreprise n'a pas eu de débit (dette) sur les 6 derniers mois"
- [x] Continuer le refactoring de `cotisationsdette`, cf [TODO de PR #94](https://github.com/signaux-faibles/opensignauxfaibles/pull/94/files#diff-1c7173d633e5647aa89b6025ee0241caR219)

Effectué partiellement en pair coding avec @JazzyPierrot, le Lundi 13 Juillet 2020.