### PR TITLE
fix(export): Paramètre `key` doit être un SIREN valide

### DIFF
--- a/dbmongo/data.go
+++ b/dbmongo/data.go
@@ -121,18 +121,11 @@ func getTimestamp() string {
 }
 
 func getKeyParam(c *gin.Context) (string, error) {
-	var params struct {
-		Key string `json:"key"`
+	key := c.Query("key")
+	if !(len(key) == 9 || len(key) == 0) {
+		return "", errors.New("si fourni, key doit être un numéro SIREN (9 chiffres)")
 	}
-	err := c.Bind(&params)
-	if err != nil {
-		return "", err
-	}
-
-	if !(len(params.Key) == 14 || len(params.Key) == 0) {
-		err = errors.New("siret de 14 caractères obligatoire si fourni")
-	}
-	return params.Key, err
+	return key, nil
 }
 
 func exportEtablissementsHandler(c *gin.Context) {

--- a/tests/test-api-export.sh
+++ b/tests/test-api-export.sh
@@ -156,19 +156,20 @@ echo "- rename 'Public_debug' collection to 'Public' 👉 ${RENAME_RESULT}"
 CLEAN_RESULT=$(echo 'db.Admin.drop(); db.ImportedData.drop(); db.RawData.drop();' | sudo docker exec -i sf-mongodb mongo --quiet signauxfaibles)
 echo "- drop other db collections 👉 ${CLEAN_RESULT}"
 
+function stopIfFailed {
+    if [[ "$1" == *failed* ]]
+    then
+        exit 1
+    fi
+}
+
 # Parameter validation
 RESULT=$(http --print=b --ignore-stdin GET :5000/api/data/etablissements key=="invalid" | (grep "key doit être un numéro SIREN" || echo -e "${COLOR_YELLOW}failed${COLOR_DEFAULT}"))
 echo "- GET /api/data/etablissements with invalid key 👉 ${RESULT}"
-if [[ "${RESULT}" == *failed* ]]
-then
-    exit 1
-fi
+stopIfFailed "${RESULT}"
 RESULT=$(http --print=b --ignore-stdin GET :5000/api/data/entreprises key=="invalid" | (grep "key doit être un numéro SIREN" || echo -e "${COLOR_YELLOW}failed${COLOR_DEFAULT}"))
 echo "- GET /api/data/entreprises with invalid key 👉 ${RESULT}"
-if [[ "${RESULT}" == *failed* ]]
-then
-    exit 1
-fi
+stopIfFailed "${RESULT}"
 
 # Export enterprise data
 ETABLISSEMENTS_FILE=$(http --print=b --ignore-stdin GET :5000/api/data/etablissements | tr -d '"')

--- a/tests/test-api-export.sh
+++ b/tests/test-api-export.sh
@@ -155,6 +155,15 @@ echo "- rename 'Public_debug' collection to 'Public' 👉 ${RENAME_RESULT}"
 # Make sure that the export only relies on Score and Public collections => clear collections that were populated for/by other endpoints
 CLEAN_RESULT=$(echo 'db.Admin.drop(); db.ImportedData.drop(); db.RawData.drop();' | sudo docker exec -i sf-mongodb mongo --quiet signauxfaibles)
 echo "- drop other db collections 👉 ${CLEAN_RESULT}"
+
+# Failure cases
+INVALID_ETAB=$(http --print=b --ignore-stdin GET :5000/api/data/etablissements key=invalid | (grep "invalid" && echo "OK" || echo -e "${COLOR_YELLOW}failed${COLOR_DEFAULT}"))
+echo "- GET /api/data/etablissements with invalid key 👉 ${INVALID_ETAB}"
+if [[ "${INVALID_ETAB}" == *failed* ]]
+then
+    exit 1
+fi
+
 # Export enterprise data
 ETABLISSEMENTS_FILE=$(http --print=b --ignore-stdin GET :5000/api/data/etablissements | tr -d '"')
 echo "- GET /api/data/etablissements 👉 ${ETABLISSEMENTS_FILE}"

--- a/tests/test-api-export.sh
+++ b/tests/test-api-export.sh
@@ -157,7 +157,7 @@ CLEAN_RESULT=$(echo 'db.Admin.drop(); db.ImportedData.drop(); db.RawData.drop();
 echo "- drop other db collections 👉 ${CLEAN_RESULT}"
 
 # Failure cases
-INVALID_ETAB=$(http --print=b --ignore-stdin GET :5000/api/data/etablissements key=invalid | (grep "invalid" && echo "OK" || echo -e "${COLOR_YELLOW}failed${COLOR_DEFAULT}"))
+INVALID_ETAB=$(http --print=b --ignore-stdin GET :5000/api/data/etablissements key=="invalid" | (grep "key doit être un numéro SIREN" || echo -e "${COLOR_YELLOW}failed${COLOR_DEFAULT}"))
 echo "- GET /api/data/etablissements with invalid key 👉 ${INVALID_ETAB}"
 if [[ "${INVALID_ETAB}" == *failed* ]]
 then

--- a/tests/test-api-export.sh
+++ b/tests/test-api-export.sh
@@ -171,6 +171,31 @@ RESULT=$(http --print=b --ignore-stdin GET :5000/api/data/entreprises key=="inva
 echo "- GET /api/data/entreprises with invalid key 👉 ${RESULT}"
 stopIfFailed "${RESULT}"
 
+# GET /api/data/etablissements with key=212345678 should return just one match
+FILE=$(http --print=b --ignore-stdin GET :5000/api/data/etablissements key=="212345678" | tr -d '"')
+MATCH=$(grep --quiet "etablissement_21234567891011" "${FILE}" && echo "found etablissement_21234567891011" || echo -e "${COLOR_YELLOW}failed${COLOR_DEFAULT}")
+COUNT=$(wc -l <"${FILE}")
+rm "${FILE}"
+echo "- GET /api/data/etablissements with key=212345678 👉 ${MATCH}, ${COUNT} result(s)"
+stopIfFailed "${MATCH}"
+if [[ "${COUNT}" -ne "1" ]]
+then
+    exit 1
+fi
+
+# GET /api/data/entreprises with key=212345678 should return just one match
+FILE=$(http --print=b --ignore-stdin GET :5000/api/data/entreprises key=="212345678" | tr -d '"')
+cat $FILE
+MATCH=$(grep --quiet "entreprise_212345678" "${FILE}" && echo "found entreprise_212345678" || echo -e "${COLOR_YELLOW}failed${COLOR_DEFAULT}")
+COUNT=$(wc -l <"${FILE}")
+rm "${FILE}"
+echo "- GET /api/data/entreprises with key=212345678 👉 ${MATCH}, ${COUNT} result(s)"
+stopIfFailed "${MATCH}"
+if [[ "${COUNT}" -ne "1" ]]
+then
+    exit 1
+fi
+
 # Export enterprise data
 ETABLISSEMENTS_FILE=$(http --print=b --ignore-stdin GET :5000/api/data/etablissements | tr -d '"')
 echo "- GET /api/data/etablissements 👉 ${ETABLISSEMENTS_FILE}"

--- a/tests/test-api-export.sh
+++ b/tests/test-api-export.sh
@@ -185,7 +185,6 @@ fi
 
 # GET /api/data/entreprises with key=212345678 should return just one match
 FILE=$(http --print=b --ignore-stdin GET :5000/api/data/entreprises key=="212345678" | tr -d '"')
-cat $FILE
 MATCH=$(grep --quiet "entreprise_212345678" "${FILE}" && echo "found entreprise_212345678" || echo -e "${COLOR_YELLOW}failed${COLOR_DEFAULT}")
 COUNT=$(wc -l <"${FILE}")
 rm "${FILE}"

--- a/tests/test-api-export.sh
+++ b/tests/test-api-export.sh
@@ -156,10 +156,16 @@ echo "- rename 'Public_debug' collection to 'Public' 👉 ${RENAME_RESULT}"
 CLEAN_RESULT=$(echo 'db.Admin.drop(); db.ImportedData.drop(); db.RawData.drop();' | sudo docker exec -i sf-mongodb mongo --quiet signauxfaibles)
 echo "- drop other db collections 👉 ${CLEAN_RESULT}"
 
-# Failure cases
-INVALID_ETAB=$(http --print=b --ignore-stdin GET :5000/api/data/etablissements key=="invalid" | (grep "key doit être un numéro SIREN" || echo -e "${COLOR_YELLOW}failed${COLOR_DEFAULT}"))
-echo "- GET /api/data/etablissements with invalid key 👉 ${INVALID_ETAB}"
-if [[ "${INVALID_ETAB}" == *failed* ]]
+# Parameter validation
+RESULT=$(http --print=b --ignore-stdin GET :5000/api/data/etablissements key=="invalid" | (grep "key doit être un numéro SIREN" || echo -e "${COLOR_YELLOW}failed${COLOR_DEFAULT}"))
+echo "- GET /api/data/etablissements with invalid key 👉 ${RESULT}"
+if [[ "${RESULT}" == *failed* ]]
+then
+    exit 1
+fi
+RESULT=$(http --print=b --ignore-stdin GET :5000/api/data/entreprises key=="invalid" | (grep "key doit être un numéro SIREN" || echo -e "${COLOR_YELLOW}failed${COLOR_DEFAULT}"))
+echo "- GET /api/data/entreprises with invalid key 👉 ${RESULT}"
+if [[ "${RESULT}" == *failed* ]]
 then
     exit 1
 fi


### PR DESCRIPTION
Cf https://github.com/signaux-faibles/opensignauxfaibles/pull/105#issuecomment-663031077

## Objectif

Les APIs `GET /api/data/entreprises` et `GET /api/data/etablissements` peuvent filtrer les résultats par numéro SIREN d'entreprise (9 chiffres), via le paramètre `key` (optionnel), et retourner une erreur en cas de valeur invalide.

## Comment tester

```sh
$ (killall dbmongo; cd dbmongo && go build) && tests/test-api-export.sh
```