### PR TITLE
fix(reduce.algo2): Extraction de entr_bdf()

### DIFF
--- a/dbmongo/js/common/omit.ts
+++ b/dbmongo/js/common/omit.ts
@@ -1,0 +1,11 @@
+// Fonction pour omettre des props, tout en retournant le bon type
+export function omit<Source, Exclusions extends Array<keyof Source>>(
+  object: Source,
+  ...propNames: Exclusions
+): Omit<Source, Exclusions[number]> {
+  const result: Omit<Source, Exclusions[number]> = Object.assign({}, object)
+  for (const prop of propNames) {
+    delete (result as any)[prop]
+  }
+  return result
+}

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -251,6 +251,18 @@ type EntréeBdf = {
   arrete_bilan_bdf: Date
   annee_bdf: number
   exercice_bdf: number
+  raison_sociale: unknown
+  secteur: unknown
+  siren: unknown
+} & RatiosBdf
+
+type RatiosBdf = {
+  poids_frng: number,
+  taux_marge: number,
+  delai_fournisseur: number,
+  dette_fiscale: number,
+  financier_court_terme: number,
+  frais_financier: number
 }
 
 type EntréeDiane = {

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -257,11 +257,11 @@ type EntréeBdf = {
 } & RatiosBdf
 
 type RatiosBdf = {
-  poids_frng: number,
-  taux_marge: number,
-  delai_fournisseur: number,
-  dette_fiscale: number,
-  financier_court_terme: number,
+  poids_frng: number
+  taux_marge: number
+  delai_fournisseur: number
+  dette_fiscale: number
+  financier_court_terme: number
   frais_financier: number
 }
 

--- a/dbmongo/js/globals.ts
+++ b/dbmongo/js/globals.ts
@@ -56,7 +56,7 @@ type BatchValue = Partial<
     DonnéesDebit &
     DonnéesCcsf &
     DonnéesSirene &
-    DonnéesSireneUL &
+    DonnéesSireneEntreprise &
     DonnéesEffectifEntreprise &
     DonnéesBdf &
     DonnéesDiane
@@ -119,8 +119,8 @@ type DonnéesSirene = {
   sirene: Record<DataHash, EntréeSirene>
 }
 
-type DonnéesSireneUL = {
-  sirene_ul: Record<DataHash, EntréeSireneUL>
+type DonnéesSireneEntreprise = {
+  sirene_ul: Record<DataHash, EntréeSireneEntreprise>
 }
 
 type DonnéesEffectifEntreprise = {
@@ -235,7 +235,7 @@ type EntréeSirene = {
   date_creation: Date
 }
 
-type EntréeSireneUL = {
+type EntréeSireneEntreprise = {
   raison_sociale: string
   nom_unite_legale: string
   nom_usage_unite_legale: string
@@ -243,7 +243,7 @@ type EntréeSireneUL = {
   prenom2_unite_legale: string
   prenom3_unite_legale: string
   prenom4_unite_legale: string
-  statut_juridique: unknown
+  statut_juridique: string | null // code numérique sérialisé en chaine de caractères
   date_creation: Date
 }
 

--- a/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
+++ b/dbmongo/js/reduce.algo2/cotisationsdettes_tests.ts
@@ -99,6 +99,9 @@ const setupCompanyValues = (dateDebut: Date) => ({
   },
 })
 
+// TODO: refactoriser les générateurs de données de tests pour éviter la
+// redondance et faciliter les tests futurs.
+
 const generatePastTestCase = (
   ouvrièreOuPatronale: "ouvriere" | "patronale",
   montantDette: number,

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -63,12 +63,11 @@ export function entr_bdf(
 
       const periodData = f.omit(entréeBdf, "raison_sociale", "secteur", "siren")
 
-      //if (outputInPeriod || periode.getTime() in periodes) {
+      // TODO: Éviter d'ajouter des données en dehors de `periodes`, sans fausser le calcul des données passées (plus bas)
       Object.assign(outputInPeriod, periodData)
       if (outputInPeriod.annee_bdf) {
         outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1
       }
-      //}
 
       const pastData = f.omit(periodData, "arrete_bilan_bdf", "exercice_bdf")
 

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -75,18 +75,15 @@ export function entr_bdf(
 
     for (const periode of series) {
       const outputInPeriod = (outputBdf[periode.getTime()] =
-        outputBdf[periode.getTime()] ||
-        {
-          /*...output_indexed[periode.getTime()]*/
-        })
+        outputBdf[periode.getTime()] || {})
       const rest = omit(bdfHashData, "raison_sociale", "secteur", "siren")
 
-      if (outputInPeriod /*periode.getTime() in periodes*/) {
-        Object.assign(outputInPeriod, rest)
-        if (outputInPeriod.annee_bdf) {
-          outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1
-        }
+      //if (outputInPeriod || periode.getTime() in periodes) {
+      Object.assign(outputInPeriod, rest)
+      if (outputInPeriod.annee_bdf) {
+        outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1
       }
+      //}
 
       for (const k of Object.keys(rest) as (keyof typeof rest)[]) {
         const past_year_offset = [1, 2]

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -96,10 +96,14 @@ export function entr_bdf(
             k !== "exercice_bdf"
             // TODO: props à inclure dans le omit ci-dessus
           ) {
+            output_indexed[periode_offset.getTime()][variable_name] =
+              v.bdf[hash][k]
+            /*
             output_indexed[periode_offset.getTime()] = {
               ...output_indexed[periode_offset.getTime()],
               [variable_name]: v.bdf[hash][k],
             }
+            */
           }
         }
       }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -6,25 +6,24 @@ type SortieBdf = {
   annee_bdf: number
   exercice_bdf: number // année
   // TODO: enumération des ratios.
-} & RatiosBdf
-  & RatiosBdfPassés
+} & RatiosBdf &
+  RatiosBdfPassés
 
 // Synchroniser les propriétés avec celles de RatiosBdf
 type RatiosBdfPassés = {
-  poids_frng_past_1: number,
-  taux_marge_past_1: number,
-  delai_fournisseur_past_1: number,
-  dette_fiscale_past_1: number,
-  financier_court_terme_past_1: number,
+  poids_frng_past_1: number
+  taux_marge_past_1: number
+  delai_fournisseur_past_1: number
+  dette_fiscale_past_1: number
+  financier_court_terme_past_1: number
   frais_financier_past_1: number
-  poids_frng_past_2: number,
-  taux_marge_past_2: number,
-  delai_fournisseur_past_2: number,
-  dette_fiscale_past_2: number,
-  financier_court_terme_past_2: number,
+  poids_frng_past_2: number
+  taux_marge_past_2: number
+  delai_fournisseur_past_2: number
+  dette_fiscale_past_2: number
+  financier_court_terme_past_2: number
   frais_financier_past_2: number
 }
-
 
 export function entr_bdf(entréeBdf: DonnéesBdf): ParPériode<SortieBdf> {
   const outputBdf: ParPériode<SortieBdf> = {}
@@ -70,12 +69,7 @@ export function entr_bdf(entréeBdf: DonnéesBdf): ParPériode<SortieBdf> {
     for (const periode of series) {
       const bdfHashData = entréeBdf.bdf[hash]
       const outputInPeriod = outputBdf[periode.getTime()]
-      const rest = omit(
-        bdfHashData,
-        "raison_sociale",
-        "secteur",
-        "siren"
-      )
+      const rest = omit(bdfHashData, "raison_sociale", "secteur", "siren")
 
       if (outputInPeriod) {
         Object.assign(outputInPeriod, rest)
@@ -98,7 +92,7 @@ export function entr_bdf(entréeBdf: DonnéesBdf): ParPériode<SortieBdf> {
           ) {
             outputBdf[periode_offset.getTime()] = {
               ...outputBdf[periode_offset.getTime()],
-              [variable_name]: entréeBdf.bdf[hash][k]
+              [variable_name]: entréeBdf.bdf[hash][k],
             }
           }
         }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -94,7 +94,7 @@ export function entr_bdf(
             // TODO: `in periodes` en récupérant un paramètre périodes.
             k !== "arrete_bilan_bdf" &&
             k !== "exercice_bdf"
-            // TODO: props à inclure dans le omit ci-dessus
+            // TODO: props à inclure dans le omit ci-dessus ?
           ) {
             output_indexed[periode_offset.getTime()][variable_name] =
               v.bdf[hash][k]

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -1,0 +1,91 @@
+import "../globals"
+import { generatePeriodSerie } from "../common/generatePeriodSerie"
+import { dateAddMonth } from "./dateAddMonth"
+
+type SortieBdf = {
+  annee_bdf: number
+  exercice_bdf: number // année
+}
+
+export function entr_bdf(entréeBdf: DonnéesBdf): ParPériode<SortieBdf> {
+  const outputBdf: ParPériode<SortieBdf> = {}
+
+  const f = { generatePeriodSerie, dateAddMonth } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
+
+  // Retourne les clés de obj, en respectant le type défini dans le type de obj.
+  // Contrat: obj ne doit contenir que les clés définies dans son type.
+  const typedObjectKeys = <T>(obj: T): Array<keyof T> =>
+    Object.keys(obj) as Array<keyof T>
+
+  // Fonction pour omettre des props, tout en retournant le bon type
+  function omit<Source, Exclusions extends Array<keyof Source>>(
+    object: Source,
+    ...propNames: Exclusions
+  ): Omit<Source, Exclusions[number]> {
+    const result: Omit<Source, Exclusions[number]> = Object.assign({}, object)
+    for (const prop of propNames) {
+      delete (result as any)[prop]
+    }
+    return result
+  }
+  // TODO: [refacto] extraire dans common/ ou reduce.algo2/
+
+  for (const hash of typedObjectKeys(entréeBdf.bdf)) {
+    const periode_arrete_bilan = new Date(
+      Date.UTC(
+        entréeBdf.bdf[hash].arrete_bilan_bdf.getUTCFullYear(),
+        entréeBdf.bdf[hash].arrete_bilan_bdf.getUTCMonth() + 1,
+        1,
+        0,
+        0,
+        0,
+        0
+      )
+    )
+    const periode_dispo = f.dateAddMonth(periode_arrete_bilan, 7)
+    const series = f.generatePeriodSerie(
+      periode_dispo,
+      f.dateAddMonth(periode_dispo, 13)
+    )
+
+    for (const periode of series) {
+      const bdfHashData = entréeBdf.bdf[hash]
+      const outputInPeriod = outputBdf[periode.getTime()]
+      const rest = omit(
+        bdfHashData as EntréeBdf & {
+          raison_sociale: unknown
+          secteur: unknown
+          siren: unknown
+        },
+        "raison_sociale",
+        "secteur",
+        "siren"
+      )
+
+      if (outputInPeriod) {
+        Object.assign(outputInPeriod, rest)
+        if (outputInPeriod.annee_bdf) {
+          outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1
+        }
+      }
+
+      for (const k of Object.keys(rest) as (keyof typeof rest)[]) {
+        const past_year_offset = [1, 2]
+        for (const offset of past_year_offset) {
+          const periode_offset = f.dateAddMonth(periode, 12 * offset)
+          const variable_name = k + "_past_" + offset
+          if (
+            periode_offset.getTime() in outputBdf &&
+            k !== "arrete_bilan_bdf" &&
+            k !== "exercice_bdf"
+          ) {
+            outputBdf[periode_offset.getTime()][variable_name] =
+              entréeBdf.bdf[hash][k]
+          }
+        }
+      }
+    }
+  }
+
+  return outputBdf
+}

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -27,8 +27,8 @@ type RatiosBdfPassés = {
 
 export function entr_bdf(
   v: DonnéesBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
-  output_indexed: ParPériode<Partial<SortieBdf>>
-  // periodes: Timestamp[]
+  output_indexed: ParPériode<Partial<SortieBdf>>,
+  periodes: Timestamp[]
 ): ParPériode<Partial<SortieBdf>> {
   "use strict"
   const outputBdf: ParPériode<Partial<SortieBdf>> = { ...output_indexed }
@@ -89,7 +89,7 @@ export function entr_bdf(
           const periode_offset = f.dateAddMonth(periode, 12 * offset)
           const variable_name = k + "_past_" + offset
           if (
-            periode_offset.getTime() in output_indexed &&
+            periode_offset.getTime() in periodes &&
             // TODO: `in periodes` en récupérant un paramètre périodes.
             k !== "arrete_bilan_bdf" &&
             k !== "exercice_bdf"
@@ -97,12 +97,6 @@ export function entr_bdf(
           ) {
             output_indexed[periode_offset.getTime()][variable_name] =
               v.bdf[hash][k]
-            /*
-            output_indexed[periode_offset.getTime()] = {
-              ...output_indexed[periode_offset.getTime()],
-              [variable_name]: v.bdf[hash][k],
-            }
-            */
           }
         }
       }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -2,11 +2,12 @@ import "../globals"
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { dateAddMonth } from "./dateAddMonth"
 
-type SortieBdf = {
+export type SortieBdf = {
   annee_bdf: number
   exercice_bdf: number // année
 } & RatiosBdf &
-  RatiosBdfPassés
+  RatiosBdfPassés &
+  Record<string, unknown> // for *_past_* props of bdf. // TODO: try to be more specific
 
 // Synchroniser les propriétés avec celles de RatiosBdf
 type RatiosBdfPassés = {
@@ -29,6 +30,7 @@ export function entr_bdf(
   output_indexed: Record<Periode, Partial<SortieBdf>>
   // periodes: Timestamp[]
 ): void /*ParPériode<SortieBdf>*/ {
+  "use strict"
   // const outputBdf: ParPériode<SortieBdf> = {}
   // const outputBdf = entréeBdf.bdf
 

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -1,7 +1,7 @@
 import "../globals"
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { dateAddMonth } from "./dateAddMonth"
-
+/*
 type SortieBdf = {
   annee_bdf: number
   exercice_bdf: number // année
@@ -23,20 +23,22 @@ type RatiosBdfPassés = {
   financier_court_terme_past_2: number
   frais_financier_past_2: number
 }
-
+*/
 export function entr_bdf(
   entréeBdf: DonnéesBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
-  periodes: Timestamp[]
-): ParPériode<SortieBdf> {
-  const outputBdf: ParPériode<SortieBdf> = {}
+  output_indexed: Record<Periode, Record<string, number>> // for *_past_* props of bdf. // TODO: try to be more specific
+  // periodes: Timestamp[]
+): void /*ParPériode<SortieBdf>*/ {
+  // const outputBdf: ParPériode<SortieBdf> = {}
+  // const outputBdf = entréeBdf.bdf
 
   const f = { generatePeriodSerie, dateAddMonth } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
-
+  /*
   // Retourne les clés de obj, en respectant le type défini dans le type de obj.
   // Contrat: obj ne doit contenir que les clés définies dans son type.
   const typedObjectKeys = <T>(obj: T): Array<keyof T> =>
     Object.keys(obj) as Array<keyof T>
-
+  */
   // Fonction pour omettre des props, tout en retournant le bon type
   function omit<Source, Exclusions extends Array<keyof Source>>(
     object: Source,
@@ -50,7 +52,7 @@ export function entr_bdf(
   }
   // TODO: [refacto] extraire dans common/ ou reduce.algo2/
 
-  for (const hash of typedObjectKeys(entréeBdf.bdf)) {
+  for (const hash in /*of typedObjectKeys*/ entréeBdf.bdf) {
     const bdfHashData = entréeBdf.bdf[hash]
     const periode_arrete_bilan = new Date(
       Date.UTC(
@@ -70,10 +72,10 @@ export function entr_bdf(
     )
 
     for (const periode of series) {
-      const outputInPeriod = outputBdf[periode.getTime()]
+      const outputInPeriod = output_indexed[periode.getTime()]
       const rest = omit(bdfHashData, "raison_sociale", "secteur", "siren")
 
-      if (periode.getTime() in periodes) {
+      if (outputInPeriod /*periode.getTime() in periodes*/) {
         Object.assign(outputInPeriod, rest)
         if (outputInPeriod.annee_bdf) {
           outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1
@@ -86,14 +88,14 @@ export function entr_bdf(
           const periode_offset = f.dateAddMonth(periode, 12 * offset)
           const variable_name = k + "_past_" + offset
           if (
-            periode_offset.getTime() in outputBdf &&
+            periode_offset.getTime() in output_indexed &&
             // TODO: `in periodes` en récupérant un paramètre périodes.
             k !== "arrete_bilan_bdf" &&
             k !== "exercice_bdf"
             // TODO: props à inclure dans le omit ci-dessus
           ) {
-            outputBdf[periode_offset.getTime()] = {
-              ...outputBdf[periode_offset.getTime()],
+            output_indexed[periode_offset.getTime()] = {
+              ...output_indexed[periode_offset.getTime()],
               [variable_name]: entréeBdf.bdf[hash][k],
             }
           }
@@ -102,5 +104,5 @@ export function entr_bdf(
     }
   }
 
-  return outputBdf
+  // return outputBdf
 }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -26,7 +26,7 @@ type RatiosBdfPassés = {
 }
 
 export function entr_bdf(
-  v: DonnéesBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
+  donnéesBdf: ParPériode<EntréeBdf>,
   periodes: Timestamp[]
 ): ParPériode<Partial<SortieBdf>> {
   "use strict"
@@ -38,8 +38,8 @@ export function entr_bdf(
     outputBdf[p] = {}
   }
 
-  for (const hash in v.bdf) {
-    const bdfHashData = v.bdf[hash]
+  for (const hash in donnéesBdf) {
+    const bdfHashData = donnéesBdf[hash]
     const periode_arrete_bilan = new Date(
       Date.UTC(
         bdfHashData.arrete_bilan_bdf.getUTCFullYear(),
@@ -79,7 +79,7 @@ export function entr_bdf(
           const outputInPast = outputBdf[periode_offset.getTime()]
           if (outputInPast) {
             Object.assign(outputInPast, {
-              [prop + "_past_" + offset]: v.bdf[hash][prop],
+              [prop + "_past_" + offset]: donnéesBdf[hash][prop],
             })
           }
         }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -85,20 +85,18 @@ export function entr_bdf(
       }
       //}
 
-      for (const k of Object.keys(rest) as (keyof typeof rest)[]) {
+      for (const prop of Object.keys(rest) as (keyof typeof rest)[]) {
         const past_year_offset = [1, 2]
         for (const offset of past_year_offset) {
           const periode_offset = f.dateAddMonth(periode, 12 * offset)
-          const variable_name = k + "_past_" + offset
+          const outputInPast = outputBdf[periode_offset.getTime()]
           if (
-            outputBdf[periode_offset.getTime()] &&
-            // periode_offset.getTime() in output_indexed &&
-            // TODO: `in periodes` en récupérant un paramètre périodes.
-            k !== "arrete_bilan_bdf" &&
-            k !== "exercice_bdf"
+            outputInPast &&
+            prop !== "arrete_bilan_bdf" &&
+            prop !== "exercice_bdf"
             // TODO: props à inclure dans le omit ci-dessus ?
           ) {
-            outputBdf[periode_offset.getTime()][variable_name] = v.bdf[hash][k]
+            outputInPast[prop + "_past_" + offset] = v.bdf[hash][prop]
           }
         }
       }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -26,7 +26,7 @@ type RatiosBdfPassés = {
 }
 
 export function entr_bdf(
-  donnéesBdf: ParPériode<EntréeBdf>,
+  donnéesBdf: Record<DataHash, EntréeBdf>,
   periodes: Timestamp[]
 ): ParPériode<Partial<SortieBdf>> {
   "use strict"

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -31,6 +31,7 @@ export function entr_bdf(
   periodes: Timestamp[]
 ): ParPériode<Partial<SortieBdf>> {
   "use strict"
+  periodes
   const outputBdf: ParPériode<Partial<SortieBdf>> = { ...output_indexed }
 
   const f = { generatePeriodSerie, dateAddMonth } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
@@ -89,14 +90,13 @@ export function entr_bdf(
           const periode_offset = f.dateAddMonth(periode, 12 * offset)
           const variable_name = k + "_past_" + offset
           if (
-            periode_offset.getTime() in periodes &&
+            periode_offset.getTime() in output_indexed &&
             // TODO: `in periodes` en récupérant un paramètre périodes.
             k !== "arrete_bilan_bdf" &&
             k !== "exercice_bdf"
             // TODO: props à inclure dans le omit ci-dessus ?
           ) {
-            output_indexed[periode_offset.getTime()][variable_name] =
-              v.bdf[hash][k]
+            outputBdf[periode_offset.getTime()][variable_name] = v.bdf[hash][k]
           }
         }
       }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -1,6 +1,7 @@
 import "../globals"
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { dateAddMonth } from "./dateAddMonth"
+import { omit } from "../common/omit"
 
 export type SortieBdf = {
   annee_bdf: number
@@ -35,19 +36,6 @@ export function entr_bdf(
   const outputBdf: ParPériode<Partial<SortieBdf>> = { ...output_indexed }
 
   const f = { generatePeriodSerie, dateAddMonth } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
-
-  // Fonction pour omettre des props, tout en retournant le bon type
-  function omit<Source, Exclusions extends Array<keyof Source>>(
-    object: Source,
-    ...propNames: Exclusions
-  ): Omit<Source, Exclusions[number]> {
-    const result: Omit<Source, Exclusions[number]> = Object.assign({}, object)
-    for (const prop of propNames) {
-      delete (result as any)[prop]
-    }
-    return result
-  }
-  // TODO: [refacto] extraire dans common/ ou reduce.algo2/
 
   for (const hash in v.bdf) {
     const bdfHashData = v.bdf[hash]

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -27,14 +27,16 @@ type RatiosBdfPassés = {
 
 export function entr_bdf(
   v: DonnéesBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
-  output_indexed: ParPériode<Partial<SortieBdf>>,
   periodes: Timestamp[]
 ): ParPériode<Partial<SortieBdf>> {
   "use strict"
-  periodes
-  const outputBdf: ParPériode<Partial<SortieBdf>> = { ...output_indexed }
 
   const f = { generatePeriodSerie, dateAddMonth } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
+
+  const outputBdf: ParPériode<Partial<SortieBdf>> = {}
+  for (const p of periodes) {
+    outputBdf[p] = {}
+  }
 
   for (const hash in v.bdf) {
     const bdfHashData = v.bdf[hash]

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -27,8 +27,8 @@ type RatiosBdfPassés = {
 
 export function entr_bdf(
   v: DonnéesBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
-  output_indexed: ParPériode<Partial<SortieBdf>>,
-  periodes: Timestamp[]
+  output_indexed: ParPériode<Partial<SortieBdf>>
+  // periodes: Timestamp[]
 ): ParPériode<Partial<SortieBdf>> {
   "use strict"
   const outputBdf: ParPériode<Partial<SortieBdf>> = { ...output_indexed }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -31,7 +31,7 @@ export function entr_bdf(
 ): ParPériode<Partial<SortieBdf>> {
   "use strict"
 
-  const f = { generatePeriodSerie, dateAddMonth } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
+  const f = { generatePeriodSerie, dateAddMonth, omit } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
 
   const outputBdf: ParPériode<Partial<SortieBdf>> = {}
   for (const p of periodes) {
@@ -39,11 +39,11 @@ export function entr_bdf(
   }
 
   for (const hash of Object.keys(donnéesBdf)) {
-    const bdfHashData = donnéesBdf[hash]
+    const entréeBdf = donnéesBdf[hash]
     const periode_arrete_bilan = new Date(
       Date.UTC(
-        bdfHashData.arrete_bilan_bdf.getUTCFullYear(),
-        bdfHashData.arrete_bilan_bdf.getUTCMonth() + 1,
+        entréeBdf.arrete_bilan_bdf.getUTCFullYear(),
+        entréeBdf.arrete_bilan_bdf.getUTCMonth() + 1,
         1,
         0,
         0,
@@ -61,7 +61,7 @@ export function entr_bdf(
       const outputInPeriod = (outputBdf[periode.getTime()] =
         outputBdf[periode.getTime()] || {})
 
-      const periodData = omit(bdfHashData, "raison_sociale", "secteur", "siren")
+      const periodData = f.omit(entréeBdf, "raison_sociale", "secteur", "siren")
 
       //if (outputInPeriod || periode.getTime() in periodes) {
       Object.assign(outputInPeriod, periodData)
@@ -70,7 +70,7 @@ export function entr_bdf(
       }
       //}
 
-      const pastData = omit(periodData, "arrete_bilan_bdf", "exercice_bdf")
+      const pastData = f.omit(periodData, "arrete_bilan_bdf", "exercice_bdf")
 
       for (const prop of Object.keys(pastData) as (keyof typeof pastData)[]) {
         const past_year_offset = [1, 2]

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -74,7 +74,9 @@ export function entr_bdf(
     )
 
     for (const periode of series) {
-      const outputInPeriod = output_indexed[periode.getTime()]
+      const outputInPeriod = (outputBdf[periode.getTime()] = outputBdf[
+        periode.getTime()
+      ] || { ...output_indexed[periode.getTime()] })
       const rest = omit(bdfHashData, "raison_sociale", "secteur", "siren")
 
       if (outputInPeriod /*periode.getTime() in periodes*/) {

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -5,7 +5,6 @@ import { dateAddMonth } from "./dateAddMonth"
 type SortieBdf = {
   annee_bdf: number
   exercice_bdf: number // année
-  // TODO: enumération des ratios.
 } & RatiosBdf &
   RatiosBdfPassés
 
@@ -25,7 +24,10 @@ type RatiosBdfPassés = {
   frais_financier_past_2: number
 }
 
-export function entr_bdf(entréeBdf: DonnéesBdf): ParPériode<SortieBdf> {
+export function entr_bdf(
+  entréeBdf: DonnéesBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
+  periodes: Timestamp[]
+): ParPériode<SortieBdf> {
   const outputBdf: ParPériode<SortieBdf> = {}
 
   const f = { generatePeriodSerie, dateAddMonth } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
@@ -49,10 +51,11 @@ export function entr_bdf(entréeBdf: DonnéesBdf): ParPériode<SortieBdf> {
   // TODO: [refacto] extraire dans common/ ou reduce.algo2/
 
   for (const hash of typedObjectKeys(entréeBdf.bdf)) {
+    const bdfHashData = entréeBdf.bdf[hash]
     const periode_arrete_bilan = new Date(
       Date.UTC(
-        entréeBdf.bdf[hash].arrete_bilan_bdf.getUTCFullYear(),
-        entréeBdf.bdf[hash].arrete_bilan_bdf.getUTCMonth() + 1,
+        bdfHashData.arrete_bilan_bdf.getUTCFullYear(),
+        bdfHashData.arrete_bilan_bdf.getUTCMonth() + 1,
         1,
         0,
         0,
@@ -67,11 +70,10 @@ export function entr_bdf(entréeBdf: DonnéesBdf): ParPériode<SortieBdf> {
     )
 
     for (const periode of series) {
-      const bdfHashData = entréeBdf.bdf[hash]
       const outputInPeriod = outputBdf[periode.getTime()]
       const rest = omit(bdfHashData, "raison_sociale", "secteur", "siren")
 
-      if (outputInPeriod) {
+      if (periode.getTime() in periodes) {
         Object.assign(outputInPeriod, rest)
         if (outputInPeriod.annee_bdf) {
           outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -7,8 +7,7 @@ export type SortieBdf = {
   annee_bdf: number
   exercice_bdf: number // année
 } & RatiosBdf &
-  RatiosBdfPassés &
-  Record<string, unknown> // for *_past_* props of bdf. // TODO: try to be more specific
+  RatiosBdfPassés
 
 // Synchroniser les propriétés avec celles de RatiosBdf
 type RatiosBdfPassés = {
@@ -77,7 +76,9 @@ export function entr_bdf(
           const periode_offset = f.dateAddMonth(periode, 12 * offset)
           const outputInPast = outputBdf[periode_offset.getTime()]
           if (outputInPast) {
-            outputInPast[prop + "_past_" + offset] = v.bdf[hash][prop]
+            Object.assign(outputInPast, {
+              [prop + "_past_" + offset]: v.bdf[hash][prop],
+            })
           }
         }
       }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -74,9 +74,11 @@ export function entr_bdf(
     )
 
     for (const periode of series) {
-      const outputInPeriod = (outputBdf[periode.getTime()] = outputBdf[
-        periode.getTime()
-      ] || { ...output_indexed[periode.getTime()] })
+      const outputInPeriod = (outputBdf[periode.getTime()] =
+        outputBdf[periode.getTime()] ||
+        {
+          /*...output_indexed[periode.getTime()]*/
+        })
       const rest = omit(bdfHashData, "raison_sociale", "secteur", "siren")
 
       if (outputInPeriod /*periode.getTime() in periodes*/) {

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -5,7 +5,26 @@ import { dateAddMonth } from "./dateAddMonth"
 type SortieBdf = {
   annee_bdf: number
   exercice_bdf: number // année
+  // TODO: enumération des ratios.
+} & RatiosBdf
+  & RatiosBdfPassés
+
+// Synchroniser les propriétés avec celles de RatiosBdf
+type RatiosBdfPassés = {
+  poids_frng_past_1: number,
+  taux_marge_past_1: number,
+  delai_fournisseur_past_1: number,
+  dette_fiscale_past_1: number,
+  financier_court_terme_past_1: number,
+  frais_financier_past_1: number
+  poids_frng_past_2: number,
+  taux_marge_past_2: number,
+  delai_fournisseur_past_2: number,
+  dette_fiscale_past_2: number,
+  financier_court_terme_past_2: number,
+  frais_financier_past_2: number
 }
+
 
 export function entr_bdf(entréeBdf: DonnéesBdf): ParPériode<SortieBdf> {
   const outputBdf: ParPériode<SortieBdf> = {}
@@ -52,11 +71,7 @@ export function entr_bdf(entréeBdf: DonnéesBdf): ParPériode<SortieBdf> {
       const bdfHashData = entréeBdf.bdf[hash]
       const outputInPeriod = outputBdf[periode.getTime()]
       const rest = omit(
-        bdfHashData as EntréeBdf & {
-          raison_sociale: unknown
-          secteur: unknown
-          siren: unknown
-        },
+        bdfHashData,
         "raison_sociale",
         "secteur",
         "siren"
@@ -76,11 +91,15 @@ export function entr_bdf(entréeBdf: DonnéesBdf): ParPériode<SortieBdf> {
           const variable_name = k + "_past_" + offset
           if (
             periode_offset.getTime() in outputBdf &&
+            // TODO: `in periodes` en récupérant un paramètre périodes.
             k !== "arrete_bilan_bdf" &&
             k !== "exercice_bdf"
+            // TODO: props à inclure dans le omit ci-dessus
           ) {
-            outputBdf[periode_offset.getTime()][variable_name] =
-              entréeBdf.bdf[hash][k]
+            outputBdf[periode_offset.getTime()] = {
+              ...outputBdf[periode_offset.getTime()],
+              [variable_name]: entréeBdf.bdf[hash][k]
+            }
           }
         }
       }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -1,7 +1,7 @@
 import "../globals"
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { dateAddMonth } from "./dateAddMonth"
-/*
+
 type SortieBdf = {
   annee_bdf: number
   exercice_bdf: number // année
@@ -23,10 +23,10 @@ type RatiosBdfPassés = {
   financier_court_terme_past_2: number
   frais_financier_past_2: number
 }
-*/
+
 export function entr_bdf(
-  entréeBdf: DonnéesBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
-  output_indexed: Record<Periode, Record<string, number>> // for *_past_* props of bdf. // TODO: try to be more specific
+  v: DonnéesBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
+  output_indexed: Record<Periode, Partial<SortieBdf>>
   // periodes: Timestamp[]
 ): void /*ParPériode<SortieBdf>*/ {
   // const outputBdf: ParPériode<SortieBdf> = {}
@@ -52,8 +52,8 @@ export function entr_bdf(
   }
   // TODO: [refacto] extraire dans common/ ou reduce.algo2/
 
-  for (const hash in /*of typedObjectKeys*/ entréeBdf.bdf) {
-    const bdfHashData = entréeBdf.bdf[hash]
+  for (const hash in /*of typedObjectKeys*/ v.bdf) {
+    const bdfHashData = v.bdf[hash]
     const periode_arrete_bilan = new Date(
       Date.UTC(
         bdfHashData.arrete_bilan_bdf.getUTCFullYear(),
@@ -96,7 +96,7 @@ export function entr_bdf(
           ) {
             output_indexed[periode_offset.getTime()] = {
               ...output_indexed[periode_offset.getTime()],
-              [variable_name]: entréeBdf.bdf[hash][k],
+              [variable_name]: v.bdf[hash][k],
             }
           }
         }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -27,12 +27,11 @@ type RatiosBdfPassés = {
 
 export function entr_bdf(
   v: DonnéesBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
-  output_indexed: Record<Periode, Partial<SortieBdf>>
-  // periodes: Timestamp[]
-): Record<Periode, Partial<SortieBdf>> {
+  output_indexed: ParPériode<Partial<SortieBdf>>,
+  periodes: Timestamp[]
+): ParPériode<Partial<SortieBdf>> {
   "use strict"
-  // const outputBdf: ParPériode<SortieBdf> = {}
-  // const outputBdf = entréeBdf.bdf
+  const outputBdf: ParPériode<Partial<SortieBdf>> = { ...output_indexed }
 
   const f = { generatePeriodSerie, dateAddMonth } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
   /*
@@ -54,7 +53,7 @@ export function entr_bdf(
   }
   // TODO: [refacto] extraire dans common/ ou reduce.algo2/
 
-  for (const hash in /*of typedObjectKeys*/ v.bdf) {
+  for (const hash in v.bdf) {
     const bdfHashData = v.bdf[hash]
     const periode_arrete_bilan = new Date(
       Date.UTC(
@@ -110,5 +109,5 @@ export function entr_bdf(
     }
   }
 
-  return output_indexed
+  return outputBdf
 }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -29,7 +29,7 @@ export function entr_bdf(
   v: DonnéesBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
   output_indexed: Record<Periode, Partial<SortieBdf>>
   // periodes: Timestamp[]
-): void /*ParPériode<SortieBdf>*/ {
+): Record<Periode, Partial<SortieBdf>> {
   "use strict"
   // const outputBdf: ParPériode<SortieBdf> = {}
   // const outputBdf = entréeBdf.bdf
@@ -110,5 +110,5 @@ export function entr_bdf(
     }
   }
 
-  // return outputBdf
+  return output_indexed
 }

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -91,7 +91,8 @@ export function entr_bdf(
           const periode_offset = f.dateAddMonth(periode, 12 * offset)
           const variable_name = k + "_past_" + offset
           if (
-            periode_offset.getTime() in output_indexed &&
+            outputBdf[periode_offset.getTime()] &&
+            // periode_offset.getTime() in output_indexed &&
             // TODO: `in periodes` en récupérant un paramètre périodes.
             k !== "arrete_bilan_bdf" &&
             k !== "exercice_bdf"

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -47,14 +47,6 @@ export function entr_bdf(
     }
     return result
   }
-  // Fonction pour omettre des props, tout en retournant le bon type
-  function omitProps<Source, Exclusions extends Array<keyof Source>>(
-    object: Source,
-    ...propNames: Exclusions
-  ): Array<keyof Omit<Source, Exclusions[number]>> {
-    const result = omit(object, ...propNames)
-    return Object.keys(result) as (keyof typeof result)[]
-  }
   // TODO: [refacto] extraire dans common/ ou reduce.algo2/
 
   for (const hash in v.bdf) {
@@ -80,25 +72,18 @@ export function entr_bdf(
       const outputInPeriod = (outputBdf[periode.getTime()] =
         outputBdf[periode.getTime()] || {})
 
+      const periodData = omit(bdfHashData, "raison_sociale", "secteur", "siren")
+
       //if (outputInPeriod || periode.getTime() in periodes) {
-      Object.assign(
-        outputInPeriod,
-        omit(bdfHashData, "raison_sociale", "secteur", "siren")
-      )
+      Object.assign(outputInPeriod, periodData)
       if (outputInPeriod.annee_bdf) {
         outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1
       }
       //}
 
-      const excludedProps = [
-        "raison_sociale",
-        "secteur",
-        "siren",
-        "arrete_bilan_bdf",
-        "exercice_bdf",
-      ] as const
+      const pastData = omit(periodData, "arrete_bilan_bdf", "exercice_bdf")
 
-      for (const prop of omitProps(bdfHashData, ...excludedProps)) {
+      for (const prop of Object.keys(pastData) as (keyof typeof pastData)[]) {
         const past_year_offset = [1, 2]
         for (const offset of past_year_offset) {
           const periode_offset = f.dateAddMonth(periode, 12 * offset)

--- a/dbmongo/js/reduce.algo2/entr_bdf.ts
+++ b/dbmongo/js/reduce.algo2/entr_bdf.ts
@@ -38,7 +38,7 @@ export function entr_bdf(
     outputBdf[p] = {}
   }
 
-  for (const hash in donnéesBdf) {
+  for (const hash of Object.keys(donnéesBdf)) {
     const bdfHashData = donnéesBdf[hash]
     const periode_arrete_bilan = new Date(
       Date.UTC(

--- a/dbmongo/js/reduce.algo2/entr_sirene.ts
+++ b/dbmongo/js/reduce.algo2/entr_sirene.ts
@@ -11,7 +11,7 @@ export type SortieSireneUL = {
   age_entreprise?: number // en années
 }
 
-export function sirene_ul(
+export function entr_sirene(
   v: DonnéesSireneUL,
   output_array: (Input & Partial<SortieSireneUL>)[]
 ): void {

--- a/dbmongo/js/reduce.algo2/entr_sirene.ts
+++ b/dbmongo/js/reduce.algo2/entr_sirene.ts
@@ -4,16 +4,16 @@ type Input = {
   periode: Date
 }
 
-export type SortieSireneUL = {
-  raison_sociale: unknown
-  statut_juridique: unknown
+export type SortieSireneEntreprise = {
+  raison_sociale: string // nom de l'entreprise
+  statut_juridique: string | null // code numérique sérialisé en chaine de caractères
   date_creation_entreprise: number | null // année
   age_entreprise?: number // en années
 }
 
 export function entr_sirene(
-  v: DonnéesSireneUL,
-  output_array: (Input & Partial<SortieSireneUL>)[]
+  v: DonnéesSireneEntreprise,
+  output_array: (Input & Partial<SortieSireneEntreprise>)[]
 ): void {
   "use strict"
   const sireneHashes = Object.keys(v.sirene_ul || {})

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -21,7 +21,7 @@ import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { poidsFrng } from "./poidsFrng"
 import { detteFiscale } from "./detteFiscale"
 import { fraisFinancier } from "./fraisFinancier"
-import { entr_bdf } from "./entr_bdf"
+import { entr_bdf, SortieBdf } from "./entr_bdf"
 
 // Paramètres globaux utilisés par "reduce.algo2"
 declare const naf: NAF
@@ -188,7 +188,8 @@ export function map(this: {
         Partial<SortieSireneEntreprise> &
         Partial<EntréeBdf> &
         Partial<EntréeDiane> &
-        Record<string, unknown> // for *_past_* props of bdf. // TODO: try to be more specific
+        Partial<EntréeBdf> &
+        Partial<SortieBdf>
 
       const output_array: SortieMapEntreprise[] = serie_periode.map(function (
         e

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -21,6 +21,7 @@ import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { poidsFrng } from "./poidsFrng"
 import { detteFiscale } from "./detteFiscale"
 import { fraisFinancier } from "./fraisFinancier"
+import { entr_bdf } from "./entr_bdf"
 
 // Paramètres globaux utilisés par "reduce.algo2"
 declare const naf: NAF
@@ -49,7 +50,7 @@ export function map(this: {
     ...{ repeatable, delais, defaillances, cotisationsdettes, ccsf }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
     ...{ sirene, populateNafAndApe, cotisation, cibleApprentissage }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
     ...{ entr_sirene, dateAddMonth, generatePeriodSerie, poidsFrng }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
-    ...{ detteFiscale, fraisFinancier }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
+    ...{ detteFiscale, fraisFinancier, entr_bdf }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
   } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
 
   // Fonction pour omettre des props, tout en retournant le bon type
@@ -227,7 +228,10 @@ export function map(this: {
       v.bdf = v.bdf || {}
       v.diane = v.diane || {}
 
-      // TODO: appeler entr_bdf()
+      if (v.bdf) {
+         const outputBdf = f.entr_bdf(v as DonnéesBdf)
+        f.add(outputBdf, output_indexed)
+      }
 
       for (const hash of Object.keys(v.diane)) {
         if (!v.diane[hash].arrete_bilan_diane) continue

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -236,7 +236,7 @@ export function map(this: {
       if (v.bdf) {
         /*const outputBdf =*/ f.entr_bdf(
           v as DonnéesBdf,
-          output_indexed as Record<Periode, Record<string, number>>
+          output_indexed
           //, periodes
         )
         //f.add(outputBdf, output_indexed)

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -178,7 +178,8 @@ export function map(this: {
         Partial<EntréeBdf> &
         Partial<EntréeDiane> &
         Partial<EntréeBdf> &
-        Partial<SortieBdf>
+        Partial<SortieBdf> &
+        Record<string, unknown> // for *_past_* props of diane. // TODO: try to be more specific
 
       const output_array: SortieMapEntreprise[] = serie_periode.map(function (
         e

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -204,7 +204,7 @@ export function map(this: {
         }
       })
 
-      let output_indexed = output_array.reduce(function (periode, val) {
+      const output_indexed = output_array.reduce(function (periode, val) {
         periode[val.periode.getTime()] = val
         return periode
       }, {} as Record<Periode, SortieMapEntreprise>)
@@ -225,11 +225,6 @@ export function map(this: {
         )
         f.add(output_effectif_ent, output_indexed)
       }
-
-      output_indexed = output_array.reduce(function (periode, val) {
-        periode[val.periode.getTime()] = val
-        return periode
-      }, {} as Record<Periode, SortieMapEntreprise>)
 
       v.bdf = v.bdf || {}
       v.diane = v.diane || {}

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -15,7 +15,7 @@ import { sirene } from "./sirene"
 import { populateNafAndApe } from "./populateNafAndApe"
 import { cotisation } from "./cotisation"
 import { cibleApprentissage } from "./cibleApprentissage"
-import { entr_sirene, SortieSireneUL } from "./entr_sirene"
+import { entr_sirene, SortieSireneEntreprise } from "./entr_sirene"
 import { dateAddMonth } from "./dateAddMonth"
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { poidsFrng } from "./poidsFrng"
@@ -184,7 +184,7 @@ export function map(this: {
         periode: Date
       }
       type SortieMapEntreprise = Input &
-        Partial<SortieSireneUL> &
+        Partial<SortieSireneEntreprise> &
         Partial<EntréeBdf> &
         Partial<EntréeDiane> &
         Record<string, unknown> // for *_past_* props of bdf. // TODO: try to be more specific
@@ -208,7 +208,7 @@ export function map(this: {
       }, {} as Record<Periode, SortieMapEntreprise>)
 
       if (v.sirene_ul) {
-        f.entr_sirene(v as DonnéesSireneUL, output_array)
+        f.entr_sirene(v as DonnéesSireneEntreprise, output_array)
       }
 
       const periodes = Object.keys(output_indexed)

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -51,7 +51,7 @@ export function map(this: {
     ...{ repeatable, delais, defaillances, cotisationsdettes, ccsf }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
     ...{ sirene, populateNafAndApe, cotisation, cibleApprentissage }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
     ...{ entr_sirene, dateAddMonth, generatePeriodSerie, poidsFrng }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
-    ...{ detteFiscale, fraisFinancier, entr_bdf }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
+    ...{ detteFiscale, fraisFinancier, entr_bdf, omit }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
   } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
 
   const v = f.flatten(this.value, actual_batch)
@@ -245,7 +245,7 @@ export function map(this: {
         )
 
         for (const periode of series) {
-          const rest = omit(
+          const rest = f.omit(
             v.diane[hash] as EntréeDiane & {
               marquee: unknown
               nom_entreprise: unknown

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -220,7 +220,7 @@ export function map(this: {
       v.diane = v.diane || {}
 
       if (v.bdf) {
-        const outputBdf = f.entr_bdf(v as DonnéesBdf, output_indexed, periodes)
+        const outputBdf = f.entr_bdf(v as DonnéesBdf, periodes)
         f.add(outputBdf, output_indexed)
       }
 

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -230,7 +230,11 @@ export function map(this: {
       v.diane = v.diane || {}
 
       if (v.bdf) {
-        const outputBdf = f.entr_bdf(v as DonnéesBdf, output_indexed, periodes)
+        const outputBdf = f.entr_bdf(
+          v as DonnéesBdf,
+          output_indexed
+          // periodes
+        )
         f.add(outputBdf, output_indexed)
       }
 

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -230,11 +230,7 @@ export function map(this: {
       v.diane = v.diane || {}
 
       if (v.bdf) {
-        const outputBdf = f.entr_bdf(
-          v as DonnéesBdf,
-          output_indexed
-          //, periodes
-        )
+        const outputBdf = f.entr_bdf(v as DonnéesBdf, output_indexed, periodes)
         f.add(outputBdf, output_indexed)
       }
 

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -203,7 +203,7 @@ export function map(this: {
         }
       })
 
-      const output_indexed = output_array.reduce(function (periode, val) {
+      let output_indexed = output_array.reduce(function (periode, val) {
         periode[val.periode.getTime()] = val
         return periode
       }, {} as Record<Periode, SortieMapEntreprise>)
@@ -225,12 +225,21 @@ export function map(this: {
         f.add(output_effectif_ent, output_indexed)
       }
 
+      output_indexed = output_array.reduce(function (periode, val) {
+        periode[val.periode.getTime()] = val
+        return periode
+      }, {} as Record<Periode, SortieMapEntreprise>)
+
       v.bdf = v.bdf || {}
       v.diane = v.diane || {}
 
       if (v.bdf) {
-        const outputBdf = f.entr_bdf(v as DonnéesBdf, periodes)
-        f.add(outputBdf, output_indexed)
+        /*const outputBdf =*/ f.entr_bdf(
+          v as DonnéesBdf,
+          output_indexed as Record<Periode, Record<string, number>>
+          //, periodes
+        )
+        //f.add(outputBdf, output_indexed)
       }
 
       for (const hash of Object.keys(v.diane)) {

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -202,7 +202,7 @@ export function map(this: {
         }
       })
 
-      let output_indexed = output_array.reduce(function (periode, val) {
+      const output_indexed = output_array.reduce(function (periode, val) {
         periode[val.periode.getTime()] = val
         return periode
       }, {} as Record<Periode, SortieMapEntreprise>)
@@ -214,6 +214,7 @@ export function map(this: {
       const periodes = Object.keys(output_indexed)
         .sort()
         .map((timestamp) => parseInt(timestamp))
+
       if (v.effectif_ent) {
         const output_effectif_ent = f.effectifs(
           v.effectif_ent,
@@ -223,70 +224,10 @@ export function map(this: {
         f.add(output_effectif_ent, output_indexed)
       }
 
-      output_indexed = output_array.reduce(function (periode, val) {
-        periode[val.periode.getTime()] = val
-        return periode
-      }, {} as Record<Periode, SortieMapEntreprise>)
-
       v.bdf = v.bdf || {}
       v.diane = v.diane || {}
 
-      for (const hash in v.bdf) {
-        const periode_arrete_bilan = new Date(
-          Date.UTC(
-            v.bdf[hash].arrete_bilan_bdf.getUTCFullYear(),
-            v.bdf[hash].arrete_bilan_bdf.getUTCMonth() + 1,
-            1,
-            0,
-            0,
-            0,
-            0
-          )
-        )
-        const periode_dispo = f.dateAddMonth(periode_arrete_bilan, 7)
-        const series = f.generatePeriodSerie(
-          periode_dispo,
-          f.dateAddMonth(periode_dispo, 13)
-        )
-
-        for (const periode of series) {
-          const bdfHashData = v.bdf[hash]
-          const outputInPeriod = output_indexed[periode.getTime()]
-          const rest = omit(
-            bdfHashData as EntréeBdf & {
-              raison_sociale: unknown
-              secteur: unknown
-              siren: unknown
-            },
-            "raison_sociale",
-            "secteur",
-            "siren"
-          )
-
-          if (outputInPeriod) {
-            Object.assign(outputInPeriod, rest)
-            if (outputInPeriod.annee_bdf) {
-              outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1
-            }
-          }
-
-          for (const k of Object.keys(rest) as (keyof typeof rest)[]) {
-            const past_year_offset = [1, 2]
-            for (const offset of past_year_offset) {
-              const periode_offset = f.dateAddMonth(periode, 12 * offset)
-              const variable_name = k + "_past_" + offset
-              if (
-                periode_offset.getTime() in output_indexed &&
-                k !== "arrete_bilan_bdf" &&
-                k !== "exercice_bdf"
-              ) {
-                output_indexed[periode_offset.getTime()][variable_name] =
-                  v.bdf[hash][k]
-              }
-            }
-          }
-        }
-      }
+      // TODO: appeler entr_bdf()
 
       for (const hash of Object.keys(v.diane)) {
         if (!v.diane[hash].arrete_bilan_diane) continue

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -229,7 +229,7 @@ export function map(this: {
       v.diane = v.diane || {}
 
       if (v.bdf) {
-        const outputBdf = f.entr_bdf(v as DonnéesBdf)
+        const outputBdf = f.entr_bdf(v as DonnéesBdf, periodes)
         f.add(outputBdf, output_indexed)
       }
 

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -229,7 +229,7 @@ export function map(this: {
       v.diane = v.diane || {}
 
       if (v.bdf) {
-         const outputBdf = f.entr_bdf(v as DonnéesBdf)
+        const outputBdf = f.entr_bdf(v as DonnéesBdf)
         f.add(outputBdf, output_indexed)
       }
 

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -230,12 +230,12 @@ export function map(this: {
       v.diane = v.diane || {}
 
       if (v.bdf) {
-        /*const outputBdf =*/ f.entr_bdf(
+        const outputBdf = f.entr_bdf(
           v as DonnéesBdf,
           output_indexed
           //, periodes
         )
-        //f.add(outputBdf, output_indexed)
+        f.add(outputBdf, output_indexed)
       }
 
       for (const hash of Object.keys(v.diane)) {

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -230,11 +230,7 @@ export function map(this: {
       v.diane = v.diane || {}
 
       if (v.bdf) {
-        const outputBdf = f.entr_bdf(
-          v as DonnéesBdf,
-          output_indexed
-          // periodes
-        )
+        const outputBdf = f.entr_bdf(v as DonnéesBdf, output_indexed, periodes)
         f.add(outputBdf, output_indexed)
       }
 

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -15,7 +15,7 @@ import { sirene } from "./sirene"
 import { populateNafAndApe } from "./populateNafAndApe"
 import { cotisation } from "./cotisation"
 import { cibleApprentissage } from "./cibleApprentissage"
-import { sirene_ul, SortieSireneUL } from "./sirene_ul"
+import { entr_sirene, SortieSireneUL } from "./entr_sirene"
 import { dateAddMonth } from "./dateAddMonth"
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { poidsFrng } from "./poidsFrng"
@@ -48,7 +48,7 @@ export function map(this: {
     ...{ flatten, outputs, apart, compte, effectifs, interim, add }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
     ...{ repeatable, delais, defaillances, cotisationsdettes, ccsf }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
     ...{ sirene, populateNafAndApe, cotisation, cibleApprentissage }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
-    ...{ sirene_ul, dateAddMonth, generatePeriodSerie, poidsFrng }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
+    ...{ entr_sirene, dateAddMonth, generatePeriodSerie, poidsFrng }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
     ...{ detteFiscale, fraisFinancier }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
   } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
 
@@ -208,7 +208,7 @@ export function map(this: {
       }, {} as Record<Periode, SortieMapEntreprise>)
 
       if (v.sirene_ul) {
-        f.sirene_ul(v as DonnéesSireneUL, output_array)
+        f.entr_sirene(v as DonnéesSireneUL, output_array)
       }
 
       const periodes = Object.keys(output_indexed)

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -220,7 +220,7 @@ export function map(this: {
       v.diane = v.diane || {}
 
       if (v.bdf) {
-        const outputBdf = f.entr_bdf(v as DonnéesBdf, periodes)
+        const outputBdf = f.entr_bdf(v.bdf, periodes)
         f.add(outputBdf, output_indexed)
       }
 

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -22,6 +22,7 @@ import { poidsFrng } from "./poidsFrng"
 import { detteFiscale } from "./detteFiscale"
 import { fraisFinancier } from "./fraisFinancier"
 import { entr_bdf, SortieBdf } from "./entr_bdf"
+import { omit } from "../common/omit"
 
 // Paramètres globaux utilisés par "reduce.algo2"
 declare const naf: NAF
@@ -52,18 +53,6 @@ export function map(this: {
     ...{ entr_sirene, dateAddMonth, generatePeriodSerie, poidsFrng }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
     ...{ detteFiscale, fraisFinancier, entr_bdf }, // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
   } // DO_NOT_INCLUDE_IN_JSFUNCTIONS_GO
-
-  // Fonction pour omettre des props, tout en retournant le bon type
-  function omit<Source, Exclusions extends Array<keyof Source>>(
-    object: Source,
-    ...propNames: Exclusions
-  ): Omit<Source, Exclusions[number]> {
-    const result: Omit<Source, Exclusions[number]> = Object.assign({}, object)
-    for (const prop of propNames) {
-      delete (result as any)[prop]
-    }
-    return result
-  }
 
   const v = f.flatten(this.value, actual_batch)
 

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1534,31 +1534,8 @@ function delais(v, debitParPériode, intervalleTraitement) {
     return output_effectif;
 }
 /* TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts */`,
-"entr_bdf": `/*
-type SortieBdf = {
-  annee_bdf: number
-  exercice_bdf: number // année
-} & RatiosBdf &
-  RatiosBdfPassés
-
-// Synchroniser les propriétés avec celles de RatiosBdf
-type RatiosBdfPassés = {
-  poids_frng_past_1: number
-  taux_marge_past_1: number
-  delai_fournisseur_past_1: number
-  dette_fiscale_past_1: number
-  financier_court_terme_past_1: number
-  frais_financier_past_1: number
-  poids_frng_past_2: number
-  taux_marge_past_2: number
-  delai_fournisseur_past_2: number
-  dette_fiscale_past_2: number
-  financier_court_terme_past_2: number
-  frais_financier_past_2: number
-}
-*/
-function entr_bdf(entréeBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
-output_indexed // for *_past_* props of bdf. // TODO: try to be more specific
+"entr_bdf": `function entr_bdf(v, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
+output_indexed
 // periodes: Timestamp[]
 ) {
     // const outputBdf: ParPériode<SortieBdf> = {}
@@ -1579,8 +1556,8 @@ output_indexed // for *_past_* props of bdf. // TODO: try to be more specific
         return result;
     }
     // TODO: [refacto] extraire dans common/ ou reduce.algo2/
-    for (const hash in /*of typedObjectKeys*/ entréeBdf.bdf) {
-        const bdfHashData = entréeBdf.bdf[hash];
+    for (const hash in /*of typedObjectKeys*/ v.bdf) {
+        const bdfHashData = v.bdf[hash];
         const periode_arrete_bilan = new Date(Date.UTC(bdfHashData.arrete_bilan_bdf.getUTCFullYear(), bdfHashData.arrete_bilan_bdf.getUTCMonth() + 1, 1, 0, 0, 0, 0));
         const periode_dispo = f.dateAddMonth(periode_arrete_bilan, 7);
         const series = f.generatePeriodSerie(periode_dispo, f.dateAddMonth(periode_dispo, 13));
@@ -1604,7 +1581,7 @@ output_indexed // for *_past_* props of bdf. // TODO: try to be more specific
                         k !== "exercice_bdf"
                     // TODO: props à inclure dans le omit ci-dessus
                     ) {
-                        output_indexed[periode_offset.getTime()] = Object.assign(Object.assign({}, output_indexed[periode_offset.getTime()]), { [variable_name]: entréeBdf.bdf[hash][k] });
+                        output_indexed[periode_offset.getTime()] = Object.assign(Object.assign({}, output_indexed[periode_offset.getTime()]), { [variable_name]: v.bdf[hash][k] });
                     }
                 }
             }

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1538,6 +1538,7 @@ function delais(v, debitParPériode, intervalleTraitement) {
 output_indexed
 // periodes: Timestamp[]
 ) {
+    "use strict";
     // const outputBdf: ParPériode<SortieBdf> = {}
     // const outputBdf = entréeBdf.bdf
 

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1535,9 +1535,7 @@ function delais(v, debitParPériode, intervalleTraitement) {
 }
 /* TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts */`,
 "entr_bdf": `function entr_bdf(v, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
-output_indexed
-// periodes: Timestamp[]
-) {
+output_indexed, periodes) {
     "use strict";
     const outputBdf = Object.assign({}, output_indexed);
 
@@ -1575,7 +1573,7 @@ output_indexed
                 for (const offset of past_year_offset) {
                     const periode_offset = f.dateAddMonth(periode, 12 * offset);
                     const variable_name = k + "_past_" + offset;
-                    if (periode_offset.getTime() in output_indexed &&
+                    if (periode_offset.getTime() in periodes &&
                         // TODO: ` + "`" + `in periodes` + "`" + ` en récupérant un paramètre périodes.
                         k !== "arrete_bilan_bdf" &&
                         k !== "exercice_bdf"
@@ -1583,12 +1581,6 @@ output_indexed
                     ) {
                         output_indexed[periode_offset.getTime()][variable_name] =
                             v.bdf[hash][k];
-                        /*
-                        output_indexed[periode_offset.getTime()] = {
-                          ...output_indexed[periode_offset.getTime()],
-                          [variable_name]: v.bdf[hash][k],
-                        }
-                        */
                     }
                 }
             }
@@ -1970,9 +1962,7 @@ function map() {
             v.bdf = v.bdf || {};
             v.diane = v.diane || {};
             if (v.bdf) {
-                const outputBdf = f.entr_bdf(v, output_indexed
-                // periodes
-                );
+                const outputBdf = f.entr_bdf(v, output_indexed, periodes);
                 f.add(outputBdf, output_indexed);
             }
             for (const hash of Object.keys(v.diane)) {

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1575,7 +1575,8 @@ output_indexed, periodes) {
                 for (const offset of past_year_offset) {
                     const periode_offset = f.dateAddMonth(periode, 12 * offset);
                     const variable_name = k + "_past_" + offset;
-                    if (periode_offset.getTime() in output_indexed &&
+                    if (outputBdf[periode_offset.getTime()] &&
+                        // periode_offset.getTime() in output_indexed &&
                         // TODO: ` + "`" + `in periodes` + "`" + ` en récupérant un paramètre périodes.
                         k !== "arrete_bilan_bdf" &&
                         k !== "exercice_bdf"

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1539,8 +1539,7 @@ output_indexed
 // periodes: Timestamp[]
 ) {
     "use strict";
-    // const outputBdf: ParPériode<SortieBdf> = {}
-    // const outputBdf = entréeBdf.bdf
+    const outputBdf = Object.assign({}, output_indexed);
 
     /*
     // Retourne les clés de obj, en respectant le type défini dans le type de obj.
@@ -1557,7 +1556,7 @@ output_indexed
         return result;
     }
     // TODO: [refacto] extraire dans common/ ou reduce.algo2/
-    for (const hash in /*of typedObjectKeys*/ v.bdf) {
+    for (const hash in v.bdf) {
         const bdfHashData = v.bdf[hash];
         const periode_arrete_bilan = new Date(Date.UTC(bdfHashData.arrete_bilan_bdf.getUTCFullYear(), bdfHashData.arrete_bilan_bdf.getUTCMonth() + 1, 1, 0, 0, 0, 0));
         const periode_dispo = f.dateAddMonth(periode_arrete_bilan, 7);
@@ -1595,7 +1594,7 @@ output_indexed
             }
         }
     }
-    return output_indexed;
+    return outputBdf;
 }`,
 "entr_sirene": `function entr_sirene(v, output_array) {
     "use strict";
@@ -1972,7 +1971,7 @@ function map() {
             v.diane = v.diane || {};
             if (v.bdf) {
                 const outputBdf = f.entr_bdf(v, output_indexed
-                //, periodes
+                // periodes
                 );
                 f.add(outputBdf, output_indexed);
             }

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1595,7 +1595,7 @@ output_indexed
             }
         }
     }
-    // return outputBdf
+    return output_indexed;
 }`,
 "entr_sirene": `function entr_sirene(v, output_array) {
     "use strict";
@@ -1971,10 +1971,10 @@ function map() {
             v.bdf = v.bdf || {};
             v.diane = v.diane || {};
             if (v.bdf) {
-                /*const outputBdf =*/ f.entr_bdf(v, output_indexed
+                const outputBdf = f.entr_bdf(v, output_indexed
                 //, periodes
                 );
-                //f.add(outputBdf, output_indexed)
+                f.add(outputBdf, output_indexed);
             }
             for (const hash of Object.keys(v.diane)) {
                 if (!v.diane[hash].arrete_bilan_diane)

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1543,11 +1543,13 @@ function delais(v, debitParPériode, intervalleTraitement) {
 }
 /* TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts */`,
 "entr_bdf": `function entr_bdf(v, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
-output_indexed, periodes) {
+periodes) {
     "use strict";
-    periodes;
-    const outputBdf = Object.assign({}, output_indexed);
 
+    const outputBdf = {};
+    for (const p of periodes) {
+        outputBdf[p] = {};
+    }
     for (const hash in v.bdf) {
         const bdfHashData = v.bdf[hash];
         const periode_arrete_bilan = new Date(Date.UTC(bdfHashData.arrete_bilan_bdf.getUTCFullYear(), bdfHashData.arrete_bilan_bdf.getUTCMonth() + 1, 1, 0, 0, 0, 0));
@@ -1946,7 +1948,7 @@ function map() {
             v.bdf = v.bdf || {};
             v.diane = v.diane || {};
             if (v.bdf) {
-                const outputBdf = f.entr_bdf(v, output_indexed, periodes);
+                const outputBdf = f.entr_bdf(v, periodes);
                 f.add(outputBdf, output_indexed);
             }
             for (const hash of Object.keys(v.diane)) {

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -193,6 +193,14 @@ function forEachPopulatedProp(obj, fct) {
     }
     return serie;
 }`,
+"omit": `// Fonction pour omettre des props, tout en retournant le bon type
+function omit(object, ...propNames) {
+    const result = Object.assign({}, object);
+    for (const prop of propNames) {
+        delete result[prop];
+    }
+    return result;
+}`,
 "raison_sociale": `function raison_sociale /*eslint-disable-line @typescript-eslint/no-unused-vars */(denomination_unite_legale, nom_unite_legale, nom_usage_unite_legale, prenom1_unite_legale, prenom2_unite_legale, prenom3_unite_legale, prenom4_unite_legale) {
     "use strict";
     const nomUsageUniteLegale = nom_usage_unite_legale
@@ -1540,15 +1548,6 @@ output_indexed, periodes) {
     periodes;
     const outputBdf = Object.assign({}, output_indexed);
 
-    // Fonction pour omettre des props, tout en retournant le bon type
-    function omit(object, ...propNames) {
-        const result = Object.assign({}, object);
-        for (const prop of propNames) {
-            delete result[prop];
-        }
-        return result;
-    }
-    // TODO: [refacto] extraire dans common/ ou reduce.algo2/
     for (const hash in v.bdf) {
         const bdfHashData = v.bdf[hash];
         const periode_arrete_bilan = new Date(Date.UTC(bdfHashData.arrete_bilan_bdf.getUTCFullYear(), bdfHashData.arrete_bilan_bdf.getUTCMonth() + 1, 1, 0, 0, 0, 0));
@@ -1837,14 +1836,6 @@ function flatten(v, actual_batch) {
 function map() {
     "use strict";
 
-    // Fonction pour omettre des props, tout en retournant le bon type
-    function omit(object, ...propNames) {
-        const result = Object.assign({}, object);
-        for (const prop of propNames) {
-            delete result[prop];
-        }
-        return result;
-    }
     const v = f.flatten(this.value, actual_batch);
     if (v.scope === "etablissement") {
         const [output_array, // DonnéesAgrégées[] dans l'ordre chronologique

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1570,7 +1570,9 @@ output_indexed, periodes) {
                     const periode_offset = f.dateAddMonth(periode, 12 * offset);
                     const outputInPast = outputBdf[periode_offset.getTime()];
                     if (outputInPast) {
-                        outputInPast[prop + "_past_" + offset] = v.bdf[hash][prop];
+                        Object.assign(outputInPast, {
+                            [prop + "_past_" + offset]: v.bdf[hash][prop],
+                        });
                     }
                 }
             }

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1582,7 +1582,14 @@ output_indexed
                         k !== "exercice_bdf"
                     // TODO: props à inclure dans le omit ci-dessus
                     ) {
-                        output_indexed[periode_offset.getTime()] = Object.assign(Object.assign({}, output_indexed[periode_offset.getTime()]), { [variable_name]: v.bdf[hash][k] });
+                        output_indexed[periode_offset.getTime()][variable_name] =
+                            v.bdf[hash][k];
+                        /*
+                        output_indexed[periode_offset.getTime()] = {
+                          ...output_indexed[periode_offset.getTime()],
+                          [variable_name]: v.bdf[hash][k],
+                        }
+                        */
                     }
                 }
             }

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1534,6 +1534,26 @@ function delais(v, debitParPériode, intervalleTraitement) {
     return output_effectif;
 }
 /* TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts */`,
+"entr_sirene": `function entr_sirene(v, output_array) {
+    "use strict";
+    const sireneHashes = Object.keys(v.sirene_ul || {});
+    output_array.forEach((val) => {
+        if (sireneHashes.length !== 0) {
+            const sirene = v.sirene_ul[sireneHashes[sireneHashes.length - 1]];
+            val.raison_sociale = f.raison_sociale(sirene.raison_sociale, sirene.nom_unite_legale, sirene.nom_usage_unite_legale, sirene.prenom1_unite_legale, sirene.prenom2_unite_legale, sirene.prenom3_unite_legale, sirene.prenom4_unite_legale);
+            val.statut_juridique = sirene.statut_juridique || null;
+            val.date_creation_entreprise = sirene.date_creation
+                ? sirene.date_creation.getFullYear()
+                : null;
+            if (val.date_creation_entreprise &&
+                sirene.date_creation &&
+                sirene.date_creation >= new Date("1901/01/01")) {
+                val.age_entreprise =
+                    val.periode.getFullYear() - val.date_creation_entreprise;
+            }
+        }
+    });
+}`,
 "finalize": `function finalize(k, v) {
     "use strict";
     const maxBsonSize = 16777216;
@@ -1876,7 +1896,7 @@ function map() {
                 return periode;
             }, {});
             if (v.sirene_ul) {
-                f.sirene_ul(v, output_array);
+                f.entr_sirene(v, output_array);
             }
             const periodes = Object.keys(output_indexed)
                 .sort()
@@ -2142,26 +2162,6 @@ function outputs(v, serie_periode) {
                     sirene.date_creation && sirene.date_creation >= new Date("1901/01/01")
                         ? val.periode.getFullYear() - val.date_creation_etablissement
                         : null;
-            }
-        }
-    });
-}`,
-"sirene_ul": `function sirene_ul(v, output_array) {
-    "use strict";
-    const sireneHashes = Object.keys(v.sirene_ul || {});
-    output_array.forEach((val) => {
-        if (sireneHashes.length !== 0) {
-            const sirene = v.sirene_ul[sireneHashes[sireneHashes.length - 1]];
-            val.raison_sociale = f.raison_sociale(sirene.raison_sociale, sirene.nom_unite_legale, sirene.nom_usage_unite_legale, sirene.prenom1_unite_legale, sirene.prenom2_unite_legale, sirene.prenom3_unite_legale, sirene.prenom4_unite_legale);
-            val.statut_juridique = sirene.statut_juridique || null;
-            val.date_creation_entreprise = sirene.date_creation
-                ? sirene.date_creation.getFullYear()
-                : null;
-            if (val.date_creation_entreprise &&
-                sirene.date_creation &&
-                sirene.date_creation >= new Date("1901/01/01")) {
-                val.age_entreprise =
-                    val.periode.getFullYear() - val.date_creation_entreprise;
             }
         }
     });

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1580,7 +1580,7 @@ output_indexed
                         // TODO: ` + "`" + `in periodes` + "`" + ` en récupérant un paramètre périodes.
                         k !== "arrete_bilan_bdf" &&
                         k !== "exercice_bdf"
-                    // TODO: props à inclure dans le omit ci-dessus
+                    // TODO: props à inclure dans le omit ci-dessus ?
                     ) {
                         output_indexed[periode_offset.getTime()][variable_name] =
                             v.bdf[hash][k];
@@ -1954,7 +1954,7 @@ function map() {
                     arrete_bilan_diane: new Date(0),
                 };
             });
-            let output_indexed = output_array.reduce(function (periode, val) {
+            const output_indexed = output_array.reduce(function (periode, val) {
                 periode[val.periode.getTime()] = val;
                 return periode;
             }, {});
@@ -1968,10 +1968,6 @@ function map() {
                 const output_effectif_ent = f.effectifs(v.effectif_ent, periodes, "effectif_ent");
                 f.add(output_effectif_ent, output_indexed);
             }
-            output_indexed = output_array.reduce(function (periode, val) {
-                periode[val.periode.getTime()] = val;
-                return periode;
-            }, {});
             v.bdf = v.bdf || {};
             v.diane = v.diane || {};
             if (v.bdf) {

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1549,7 +1549,7 @@ function delais(v, debitParPériode, intervalleTraitement) {
     for (const p of periodes) {
         outputBdf[p] = {};
     }
-    for (const hash in donnéesBdf) {
+    for (const hash of Object.keys(donnéesBdf)) {
         const bdfHashData = donnéesBdf[hash];
         const periode_arrete_bilan = new Date(Date.UTC(bdfHashData.arrete_bilan_bdf.getUTCFullYear(), bdfHashData.arrete_bilan_bdf.getUTCMonth() + 1, 1, 0, 0, 0, 0));
         const periode_dispo = f.dateAddMonth(periode_arrete_bilan, 7);

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1534,7 +1534,8 @@ function delais(v, debitParPériode, intervalleTraitement) {
     return output_effectif;
 }
 /* TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts */`,
-"entr_bdf": `function entr_bdf(entréeBdf) {
+"entr_bdf": `function entr_bdf(entréeBdf, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
+periodes) {
     const outputBdf = {};
 
     // Retourne les clés de obj, en respectant le type défini dans le type de obj.
@@ -1550,14 +1551,14 @@ function delais(v, debitParPériode, intervalleTraitement) {
     }
     // TODO: [refacto] extraire dans common/ ou reduce.algo2/
     for (const hash of typedObjectKeys(entréeBdf.bdf)) {
-        const periode_arrete_bilan = new Date(Date.UTC(entréeBdf.bdf[hash].arrete_bilan_bdf.getUTCFullYear(), entréeBdf.bdf[hash].arrete_bilan_bdf.getUTCMonth() + 1, 1, 0, 0, 0, 0));
+        const bdfHashData = entréeBdf.bdf[hash];
+        const periode_arrete_bilan = new Date(Date.UTC(bdfHashData.arrete_bilan_bdf.getUTCFullYear(), bdfHashData.arrete_bilan_bdf.getUTCMonth() + 1, 1, 0, 0, 0, 0));
         const periode_dispo = f.dateAddMonth(periode_arrete_bilan, 7);
         const series = f.generatePeriodSerie(periode_dispo, f.dateAddMonth(periode_dispo, 13));
         for (const periode of series) {
-            const bdfHashData = entréeBdf.bdf[hash];
             const outputInPeriod = outputBdf[periode.getTime()];
             const rest = omit(bdfHashData, "raison_sociale", "secteur", "siren");
-            if (outputInPeriod) {
+            if (periode.getTime() in periodes) {
                 Object.assign(outputInPeriod, rest);
                 if (outputInPeriod.annee_bdf) {
                     outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1;
@@ -1956,7 +1957,7 @@ function map() {
             v.bdf = v.bdf || {};
             v.diane = v.diane || {};
             if (v.bdf) {
-                const outputBdf = f.entr_bdf(v);
+                const outputBdf = f.entr_bdf(v, periodes);
                 f.add(outputBdf, output_indexed);
             }
             for (const hash of Object.keys(v.diane)) {

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1562,17 +1562,14 @@ output_indexed, periodes) {
         const series = f.generatePeriodSerie(periode_dispo, f.dateAddMonth(periode_dispo, 13));
         for (const periode of series) {
             const outputInPeriod = (outputBdf[periode.getTime()] =
-                outputBdf[periode.getTime()] ||
-                    {
-                    /*...output_indexed[periode.getTime()]*/
-                    });
+                outputBdf[periode.getTime()] || {});
             const rest = omit(bdfHashData, "raison_sociale", "secteur", "siren");
-            if (outputInPeriod /*periode.getTime() in periodes*/) {
-                Object.assign(outputInPeriod, rest);
-                if (outputInPeriod.annee_bdf) {
-                    outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1;
-                }
+            //if (outputInPeriod || periode.getTime() in periodes) {
+            Object.assign(outputInPeriod, rest);
+            if (outputInPeriod.annee_bdf) {
+                outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1;
             }
+            //}
             for (const k of Object.keys(rest)) {
                 const past_year_offset = [1, 2];
                 for (const offset of past_year_offset) {

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1561,7 +1561,7 @@ output_indexed, periodes) {
         const periode_dispo = f.dateAddMonth(periode_arrete_bilan, 7);
         const series = f.generatePeriodSerie(periode_dispo, f.dateAddMonth(periode_dispo, 13));
         for (const periode of series) {
-            const outputInPeriod = output_indexed[periode.getTime()];
+            const outputInPeriod = (outputBdf[periode.getTime()] = outputBdf[periode.getTime()] || Object.assign({}, output_indexed[periode.getTime()]));
             const rest = omit(bdfHashData, "raison_sociale", "secteur", "siren");
             if (outputInPeriod /*periode.getTime() in periodes*/) {
                 Object.assign(outputInPeriod, rest);

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1548,11 +1548,6 @@ output_indexed, periodes) {
         }
         return result;
     }
-    // Fonction pour omettre des props, tout en retournant le bon type
-    function omitProps(object, ...propNames) {
-        const result = omit(object, ...propNames);
-        return Object.keys(result);
-    }
     // TODO: [refacto] extraire dans common/ ou reduce.algo2/
     for (const hash in v.bdf) {
         const bdfHashData = v.bdf[hash];
@@ -1562,20 +1557,15 @@ output_indexed, periodes) {
         for (const periode of series) {
             const outputInPeriod = (outputBdf[periode.getTime()] =
                 outputBdf[periode.getTime()] || {});
+            const periodData = omit(bdfHashData, "raison_sociale", "secteur", "siren");
             //if (outputInPeriod || periode.getTime() in periodes) {
-            Object.assign(outputInPeriod, omit(bdfHashData, "raison_sociale", "secteur", "siren"));
+            Object.assign(outputInPeriod, periodData);
             if (outputInPeriod.annee_bdf) {
                 outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1;
             }
             //}
-            const excludedProps = [
-                "raison_sociale",
-                "secteur",
-                "siren",
-                "arrete_bilan_bdf",
-                "exercice_bdf",
-            ];
-            for (const prop of omitProps(bdfHashData, ...excludedProps)) {
+            const pastData = omit(periodData, "arrete_bilan_bdf", "exercice_bdf");
+            for (const prop of Object.keys(pastData)) {
                 const past_year_offset = [1, 2];
                 for (const offset of past_year_offset) {
                     const periode_offset = f.dateAddMonth(periode, 12 * offset);

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1537,6 +1537,7 @@ function delais(v, debitParPériode, intervalleTraitement) {
 "entr_bdf": `function entr_bdf(v, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
 output_indexed, periodes) {
     "use strict";
+    periodes;
     const outputBdf = Object.assign({}, output_indexed);
 
     /*
@@ -1573,14 +1574,13 @@ output_indexed, periodes) {
                 for (const offset of past_year_offset) {
                     const periode_offset = f.dateAddMonth(periode, 12 * offset);
                     const variable_name = k + "_past_" + offset;
-                    if (periode_offset.getTime() in periodes &&
+                    if (periode_offset.getTime() in output_indexed &&
                         // TODO: ` + "`" + `in periodes` + "`" + ` en récupérant un paramètre périodes.
                         k !== "arrete_bilan_bdf" &&
                         k !== "exercice_bdf"
                     // TODO: props à inclure dans le omit ci-dessus ?
                     ) {
-                        output_indexed[periode_offset.getTime()][variable_name] =
-                            v.bdf[hash][k];
+                        outputBdf[periode_offset.getTime()][variable_name] = v.bdf[hash][k];
                     }
                 }
             }

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1550,21 +1550,21 @@ function delais(v, debitParPériode, intervalleTraitement) {
         outputBdf[p] = {};
     }
     for (const hash of Object.keys(donnéesBdf)) {
-        const bdfHashData = donnéesBdf[hash];
-        const periode_arrete_bilan = new Date(Date.UTC(bdfHashData.arrete_bilan_bdf.getUTCFullYear(), bdfHashData.arrete_bilan_bdf.getUTCMonth() + 1, 1, 0, 0, 0, 0));
+        const entréeBdf = donnéesBdf[hash];
+        const periode_arrete_bilan = new Date(Date.UTC(entréeBdf.arrete_bilan_bdf.getUTCFullYear(), entréeBdf.arrete_bilan_bdf.getUTCMonth() + 1, 1, 0, 0, 0, 0));
         const periode_dispo = f.dateAddMonth(periode_arrete_bilan, 7);
         const series = f.generatePeriodSerie(periode_dispo, f.dateAddMonth(periode_dispo, 13));
         for (const periode of series) {
             const outputInPeriod = (outputBdf[periode.getTime()] =
                 outputBdf[periode.getTime()] || {});
-            const periodData = omit(bdfHashData, "raison_sociale", "secteur", "siren");
+            const periodData = f.omit(entréeBdf, "raison_sociale", "secteur", "siren");
             //if (outputInPeriod || periode.getTime() in periodes) {
             Object.assign(outputInPeriod, periodData);
             if (outputInPeriod.annee_bdf) {
                 outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1;
             }
             //}
-            const pastData = omit(periodData, "arrete_bilan_bdf", "exercice_bdf");
+            const pastData = f.omit(periodData, "arrete_bilan_bdf", "exercice_bdf");
             for (const prop of Object.keys(pastData)) {
                 const past_year_offset = [1, 2];
                 for (const offset of past_year_offset) {
@@ -1959,7 +1959,7 @@ function map() {
                 const series = f.generatePeriodSerie(periode_dispo, f.dateAddMonth(periode_dispo, 14) // periode de validité d'un bilan auprès de la Banque de France: 21 mois (14+7)
                 );
                 for (const periode of series) {
-                    const rest = omit(v.diane[hash], "marquee", "nom_entreprise", "numero_siren", "statut_juridique", "procedure_collective");
+                    const rest = f.omit(v.diane[hash], "marquee", "nom_entreprise", "numero_siren", "statut_juridique", "procedure_collective");
                     if (periode.getTime() in output_indexed) {
                         Object.assign(output_indexed[periode.getTime()], rest);
                     }

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1542,16 +1542,15 @@ function delais(v, debitParPériode, intervalleTraitement) {
     return output_effectif;
 }
 /* TODO: appliquer même logique d'itération sur futureTimestamps que dans cotisationsdettes.ts */`,
-"entr_bdf": `function entr_bdf(v, // TODO: prendre ParPériode<EntréeBdf> au lieu de DonnéesBdf
-periodes) {
+"entr_bdf": `function entr_bdf(donnéesBdf, periodes) {
     "use strict";
 
     const outputBdf = {};
     for (const p of periodes) {
         outputBdf[p] = {};
     }
-    for (const hash in v.bdf) {
-        const bdfHashData = v.bdf[hash];
+    for (const hash in donnéesBdf) {
+        const bdfHashData = donnéesBdf[hash];
         const periode_arrete_bilan = new Date(Date.UTC(bdfHashData.arrete_bilan_bdf.getUTCFullYear(), bdfHashData.arrete_bilan_bdf.getUTCMonth() + 1, 1, 0, 0, 0, 0));
         const periode_dispo = f.dateAddMonth(periode_arrete_bilan, 7);
         const series = f.generatePeriodSerie(periode_dispo, f.dateAddMonth(periode_dispo, 13));
@@ -1573,7 +1572,7 @@ periodes) {
                     const outputInPast = outputBdf[periode_offset.getTime()];
                     if (outputInPast) {
                         Object.assign(outputInPast, {
-                            [prop + "_past_" + offset]: v.bdf[hash][prop],
+                            [prop + "_past_" + offset]: donnéesBdf[hash][prop],
                         });
                     }
                 }
@@ -1948,7 +1947,7 @@ function map() {
             v.bdf = v.bdf || {};
             v.diane = v.diane || {};
             if (v.bdf) {
-                const outputBdf = f.entr_bdf(v, periodes);
+                const outputBdf = f.entr_bdf(v.bdf, periodes);
                 f.add(outputBdf, output_indexed);
             }
             for (const hash of Object.keys(v.diane)) {

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1570,19 +1570,17 @@ output_indexed, periodes) {
                 outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1;
             }
             //}
-            for (const k of Object.keys(rest)) {
+            for (const prop of Object.keys(rest)) {
                 const past_year_offset = [1, 2];
                 for (const offset of past_year_offset) {
                     const periode_offset = f.dateAddMonth(periode, 12 * offset);
-                    const variable_name = k + "_past_" + offset;
-                    if (outputBdf[periode_offset.getTime()] &&
-                        // periode_offset.getTime() in output_indexed &&
-                        // TODO: ` + "`" + `in periodes` + "`" + ` en récupérant un paramètre périodes.
-                        k !== "arrete_bilan_bdf" &&
-                        k !== "exercice_bdf"
+                    const outputInPast = outputBdf[periode_offset.getTime()];
+                    if (outputInPast &&
+                        prop !== "arrete_bilan_bdf" &&
+                        prop !== "exercice_bdf"
                     // TODO: props à inclure dans le omit ci-dessus ?
                     ) {
-                        outputBdf[periode_offset.getTime()][variable_name] = v.bdf[hash][k];
+                        outputInPast[prop + "_past_" + offset] = v.bdf[hash][prop];
                     }
                 }
             }

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1559,12 +1559,11 @@ function delais(v, debitParPériode, intervalleTraitement) {
             const outputInPeriod = (outputBdf[periode.getTime()] =
                 outputBdf[periode.getTime()] || {});
             const periodData = f.omit(entréeBdf, "raison_sociale", "secteur", "siren");
-            //if (outputInPeriod || periode.getTime() in periodes) {
+            // TODO: Éviter d'ajouter des données en dehors de ` + "`" + `periodes` + "`" + `, sans fausser le calcul des données passées (plus bas)
             Object.assign(outputInPeriod, periodData);
             if (outputInPeriod.annee_bdf) {
                 outputInPeriod.exercice_bdf = outputInPeriod.annee_bdf - 1;
             }
-            //}
             const pastData = f.omit(periodData, "arrete_bilan_bdf", "exercice_bdf");
             for (const prop of Object.keys(pastData)) {
                 const past_year_offset = [1, 2];

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1561,7 +1561,11 @@ output_indexed, periodes) {
         const periode_dispo = f.dateAddMonth(periode_arrete_bilan, 7);
         const series = f.generatePeriodSerie(periode_dispo, f.dateAddMonth(periode_dispo, 13));
         for (const periode of series) {
-            const outputInPeriod = (outputBdf[periode.getTime()] = outputBdf[periode.getTime()] || Object.assign({}, output_indexed[periode.getTime()]));
+            const outputInPeriod = (outputBdf[periode.getTime()] =
+                outputBdf[periode.getTime()] ||
+                    {
+                    /*...output_indexed[periode.getTime()]*/
+                    });
             const rest = omit(bdfHashData, "raison_sociale", "secteur", "siren");
             if (outputInPeriod /*periode.getTime() in periodes*/) {
                 Object.assign(outputInPeriod, rest);


### PR DESCRIPTION
Effectué en pair coding avec @JazzyPierrot:

- Extraction de fonction `entr_bdf()` depuis le `map()` de `reduce.algo2`
- Réutilisation de `omit()` => déplacement dans `common/`
- Uniformisation du nommage de fichiers et types pour fonctions de calcul s'appliquant aux entreprises
- Explicitation et documentation de types Bdf

Next steps (dans PR séparée(s)):

- cf questions en commentaires de cette PR
- ajout d'un test unitaire pour éviter regressions silencieuses en CI (cf https://github.com/signaux-faibles/opensignauxfaibles/pull/101#issuecomment-661844701 et https://github.com/signaux-faibles/opensignauxfaibles/pull/101#issuecomment-661978167)
- et TODOs