### PR TITLE
fix(reduce.algo2): Simplification de la signature de entr_sirene()

### DIFF
--- a/dbmongo/js/reduce.algo2/entr_sirene.ts
+++ b/dbmongo/js/reduce.algo2/entr_sirene.ts
@@ -12,14 +12,14 @@ export type SortieSireneEntreprise = {
 }
 
 export function entr_sirene(
-  v: DonnéesSireneEntreprise,
+  sirene_ul: Record<DataHash, EntréeSireneEntreprise>,
   output_array: (Input & Partial<SortieSireneEntreprise>)[]
 ): void {
   "use strict"
-  const sireneHashes = Object.keys(v.sirene_ul || {})
+  const sireneHashes = Object.keys(sirene_ul || {})
   output_array.forEach((val) => {
     if (sireneHashes.length !== 0) {
-      const sirene = v.sirene_ul[sireneHashes[sireneHashes.length - 1]]
+      const sirene = sirene_ul[sireneHashes[sireneHashes.length - 1]]
       val.raison_sociale = f.raison_sociale(
         sirene.raison_sociale,
         sirene.nom_unite_legale,

--- a/dbmongo/js/reduce.algo2/entr_sirene.ts
+++ b/dbmongo/js/reduce.algo2/entr_sirene.ts
@@ -1,9 +1,5 @@
 import * as f from "../common/raison_sociale"
 
-type Input = {
-  periode: Date
-}
-
 export type SortieSireneEntreprise = {
   raison_sociale: string // nom de l'entreprise
   statut_juridique: string | null // code numérique sérialisé en chaine de caractères
@@ -13,12 +9,14 @@ export type SortieSireneEntreprise = {
 
 export function entr_sirene(
   sirene_ul: Record<DataHash, EntréeSireneEntreprise>,
-  output_array: (Input & Partial<SortieSireneEntreprise>)[]
-): void {
+  sériePériode: Date[]
+): ParPériode<Partial<SortieSireneEntreprise>> {
   "use strict"
+  const retourEntrSirene: ParPériode<Partial<SortieSireneEntreprise>> = {}
   const sireneHashes = Object.keys(sirene_ul || {})
-  output_array.forEach((val) => {
+  sériePériode.forEach((période) => {
     if (sireneHashes.length !== 0) {
+      const val: Partial<SortieSireneEntreprise> = {}
       const sirene = sirene_ul[sireneHashes[sireneHashes.length - 1]]
       val.raison_sociale = f.raison_sociale(
         sirene.raison_sociale,
@@ -39,8 +37,10 @@ export function entr_sirene(
         sirene.date_creation >= new Date("1901/01/01")
       ) {
         val.age_entreprise =
-          val.periode.getFullYear() - val.date_creation_entreprise
+          période.getFullYear() - val.date_creation_entreprise
       }
+      retourEntrSirene[période.getTime()] = val
     }
   })
+  return retourEntrSirene
 }

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -179,23 +179,18 @@ export function map(this: {
         Partial<SortieBdf> &
         Record<string, unknown> // for *_past_* props of diane. // TODO: try to be more specific
 
-      const output_array: SortieMapEntreprise[] = serie_periode.map(function (
-        e
-      ) {
-        return {
+      const output_indexed: Record<Periode, SortieMapEntreprise> = {}
+
+      for (const periode of serie_periode) {
+        output_indexed[periode.getTime()] = {
           siren: v.key,
-          periode: e,
+          periode,
           exercice_bdf: 0,
           arrete_bilan_bdf: new Date(0),
           exercice_diane: 0,
           arrete_bilan_diane: new Date(0),
         }
-      })
-
-      const output_indexed = output_array.reduce(function (periode, val) {
-        periode[val.periode.getTime()] = val
-        return periode
-      }, {} as Record<Periode, SortieMapEntreprise>)
+      }
 
       if (v.sirene_ul) {
         const outputEntrSirene = f.entr_sirene(v.sirene_ul, serie_periode)
@@ -330,12 +325,13 @@ export function map(this: {
         }
       }
 
-      output_array.forEach((periode, index) => {
+      serie_periode.forEach((date) => {
+        const periode = output_indexed[date.getTime()]
         if (
           (periode.arrete_bilan_bdf || new Date(0)).getTime() === 0 &&
           (periode.arrete_bilan_diane || new Date(0)).getTime() === 0
         ) {
-          delete output_array[index]
+          delete output_indexed[date.getTime()]
         }
         if ((periode.arrete_bilan_bdf || new Date(0)).getTime() === 0) {
           delete periode.arrete_bilan_bdf

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -200,9 +200,11 @@ export function map(this: {
       }, {} as Record<Periode, SortieMapEntreprise>)
 
       if (v.sirene_ul) {
-        f.entr_sirene(v.sirene_ul, output_array)
+        const outputEntrSirene = f.entr_sirene(v.sirene_ul, serie_periode)
+        f.add(outputEntrSirene, output_indexed)
       }
 
+      // TODO: calculer à partir de serie_periode (Date[]) au lieu de output_indexed
       const periodes = Object.keys(output_indexed)
         .sort()
         .map((timestamp) => parseInt(timestamp))

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -170,11 +170,9 @@ export function map(this: {
 
   if (v.scope === "entreprise") {
     if (includes["all"]) {
-      type Input = {
+      type SortieMapEntreprise = {
         periode: Date
-      }
-      type SortieMapEntreprise = Input &
-        Partial<SortieSireneEntreprise> &
+      } & Partial<SortieSireneEntreprise> &
         Partial<EntréeBdf> &
         Partial<EntréeDiane> &
         Partial<EntréeBdf> &
@@ -204,10 +202,7 @@ export function map(this: {
         f.add(outputEntrSirene, output_indexed)
       }
 
-      // TODO: calculer à partir de serie_periode (Date[]) au lieu de output_indexed
-      const periodes = Object.keys(output_indexed)
-        .sort()
-        .map((timestamp) => parseInt(timestamp))
+      const periodes = serie_periode.map((date) => date.getTime())
 
       if (v.effectif_ent) {
         const output_effectif_ent = f.effectifs(

--- a/dbmongo/js/reduce.algo2/map.ts
+++ b/dbmongo/js/reduce.algo2/map.ts
@@ -200,7 +200,7 @@ export function map(this: {
       }, {} as Record<Periode, SortieMapEntreprise>)
 
       if (v.sirene_ul) {
-        f.entr_sirene(v as DonnéesSireneEntreprise, output_array)
+        f.entr_sirene(v.sirene_ul, output_array)
       }
 
       const periodes = Object.keys(output_indexed)

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1924,20 +1924,17 @@ function map() {
     }
     if (v.scope === "entreprise") {
         if (includes["all"]) {
-            const output_array = serie_periode.map(function (e) {
-                return {
+            const output_indexed = {};
+            for (const periode of serie_periode) {
+                output_indexed[periode.getTime()] = {
                     siren: v.key,
-                    periode: e,
+                    periode,
                     exercice_bdf: 0,
                     arrete_bilan_bdf: new Date(0),
                     exercice_diane: 0,
                     arrete_bilan_diane: new Date(0),
                 };
-            });
-            const output_indexed = output_array.reduce(function (periode, val) {
-                periode[val.periode.getTime()] = val;
-                return periode;
-            }, {});
+            }
             if (v.sirene_ul) {
                 const outputEntrSirene = f.entr_sirene(v.sirene_ul, serie_periode);
                 f.add(outputEntrSirene, output_indexed);
@@ -2029,10 +2026,11 @@ function map() {
                     }
                 }
             }
-            output_array.forEach((periode, index) => {
+            serie_periode.forEach((date) => {
+                const periode = output_indexed[date.getTime()];
                 if ((periode.arrete_bilan_bdf || new Date(0)).getTime() === 0 &&
                     (periode.arrete_bilan_diane || new Date(0)).getTime() === 0) {
-                    delete output_array[index];
+                    delete output_indexed[date.getTime()];
                 }
                 if ((periode.arrete_bilan_bdf || new Date(0)).getTime() === 0) {
                     delete periode.arrete_bilan_bdf;

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1581,11 +1581,13 @@ function delais(v, debitParPériode, intervalleTraitement) {
     }
     return outputBdf;
 }`,
-"entr_sirene": `function entr_sirene(sirene_ul, output_array) {
+"entr_sirene": `function entr_sirene(sirene_ul, sériePériode) {
     "use strict";
+    const retourEntrSirene = {};
     const sireneHashes = Object.keys(sirene_ul || {});
-    output_array.forEach((val) => {
+    sériePériode.forEach((période) => {
         if (sireneHashes.length !== 0) {
+            const val = {};
             const sirene = sirene_ul[sireneHashes[sireneHashes.length - 1]];
             val.raison_sociale = f.raison_sociale(sirene.raison_sociale, sirene.nom_unite_legale, sirene.nom_usage_unite_legale, sirene.prenom1_unite_legale, sirene.prenom2_unite_legale, sirene.prenom3_unite_legale, sirene.prenom4_unite_legale);
             val.statut_juridique = sirene.statut_juridique || null;
@@ -1596,10 +1598,12 @@ function delais(v, debitParPériode, intervalleTraitement) {
                 sirene.date_creation &&
                 sirene.date_creation >= new Date("1901/01/01")) {
                 val.age_entreprise =
-                    val.periode.getFullYear() - val.date_creation_entreprise;
+                    période.getFullYear() - val.date_creation_entreprise;
             }
+            retourEntrSirene[période.getTime()] = val;
         }
     });
+    return retourEntrSirene;
 }`,
 "finalize": `function finalize(k, v) {
     "use strict";
@@ -1935,8 +1939,10 @@ function map() {
                 return periode;
             }, {});
             if (v.sirene_ul) {
-                f.entr_sirene(v.sirene_ul, output_array);
+                const outputEntrSirene = f.entr_sirene(v.sirene_ul, serie_periode);
+                f.add(outputEntrSirene, output_indexed);
             }
+            // TODO: calculer à partir de serie_periode (Date[]) au lieu de output_indexed
             const periodes = Object.keys(output_indexed)
                 .sort()
                 .map((timestamp) => parseInt(timestamp));

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1581,12 +1581,12 @@ function delais(v, debitParPériode, intervalleTraitement) {
     }
     return outputBdf;
 }`,
-"entr_sirene": `function entr_sirene(v, output_array) {
+"entr_sirene": `function entr_sirene(sirene_ul, output_array) {
     "use strict";
-    const sireneHashes = Object.keys(v.sirene_ul || {});
+    const sireneHashes = Object.keys(sirene_ul || {});
     output_array.forEach((val) => {
         if (sireneHashes.length !== 0) {
-            const sirene = v.sirene_ul[sireneHashes[sireneHashes.length - 1]];
+            const sirene = sirene_ul[sireneHashes[sireneHashes.length - 1]];
             val.raison_sociale = f.raison_sociale(sirene.raison_sociale, sirene.nom_unite_legale, sirene.nom_usage_unite_legale, sirene.prenom1_unite_legale, sirene.prenom2_unite_legale, sirene.prenom3_unite_legale, sirene.prenom4_unite_legale);
             val.statut_juridique = sirene.statut_juridique || null;
             val.date_creation_entreprise = sirene.date_creation
@@ -1935,7 +1935,7 @@ function map() {
                 return periode;
             }, {});
             if (v.sirene_ul) {
-                f.entr_sirene(v, output_array);
+                f.entr_sirene(v.sirene_ul, output_array);
             }
             const periodes = Object.keys(output_indexed)
                 .sort()

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1942,10 +1942,7 @@ function map() {
                 const outputEntrSirene = f.entr_sirene(v.sirene_ul, serie_periode);
                 f.add(outputEntrSirene, output_indexed);
             }
-            // TODO: calculer à partir de serie_periode (Date[]) au lieu de output_indexed
-            const periodes = Object.keys(output_indexed)
-                .sort()
-                .map((timestamp) => parseInt(timestamp));
+            const periodes = serie_periode.map((date) => date.getTime());
             if (v.effectif_ent) {
                 const output_effectif_ent = f.effectifs(v.effectif_ent, periodes, "effectif_ent");
                 f.add(output_effectif_ent, output_indexed);


### PR DESCRIPTION
Comme suggéré dans https://github.com/signaux-faibles/opensignauxfaibles/pull/101#discussion_r458234857, et similairement à la signature de `entr_bdf`, passer `v.sirene_ul` à `f.entr_sirene`, au lieu de `v` pour éviter d'avoir à convertir/forcer le type de `v` lors de l'appel depuis `map()`.

J'en ai profité pour aller un poil plus loin dans le refactoring de `f.entr_sirene()` et la partie "entreprise" de `f.map()`:

- rendre `entr_sirene()` pure, en m'inspirant de notre travail sur `entr_bdf()`
- retrait de `output_array` => `output_indexed` devient l'unique source de vérité.