### PR TITLE
fix(reduce.algo2): Renommage et explicitation des types dans effectifs()

### DIFF
--- a/dbmongo/js/reduce.algo2/effectifs.ts
+++ b/dbmongo/js/reduce.algo2/effectifs.ts
@@ -3,13 +3,11 @@ import * as f from "./dateAddMonth"
 // Paramètres globaux utilisés par "reduce.algo2"
 declare const offset_effectif: number
 
-type Time = string
-
 type PropertyName = "effectif_ent" | "effectif" // effectif entreprise ou établissement
 
 type ValeurEffectif = number
 
-type SortieEffectifs = Record<Time, Record<PropertyName, ValeurEffectif | null>>
+type SortieEffectifs = Record<string, ValeurEffectif | null> // TODO: spécifier les propriétés
 
 type EffectifEntreprise = Record<DataHash, EntréeEffectif>
 
@@ -17,10 +15,10 @@ export function effectifs(
   effobj: EffectifEntreprise,
   periodes: Timestamp[],
   propertyName: PropertyName
-): SortieEffectifs {
+): ParPériode<SortieEffectifs> {
   "use strict"
 
-  const output_effectif: SortieEffectifs = {}
+  const output_effectif: ParPériode<SortieEffectifs> = {}
 
   // Construction d'une map[time] = effectif à cette periode
   const map_effectif = Object.keys(effobj).reduce((m, hash) => {
@@ -31,7 +29,7 @@ export function effectifs(
     const effectifTime = effectif.periode.getTime()
     m[effectifTime] = (m[effectifTime] || 0) + effectif.effectif
     return m
-  }, {} as Record<Time, ValeurEffectif>)
+  }, {} as SortieEffectifs)
 
   //ne reporter que si le dernier est disponible
   // 1- quelle periode doit être disponible

--- a/dbmongo/js/reduce.algo2/effectifs.ts
+++ b/dbmongo/js/reduce.algo2/effectifs.ts
@@ -4,15 +4,28 @@ import * as f from "./dateAddMonth"
 declare const offset_effectif: number
 
 type PropertyName = "effectif_ent" | "effectif" // effectif entreprise ou établissement
-
-type PropertyNameÉtendu = string /*
-  | PropertyName
-  | "effectif_ent_reporte"
-  | "effectif_reporte"*/
+type PropertyNameReporté = "effectif_ent_reporte" | "effectif_reporte"
+type PastPropertyName =
+  | "effectif_past_6"
+  | "effectif_past_12"
+  | "effectif_past_18"
+  | "effectif_past_24"
+  | "effectif_ent_past_6"
+  | "effectif_ent_past_12"
+  | "effectif_ent_past_18"
+  | "effectif_ent_past_24"
 
 type ValeurEffectif = number
 
-type SortieEffectifs = Record<PropertyNameÉtendu, ValeurEffectif | null>
+type SortieEffectifs = {
+  [propName in PropertyName]: ValeurEffectif | null
+} &
+  {
+    [propName in PropertyNameReporté]: 1 | 0
+  } &
+  {
+    [propName in PastPropertyName]: ValeurEffectif
+  }
 
 type EffectifEntreprise = Record<DataHash, EntréeEffectif>
 
