### PR TITLE
fix(import): Les erreurs de filtrage de Delai ne sont pas fatales

### DIFF
--- a/dbmongo/docs/swagger/swagger.json
+++ b/dbmongo/docs/swagger/swagger.json
@@ -466,6 +466,17 @@
         "/api/admin/events": {
             "get": {
                 "description": "Liste les 250 derniers évènements du journal",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "batchKey",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": false,
+                        "description": "Identifiant de batch d'importation, pour filtrer les résultats."
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",

--- a/dbmongo/docs/swagger/swagger.yaml
+++ b/dbmongo/docs/swagger/swagger.yaml
@@ -310,6 +310,13 @@ paths:
     get:
       description: |-
         Liste les 250 derniers évènements du journal
+      parameters:
+        - in: query
+          name: batchKey
+          schema:
+            type: string
+          required: false
+          description: Identifiant de batch d'importation, pour filtrer les résultats.
       responses:
         "200":
           description: OK

--- a/dbmongo/handlers.go
+++ b/dbmongo/handlers.go
@@ -271,7 +271,7 @@ func checkBatchHandler(c *gin.Context) {
 //
 func eventsHandler(c *gin.Context) {
 	batchKey := c.Query("batchKey")
-	var query interface{} = nil
+	var query interface{}
 	if batchKey != "" {
 		query = bson.M{"event.batchKey": batchKey}
 	}

--- a/dbmongo/handlers.go
+++ b/dbmongo/handlers.go
@@ -270,7 +270,12 @@ func checkBatchHandler(c *gin.Context) {
 
 //
 func eventsHandler(c *gin.Context) {
-	logs, err := engine.GetEventsFromDB(nil, 250)
+	batchKey := c.Query("batchKey")
+	var query interface{} = nil
+	if batchKey != "" {
+		query = bson.M{"event.batchKey": batchKey}
+	}
+	logs, err := engine.GetEventsFromDB(query, 250)
 	if err != nil {
 		c.JSON(500, err.Error())
 	} else {

--- a/dbmongo/lib/engine/main.go
+++ b/dbmongo/lib/engine/main.go
@@ -190,6 +190,7 @@ func reportAbstract(tracker gournal.Tracker) interface{} {
 	)
 
 	return bson.M{
+		"batchKey":    tracker.Context["batchKey"],
 		"report":      report,
 		"total":       tracker.Count,
 		"valid":       nValid,

--- a/dbmongo/lib/urssaf/delai.go
+++ b/dbmongo/lib/urssaf/delai.go
@@ -77,7 +77,7 @@ func ParserDelai(cache engine.Cache, batch *engine.AdminBatch) (chan engine.Tupl
 
 		for _, path := range batch.Files["delai"] {
 			tracker := gournal.NewTracker(
-				map[string]string{"path": path},
+				map[string]string{"path": path, "batchKey": batch.ID.Key},
 				engine.TrackerReports)
 
 			file, err := os.Open(viper.GetString("APP_DATA") + path)

--- a/dbmongo/lib/urssaf/delai.go
+++ b/dbmongo/lib/urssaf/delai.go
@@ -115,7 +115,7 @@ func ParserDelai(cache engine.Cache, batch *engine.AdminBatch) (chan engine.Tupl
 						outputChannel <- delai
 					}
 				} else {
-					tracker.Error(err)
+					tracker.Error(engine.NewFilterError(err, "filter"))
 					continue
 				}
 

--- a/tests/output-snapshots/test-api-import.golden.txt
+++ b/tests/output-snapshots/test-api-import.golden.txt
@@ -53,6 +53,20 @@
 		}
 	}
 ]
+// Documents from db.Journal:
+[
+	{
+		"event" : {
+			"headFilters" : [ ],
+			"headErrors" : [ ],
+			"headFatal" : [
+				"Cycle 2: Pas de siret associé au compte 450359886246036238 à la période 2019-01-23 00:00:00 +0000 UTC"
+			],
+			"report" : "/../lib/urssaf/testData/delaiTestData.csv: intégration terminée, 2 lignes traitées, 1 erreures fatales, 0 rejets, 0 lignes filtrées, 2 lignes valides"
+		},
+		"code" : "delaiParser"
+	}
+]
 // Results of call to /api/data/validate:
 {"_id":"________ObjectId________","batchKey":"1910","dataHash":"______________Hash______________","dataObject":{"action":"bad mu","annee_creation":9941,"date_creation":"2000-03-02T23:00:00Z","date_echeance":"2001-05-04T22:00:00Z","denomination":"mtj n.p. eg saxjoc","duree_delai":758,"indic_6m":"uqu","montant_echeancier":74825.41,"numero_compte":"636043216536562844","numero_contentieux":"8981265766679","stade":"qh"},"dataType":"delai"}
 {"_id":"________ObjectId________","batchKey":"1910","dataHash":"______________Hash______________","dataObject":{"action":"cya ng","annee_creation":5647,"date_creation":"1999-12-31T23:00:00Z","date_echeance":"2001-01-03T23:00:00Z","denomination":"etmlgcthph ecoowixknaae se","duree_delai":456,"indic_6m":"lhm","montant_echeancier":5065.79,"numero_compte":"111982477292496174","numero_contentieux":"5856690802766","stade":"nbz sk"},"dataType":"delai"}

--- a/tests/output-snapshots/test-api-import.golden.txt
+++ b/tests/output-snapshots/test-api-import.golden.txt
@@ -57,12 +57,12 @@
 [
 	{
 		"event" : {
-			"headFilters" : [ ],
-			"headErrors" : [ ],
-			"headFatal" : [
-				"Cycle 2: Pas de siret associé au compte 450359886246036238 à la période 2019-01-23 00:00:00 +0000 UTC"
+			"headFatal" : [ ],
+			"report" : "/../lib/urssaf/testData/delaiTestData.csv: intégration terminée, 2 lignes traitées, 0 erreures fatales, 0 rejets, 1 lignes filtrées, 2 lignes valides",
+			"headFilters" : [
+				"Cycle 2: Error while loading or applying filter: Pas de siret associé au compte 450359886246036238 à la période 2019-01-23 00:00:00 +0000 UTC"
 			],
-			"report" : "/../lib/urssaf/testData/delaiTestData.csv: intégration terminée, 2 lignes traitées, 1 erreures fatales, 0 rejets, 0 lignes filtrées, 2 lignes valides"
+			"headErrors" : [ ]
 		},
 		"code" : "delaiParser"
 	}

--- a/tests/output-snapshots/test-api-import.golden.txt
+++ b/tests/output-snapshots/test-api-import.golden.txt
@@ -62,7 +62,8 @@
 			],
 			"headErrors" : [ ],
 			"headFatal" : [ ],
-			"report" : "/../lib/urssaf/testData/delaiTestData.csv: intégration terminée, 2 lignes traitées, 0 erreures fatales, 0 rejets, 1 lignes filtrées, 2 lignes valides"
+			"report" : "/../lib/urssaf/testData/delaiTestData.csv: intégration terminée, 2 lignes traitées, 0 erreures fatales, 0 rejets, 1 lignes filtrées, 2 lignes valides",
+			"batchKey" : "1910"
 		},
 		"code" : "delaiParser"
 	}

--- a/tests/output-snapshots/test-api-import.golden.txt
+++ b/tests/output-snapshots/test-api-import.golden.txt
@@ -57,12 +57,12 @@
 [
 	{
 		"event" : {
-			"headFatal" : [ ],
-			"report" : "/../lib/urssaf/testData/delaiTestData.csv: intégration terminée, 2 lignes traitées, 0 erreures fatales, 0 rejets, 1 lignes filtrées, 2 lignes valides",
 			"headFilters" : [
 				"Cycle 2: Error while loading or applying filter: Pas de siret associé au compte 450359886246036238 à la période 2019-01-23 00:00:00 +0000 UTC"
 			],
-			"headErrors" : [ ]
+			"headErrors" : [ ],
+			"headFatal" : [ ],
+			"report" : "/../lib/urssaf/testData/delaiTestData.csv: intégration terminée, 2 lignes traitées, 0 erreures fatales, 0 rejets, 1 lignes filtrées, 2 lignes valides"
 		},
 		"code" : "delaiParser"
 	}

--- a/tests/test-api-import.sh
+++ b/tests/test-api-import.sh
@@ -66,6 +66,15 @@ echo "- POST /api/data/validate 👉 ${OUTPUT_GZ_FILE}"
 ) << CONTENT
 print("// Documents from db.ImportedData, after call to /api/data/import:");
 printjson(db.ImportedData.find().sort({"value.key":1}).toArray());
+print("// Documents from db.Journal:");
+printjson(db.Journal.find({ "event.report": { "\$exists": true } }, {
+  "_id": 0,
+  "code": 1,
+  "event.headFilters": "$event.headFilters", 
+  "event.headErrors": "$event.headErrors", 
+  "event.headFatal": "$event.headFatal", 
+  "event.report": "$event.report", 
+}).toArray());
 print("// Results of call to /api/data/validate:");
 CONTENT
 

--- a/tests/test-api-import.sh
+++ b/tests/test-api-import.sh
@@ -67,14 +67,17 @@ echo "- POST /api/data/validate 👉 ${OUTPUT_GZ_FILE}"
 print("// Documents from db.ImportedData, after call to /api/data/import:");
 printjson(db.ImportedData.find().sort({"value.key":1}).toArray());
 print("// Documents from db.Journal:");
-printjson(db.Journal.find({ "event.report": { "\$exists": true } }, {
-  "_id": 0,
-  "code": 1,
-  "event.headFilters": "$event.headFilters", 
-  "event.headErrors": "$event.headErrors", 
-  "event.headFatal": "$event.headFatal", 
-  "event.report": "$event.report", 
-}).toArray());
+printjson(db.Journal.find({ "event.report": { "\$exists": true } }).toArray().map(doc => ({
+  // note: we use map() to force the order of properties at every run of this test
+  event: {
+    headFilters: doc.event.headFilters,
+    headErrors: doc.event.headErrors,
+    headFatal: doc.event.headFatal,
+    report: doc.event.report
+  },
+  code: doc.code
+})));
+
 print("// Results of call to /api/data/validate:");
 CONTENT
 

--- a/tests/test-api-import.sh
+++ b/tests/test-api-import.sh
@@ -73,7 +73,8 @@ printjson(db.Journal.find({ "event.report": { "\$exists": true } }).toArray().ma
     headFilters: doc.event.headFilters,
     headErrors: doc.event.headErrors,
     headFatal: doc.event.headFatal,
-    report: doc.event.report
+    report: doc.event.report,
+    batchKey: doc.event.batchKey
   },
   code: doc.code
 })));


### PR DESCRIPTION
## Avant

Les erreurs `Cycle 2: Pas de siret associé au compte CCC à la période DDD` étaient listées dans la propriété `event.headFatal` de `Journal`, après la tentative d'importation d'une entrée `Delai` filtrée.

Et le rapport d'importation comptait ces erreurs comme fatales: `delaiTestData.csv: intégration terminée, 2 lignes traitées, 1 erreures fatales, 0 rejets, 0 lignes filtrées, 2 lignes valides `

## Après

Elles sont désormais listées dans `event.headFilters`, cf: https://github.com/signaux-faibles/opensignauxfaibles/pull/157/commits/80c1db20253208d65fe9d60f3e3ae19670309c1a#diff-e6c67309a010c09ce456b6447337e994R62.

=> Rapport d'importation corrigé: `delaiTestData.csv: intégration terminée, 2 lignes traitées, 0 erreures fatales, 0 rejets, 1 lignes filtrées, 2 lignes valides`

## Bonus

- Pour éviter les régressions: vérification du rapport d'importation, dans `test-api-import.sh`.
- Ajout de `batchKey` dans le rapport d'importation (gournal)
- Possibilité de récupérer le(s) rapport(s) gournal pour un `batchKey` donné:
    ```sh
    $ http :5000/api/admin/events?batchKey=1910
    ```
