### PR TITLE
fix(codacy): Rapporter seulement la couverture des fonctions TS

### DIFF
--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -62,11 +62,11 @@ jobs:
           gpg --import --no-tty --batch --yes ./private_key.gpg
           git secret reveal
 
-      - name: JS Tests driven by Node/AVA
+      - name: Tests driven by Node/AVA
         working-directory: dbmongo/js
         run: |
           npm run test:coverage
-          npx nyc report --reporter=lcov # stores the coverage report in ./coverage/lcov.info
+          npx nyc report --reporter=lcov --include="**/*.ts" --exclude="**/*.js" # stores the coverage report in ./coverage/lcov.info
 
       - name: Upload coverage to codacy
         uses: codacy/codacy-coverage-reporter-action@master


### PR DESCRIPTION
## Problème

Codacy rapportait un taux de couverture de 40% de notre code JS/TS alors que notre outil de mesure rapporte 88%.

Après une discussion avec le support technique de Codacy, il s'avère que leur analyseur ne supporte pas les rapport mélangeant plusieurs langages, et que c'est le taux de couverture du premier langage (en l'occurrence: JS) qui l'emportait.

## Solution

N'envoyer le rapport de couverture que pour les fichiers TS. (soit la majorité de nos fonctions map-reduce)