@@ -54,15 +67,14 @@ export function effectifs(
     // le cas échéant, on met à jour l'accu avec le dernier effectif disponible
     accu = map_effectif[time] || accu
 
-    output_effectif[time][propertyName + "_reporte"] = map_effectif[time]
-      ? 0
-      : 1
+    const propNameReporté = (propertyName + "_reporte") as PropertyNameReporté
+    output_effectif[time][propNameReporté] = map_effectif[time] ? 0 : 1
     return accu
   }, null as ValeurEffectif | null)
 
   Object.keys(map_effectif).forEach((time) => {
     const periode = new Date(parseInt(time))
-    const past_month_offsets = [6, 12, 18, 24]
+    const past_month_offsets = [6, 12, 18, 24] // Note: à garder en synchro avec la définition du type PastPropertyName
     past_month_offsets.forEach((lookback) => {
       // On ajoute un offset pour partir de la dernière période où l'effectif est connu
       const time_past_lookback = f.dateAddMonth(
@@ -70,7 +82,9 @@ export function effectifs(
         lookback - offset_effectif - 1
       )
 
-      const variable_name_effectif = propertyName + "_past_" + lookback
+      const variable_name_effectif = (propertyName +
+        "_past_" +
+        lookback) as PastPropertyName
       output_effectif[time_past_lookback.getTime()] =
         output_effectif[time_past_lookback.getTime()] || {}
       output_effectif[time_past_lookback.getTime()][variable_name_effectif] =

--- a/dbmongo/js/reduce.algo2/effectifs.ts
+++ b/dbmongo/js/reduce.algo2/effectifs.ts
@@ -5,9 +5,14 @@ declare const offset_effectif: number
 
 type PropertyName = "effectif_ent" | "effectif" // effectif entreprise ou établissement
 
+type PropertyNameÉtendu = string /*
+  | PropertyName
+  | "effectif_ent_reporte"
+  | "effectif_reporte"*/
+
 type ValeurEffectif = number
 
-type SortieEffectifs = Record<string, ValeurEffectif | null> // TODO: spécifier les propriétés
+type SortieEffectifs = Record<PropertyNameÉtendu, ValeurEffectif | null>
 
 type EffectifEntreprise = Record<DataHash, EntréeEffectif>
 
@@ -29,7 +34,7 @@ export function effectifs(
     const effectifTime = effectif.periode.getTime()
     m[effectifTime] = (m[effectifTime] || 0) + effectif.effectif
     return m
-  }, {} as SortieEffectifs)
+  }, {} as Record<Periode, number>)
 
   //ne reporter que si le dernier est disponible
   // 1- quelle periode doit être disponible

--- a/dbmongo/js/reduce.algo2/effectifs.ts
+++ b/dbmongo/js/reduce.algo2/effectifs.ts
@@ -5,18 +5,18 @@ declare const offset_effectif: number
 
 type Time = string
 
-type EffectifName = string
+type PropertyName = "effectif_ent" | "effectif" // effectif entreprise ou établissement
 
 type ValeurEffectif = number
 
-type SortieEffectifs = Record<Time, Record<EffectifName, ValeurEffectif | null>>
+type SortieEffectifs = Record<Time, Record<PropertyName, ValeurEffectif | null>>
 
 type EffectifEntreprise = Record<DataHash, EntréeEffectif>
 
 export function effectifs(
   effobj: EffectifEntreprise,
   periodes: Timestamp[],
-  effectif_name: EffectifName
+  propertyName: PropertyName
 ): SortieEffectifs {
   "use strict"
 
@@ -45,13 +45,13 @@ export function effectifs(
   periodes.reduce((accu, time) => {
     // si disponible on reporte l'effectif tel quel, sinon, on recupère l'accu
     output_effectif[time] = output_effectif[time] || {}
-    output_effectif[time][effectif_name] =
+    output_effectif[time][propertyName] =
       map_effectif[time] || (available ? accu : null)
 
     // le cas échéant, on met à jour l'accu avec le dernier effectif disponible
     accu = map_effectif[time] || accu
 
-    output_effectif[time][effectif_name + "_reporte"] = map_effectif[time]
+    output_effectif[time][propertyName + "_reporte"] = map_effectif[time]
       ? 0
       : 1
     return accu
@@ -67,7 +67,7 @@ export function effectifs(
         lookback - offset_effectif - 1
       )
 
-      const variable_name_effectif = effectif_name + "_past_" + lookback
+      const variable_name_effectif = propertyName + "_past_" + lookback
       output_effectif[time_past_lookback.getTime()] =
         output_effectif[time_past_lookback.getTime()] || {}
       output_effectif[time_past_lookback.getTime()][variable_name_effectif] =

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1506,18 +1506,19 @@ function delais(v, debitParPériode, intervalleTraitement) {
             map_effectif[time] || (available ? accu : null);
         // le cas échéant, on met à jour l'accu avec le dernier effectif disponible
         accu = map_effectif[time] || accu;
-        output_effectif[time][propertyName + "_reporte"] = map_effectif[time]
-            ? 0
-            : 1;
+        const propNameReporté = (propertyName + "_reporte");
+        output_effectif[time][propNameReporté] = map_effectif[time] ? 0 : 1;
         return accu;
     }, null);
     Object.keys(map_effectif).forEach((time) => {
         const periode = new Date(parseInt(time));
-        const past_month_offsets = [6, 12, 18, 24];
+        const past_month_offsets = [6, 12, 18, 24]; // Note: à garder en synchro avec la définition du type PastPropertyName
         past_month_offsets.forEach((lookback) => {
             // On ajoute un offset pour partir de la dernière période où l'effectif est connu
             const time_past_lookback = f.dateAddMonth(periode, lookback - offset_effectif - 1);
-            const variable_name_effectif = propertyName + "_past_" + lookback;
+            const variable_name_effectif = (propertyName +
+                "_past_" +
+                lookback);
             output_effectif[time_past_lookback.getTime()] =
                 output_effectif[time_past_lookback.getTime()] || {};
             output_effectif[time_past_lookback.getTime()][variable_name_effectif] =

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1479,7 +1479,7 @@ function delais(v, debitParPériode, intervalleTraitement) {
         return null;
     }
 }`,
-"effectifs": `function effectifs(effobj, periodes, effectif_name) {
+"effectifs": `function effectifs(effobj, periodes, propertyName) {
     "use strict";
     const output_effectif = {};
     // Construction d'une map[time] = effectif à cette periode
@@ -1502,11 +1502,11 @@ function delais(v, debitParPériode, intervalleTraitement) {
     periodes.reduce((accu, time) => {
         // si disponible on reporte l'effectif tel quel, sinon, on recupère l'accu
         output_effectif[time] = output_effectif[time] || {};
-        output_effectif[time][effectif_name] =
+        output_effectif[time][propertyName] =
             map_effectif[time] || (available ? accu : null);
         // le cas échéant, on met à jour l'accu avec le dernier effectif disponible
         accu = map_effectif[time] || accu;
-        output_effectif[time][effectif_name + "_reporte"] = map_effectif[time]
+        output_effectif[time][propertyName + "_reporte"] = map_effectif[time]
             ? 0
             : 1;
         return accu;
@@ -1517,7 +1517,7 @@ function delais(v, debitParPériode, intervalleTraitement) {
         past_month_offsets.forEach((lookback) => {
             // On ajoute un offset pour partir de la dernière période où l'effectif est connu
             const time_past_lookback = f.dateAddMonth(periode, lookback - offset_effectif - 1);
-            const variable_name_effectif = effectif_name + "_past_" + lookback;
+            const variable_name_effectif = propertyName + "_past_" + lookback;
             output_effectif[time_past_lookback.getTime()] =
                 output_effectif[time_past_lookback.getTime()] || {};
             output_effectif[time_past_lookback.getTime()][variable_name_effectif] =


### PR DESCRIPTION
Volonté initiale: améliorer le nom et le type du paramètre `effectif_name` de la fonction `effectifs` pour rendre plus explicite le fait que cette fonction peut s'appliquer à la fois aux entreprises et aux établissements – contrairement à la plupart des autres fonctions de calcul.

Problèmes sous-jacents: ils s'avère que tous les types de cette fonction – notamment le type des données en sortie – manquaient de précision.
