### PR TITLE
feat(check): L'API /data/check lit chaque fichier jusqu'à la fin

### DIFF
--- a/dbmongo/lib/base/cron.go
+++ b/dbmongo/lib/base/cron.go
@@ -1,0 +1,23 @@
+package base
+
+import (
+	"context"
+	"time"
+)
+
+// Cron exécute function régulièrement, avec l'interval fourni.
+// Il retourne une fonction stop().
+func Cron(interval time.Duration, function func()) (stop context.CancelFunc) {
+	ctx, stop := context.WithCancel(context.Background())
+	go func(ctx context.Context) {
+		for range time.Tick(interval) {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			function()
+		}
+	}(ctx)
+	return stop
+}

--- a/dbmongo/lib/engine/adminBatch.go
+++ b/dbmongo/lib/engine/adminBatch.go
@@ -104,6 +104,7 @@ func CheckBatch(batch base.AdminBatch, parsers []marshal.Parser) (reports []stri
 		return nil, err
 	}
 	var cache = marshal.NewCache()
+	cache.Set("maxParsingErrors", -1) // read the whole file even if the number of parse errors > MaxParsingErrors, for parsers that support this override
 	for _, parser := range parsers {
 		outputChannel, eventChannel := parser(cache, &batch)
 		DiscardTuple(outputChannel)

--- a/dbmongo/lib/engine/main.go
+++ b/dbmongo/lib/engine/main.go
@@ -1,8 +1,10 @@
 package engine
 
 import (
+	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/globalsign/mgo/bson"
 	"github.com/signaux-faibles/gournal"
@@ -129,4 +131,15 @@ var TrackerReports = map[string]gournal.ReportFunction{
 	"abstract":   reportAbstract,
 	"errors":     reportCycleErrors,
 	"fatalError": reportFatalError,
+}
+
+// StopAfterTooManyErrors vérifie toutes les 2s le nombre d'erreurs de parsing
+// et passe shouldStop à true si la limite est dépassée.
+func StopAfterTooManyErrors(tracker gournal.Tracker, maxErrors int, shouldStop *bool) (stop context.CancelFunc) {
+	return base.Cron(time.Second*2, func() {
+		*shouldStop = ShouldBreak(tracker, maxErrors)
+		if *shouldStop {
+			fmt.Printf("Reached %d parsing errors => stopping.\n", maxErrors)
+		}
+	})
 }

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -34,12 +34,7 @@ func LogProgress(lineNumber *int) (stop context.CancelFunc) {
 				return
 			default:
 			}
-			// shouldBreak = maxParsingErrors > 0 && engine.ShouldBreak(tracker, maxParsingErrors)
-			// if shouldBreak {
-			// 	fmt.Printf("Reached %d parsing errors => stopping.\n", maxParsingErrors)
-			// } else {
 			fmt.Printf("Reading csv line %d\n", *lineNumber)
-			// }
 		}
 	}(ctx)
 	return stop

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -26,16 +26,7 @@ func GetJSON(tuple Tuple) ([]byte, error) {
 
 // LogProgress affiche le numéro de ligne en cours de parsing, toutes les 2s.
 func LogProgress(lineNumber *int) (stop context.CancelFunc) {
-	ctx, stop := context.WithCancel(context.Background())
-	go func(ctx context.Context) {
-		for range time.Tick(time.Second * 2) {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-			fmt.Printf("Reading csv line %d\n", *lineNumber)
-		}
-	}(ctx)
-	return stop
+	return base.Cron(time.Second*2, func() {
+		fmt.Printf("Reading csv line %d\n", *lineNumber)
+	})
 }

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -38,7 +38,7 @@ func LogProgress(lineNumber *int) (stop context.CancelFunc) {
 			// if shouldBreak {
 			// 	fmt.Printf("Reached %d parsing errors => stopping.\n", maxParsingErrors)
 			// } else {
-			fmt.Printf("Reading csv line %d\n", lineNumber)
+			fmt.Printf("Reading csv line %d\n", *lineNumber)
 			// }
 		}
 	}(ctx)

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -1,7 +1,10 @@
 package marshal
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"time"
 
 	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/base"
 )
@@ -19,4 +22,25 @@ type Tuple interface {
 // GetJSON sérialise un tuple au format JSON.
 func GetJSON(tuple Tuple) ([]byte, error) {
 	return json.MarshalIndent(tuple, "", "  ")
+}
+
+// LogProgress affiche le numéro de ligne en cours de parsing, toutes les 2s.
+func LogProgress(lineNumber *int) (stop context.CancelFunc) {
+	ctx, stop := context.WithCancel(context.Background())
+	go func(ctx context.Context) {
+		for range time.Tick(time.Second * 2) {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			// shouldBreak = maxParsingErrors > 0 && engine.ShouldBreak(tracker, maxParsingErrors)
+			// if shouldBreak {
+			// 	fmt.Printf("Reached %d parsing errors => stopping.\n", maxParsingErrors)
+			// } else {
+			fmt.Printf("Reading csv line %d\n", lineNumber)
+			// }
+		}
+	}(ctx)
+	return stop
 }

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -3,6 +3,7 @@ package urssaf
 import (
 	"bufio"
 	"encoding/csv"
+	"fmt"
 	"io"
 	"os"
 	"strconv"

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -2,9 +2,7 @@ package urssaf
 
 import (
 	"bufio"
-	"context"
 	"encoding/csv"
-	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -107,29 +105,14 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 			var shouldBreak = false
 			var lineNumber = 0 // starting with the header
 
-			var maxParsingErrors = engine.MaxParsingErrors
-			val, _ := cache.Get("maxParsingErrors")
-			if intVal, ok := val.(int); ok {
-				maxParsingErrors = intVal
-			}
+			// var maxParsingErrors = engine.MaxParsingErrors
+			// val, _ := cache.Get("maxParsingErrors")
+			// if intVal, ok := val.(int); ok {
+			// 	maxParsingErrors = intVal
+			// }
 
-			ctx, stopTheTimer := context.WithCancel(context.Background())
-			go func(ctx context.Context) {
-				for range time.Tick(time.Second * 2) {
-					select {
-					case <-ctx.Done():
-						return
-					default:
-					}
-					shouldBreak = maxParsingErrors > 0 && engine.ShouldBreak(tracker, maxParsingErrors)
-					if shouldBreak {
-						fmt.Printf("Reached %d parsing errors => stopping.\n", maxParsingErrors)
-					} else {
-						fmt.Printf("Reading csv line %d\n", lineNumber)
-					}
-				}
-			}(ctx)
-			defer stopTheTimer()
+			stopProgressLogger := marshal.LogProgress(&lineNumber)
+			defer stopProgressLogger()
 
 			for {
 				lineNumber++

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -194,27 +194,10 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 	return outputChannel, eventChannel
 }
 
-// Cron exécute function régulièrement, avec l'interval fourni.
-// Il retourne une fonction stop().
-func Cron(interval time.Duration, function func()) (stop context.CancelFunc) {
-	ctx, stop := context.WithCancel(context.Background())
-	go func(ctx context.Context) {
-		for range time.Tick(interval) {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-			function()
-		}
-	}(ctx)
-	return stop
-}
-
 // StopAfterTooManyErrors vérifie toutes les 2s le nombre d'erreurs de parsing
 // et passe shouldStop à true si la limite est dépassée.
 func StopAfterTooManyErrors(tracker gournal.Tracker, maxErrors int, shouldStop *bool) (stop context.CancelFunc) {
-	return Cron(time.Second*2, func() {
+	return base.Cron(time.Second*2, func() {
 		*shouldStop = engine.ShouldBreak(tracker, maxErrors)
 		if *shouldStop {
 			fmt.Printf("Reached %d parsing errors => stopping.\n", maxErrors)

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -147,49 +147,46 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 					continue
 				}
 
-				justParse := false
-				if !justParse {
-					period, _ := marshal.UrssafToPeriod(row[periodeIndex])
-					date := period.Start
+				period, _ := marshal.UrssafToPeriod(row[periodeIndex])
+				date := period.Start
 
-					if siret, err := marshal.GetSiret(row[numeroCompteIndex], &date, cache, batch); err == nil {
+				if siret, err := marshal.GetSiret(row[numeroCompteIndex], &date, cache, batch); err == nil {
 
-						debit := Debit{
-							key:                       siret,
-							NumeroCompte:              row[numeroCompteIndex],
-							NumeroEcartNegatif:        row[numeroEcartNegatifIndex],
-							CodeProcedureCollective:   row[codeProcedureCollectiveIndex],
-							CodeOperationEcartNegatif: row[codeOperationEcartNegatifIndex],
-							CodeMotifEcartNegatif:     row[codeMotifEcartNegatifIndex],
-						}
-
-						debit.DateTraitement, err = marshal.UrssafToDate(row[dateTraitementIndex])
-						tracker.Add(err)
-						debit.PartOuvriere, err = strconv.ParseFloat(row[partOuvriereIndex], 64)
-						tracker.Add(err)
-						debit.PartOuvriere = debit.PartOuvriere / 100
-						debit.PartPatronale, err = strconv.ParseFloat(row[partPatronaleIndex], 64)
-						tracker.Add(err)
-						debit.PartPatronale = debit.PartPatronale / 100
-						debit.NumeroHistoriqueEcartNegatif, err = strconv.Atoi(row[numeroHistoriqueEcartNegatifIndex])
-						tracker.Add(err)
-						debit.EtatCompte, err = strconv.Atoi(row[etatCompteIndex])
-						tracker.Add(err)
-						debit.Periode, err = marshal.UrssafToPeriod(row[periodeIndex])
-						tracker.Add(err)
-						debit.Recours, err = strconv.ParseBool(row[recoursIndex])
-						tracker.Add(err)
-						// debit.MontantMajorations, err = strconv.ParseFloat(row[montantMajorationsIndex], 64)
-						// tracker.Error(err)
-						// debit.MontantMajorations = debit.MontantMajorations / 100
-
-						if !tracker.HasErrorInCurrentCycle() {
-							outputChannel <- debit
-						}
-					} else {
-						tracker.Add(base.NewFilterError(err))
-						continue
+					debit := Debit{
+						key:                       siret,
+						NumeroCompte:              row[numeroCompteIndex],
+						NumeroEcartNegatif:        row[numeroEcartNegatifIndex],
+						CodeProcedureCollective:   row[codeProcedureCollectiveIndex],
+						CodeOperationEcartNegatif: row[codeOperationEcartNegatifIndex],
+						CodeMotifEcartNegatif:     row[codeMotifEcartNegatifIndex],
 					}
+
+					debit.DateTraitement, err = marshal.UrssafToDate(row[dateTraitementIndex])
+					tracker.Add(err)
+					debit.PartOuvriere, err = strconv.ParseFloat(row[partOuvriereIndex], 64)
+					tracker.Add(err)
+					debit.PartOuvriere = debit.PartOuvriere / 100
+					debit.PartPatronale, err = strconv.ParseFloat(row[partPatronaleIndex], 64)
+					tracker.Add(err)
+					debit.PartPatronale = debit.PartPatronale / 100
+					debit.NumeroHistoriqueEcartNegatif, err = strconv.Atoi(row[numeroHistoriqueEcartNegatifIndex])
+					tracker.Add(err)
+					debit.EtatCompte, err = strconv.Atoi(row[etatCompteIndex])
+					tracker.Add(err)
+					debit.Periode, err = marshal.UrssafToPeriod(row[periodeIndex])
+					tracker.Add(err)
+					debit.Recours, err = strconv.ParseBool(row[recoursIndex])
+					tracker.Add(err)
+					// debit.MontantMajorations, err = strconv.ParseFloat(row[montantMajorationsIndex], 64)
+					// tracker.Error(err)
+					// debit.MontantMajorations = debit.MontantMajorations / 100
+
+					if !tracker.HasErrorInCurrentCycle() {
+						outputChannel <- debit
+					}
+				} else {
+					tracker.Add(base.NewFilterError(err))
+					continue
 				}
 
 				if shouldBreak {

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -160,6 +160,7 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 				}
 
 				if tracker.Count%10000 == 0 && engine.ShouldBreak(tracker, engine.MaxParsingErrors) {
+					fmt.Printf("Reached %d parsing errors => stopping.\n", engine.MaxParsingErrors)
 					break
 				}
 				tracker.Next()

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -103,7 +103,23 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 				continue
 			}
 
+			var lineNumber = 0 // starting with the header
+
+			ctx, stopTheTimer := context.WithCancel(context.Background())
+			go func(ctx context.Context) {
+				for range time.Tick(time.Second * 2) {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+					}
+					fmt.Printf("Reading csv line %d\n", lineNumber)
+				}
+			}(ctx)
+			defer stopTheTimer()
+
 			for {
+				lineNumber++
 				row, err := reader.Read()
 				if err == io.EOF {
 					break

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -112,8 +112,10 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 			if intVal, ok := val.(int); ok {
 				maxParsingErrors = intVal
 			}
-			stopErrorLimiter := StopAfterTooManyErrors(tracker, maxParsingErrors, &shouldBreak)
-			defer stopErrorLimiter()
+			if maxParsingErrors > 0 {
+				stopErrorLimiter := StopAfterTooManyErrors(tracker, maxParsingErrors, &shouldBreak)
+				defer stopErrorLimiter()
+			}
 
 			stopProgressLogger := marshal.LogProgress(&lineNumber)
 			defer stopProgressLogger()
@@ -203,7 +205,7 @@ func StopAfterTooManyErrors(tracker gournal.Tracker, maxErrors int, shouldStop *
 				return
 			default:
 			}
-			*shouldStop = maxErrors > 0 && engine.ShouldBreak(tracker, maxErrors)
+			*shouldStop = engine.ShouldBreak(tracker, maxErrors)
 			if *shouldStop {
 				fmt.Printf("Reached %d parsing errors => stopping.\n", maxErrors)
 			}

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -111,7 +111,7 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 				maxParsingErrors = intVal
 			}
 			if maxParsingErrors > 0 {
-				stopErrorLimiter := StopAfterTooManyErrors(tracker, maxParsingErrors, &shouldBreak)
+				stopErrorLimiter := engine.StopAfterTooManyErrors(tracker, maxParsingErrors, &shouldBreak)
 				defer stopErrorLimiter()
 			}
 

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -106,7 +106,12 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 
 			var shouldBreak = false
 			var lineNumber = 0 // starting with the header
+
 			var maxParsingErrors = engine.MaxParsingErrors
+			val, _ := cache.Get("maxParsingErrors")
+			if intVal, ok := val.(int); ok {
+				maxParsingErrors = intVal
+			}
 
 			ctx, stopTheTimer := context.WithCancel(context.Background())
 			go func(ctx context.Context) {

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -106,6 +106,7 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 
 			var shouldBreak = false
 			var lineNumber = 0 // starting with the header
+			var maxParsingErrors = engine.MaxParsingErrors
 
 			ctx, stopTheTimer := context.WithCancel(context.Background())
 			go func(ctx context.Context) {
@@ -115,9 +116,9 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 						return
 					default:
 					}
-					shouldBreak = engine.ShouldBreak(tracker, engine.MaxParsingErrors)
+					shouldBreak = maxParsingErrors > 0 && engine.ShouldBreak(tracker, maxParsingErrors)
 					if shouldBreak {
-						fmt.Printf("Reached %d parsing errors => stopping.\n", engine.MaxParsingErrors)
+						fmt.Printf("Reached %d parsing errors => stopping.\n", maxParsingErrors)
 					} else {
 						fmt.Printf("Reading csv line %d\n", lineNumber)
 					}

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -2,9 +2,7 @@ package urssaf
 
 import (
 	"bufio"
-	"context"
 	"encoding/csv"
-	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -192,15 +190,4 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 	}()
 
 	return outputChannel, eventChannel
-}
-
-// StopAfterTooManyErrors vérifie toutes les 2s le nombre d'erreurs de parsing
-// et passe shouldStop à true si la limite est dépassée.
-func StopAfterTooManyErrors(tracker gournal.Tracker, maxErrors int, shouldStop *bool) (stop context.CancelFunc) {
-	return base.Cron(time.Second*2, func() {
-		*shouldStop = engine.ShouldBreak(tracker, maxErrors)
-		if *shouldStop {
-			fmt.Printf("Reached %d parsing errors => stopping.\n", maxErrors)
-		}
-	})
 }

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -134,49 +134,46 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 					continue
 				}
 
-				justParse := true
-				if !justParse {
-					period, _ := marshal.UrssafToPeriod(row[periodeIndex])
-					date := period.Start
+				period, _ := marshal.UrssafToPeriod(row[periodeIndex])
+				date := period.Start
 
-					if siret, err := marshal.GetSiret(row[numeroCompteIndex], &date, cache, batch); err == nil {
+				if siret, err := marshal.GetSiret(row[numeroCompteIndex], &date, cache, batch); err == nil {
 
-						debit := Debit{
-							key:                       siret,
-							NumeroCompte:              row[numeroCompteIndex],
-							NumeroEcartNegatif:        row[numeroEcartNegatifIndex],
-							CodeProcedureCollective:   row[codeProcedureCollectiveIndex],
-							CodeOperationEcartNegatif: row[codeOperationEcartNegatifIndex],
-							CodeMotifEcartNegatif:     row[codeMotifEcartNegatifIndex],
-						}
-
-						debit.DateTraitement, err = marshal.UrssafToDate(row[dateTraitementIndex])
-						tracker.Add(err)
-						debit.PartOuvriere, err = strconv.ParseFloat(row[partOuvriereIndex], 64)
-						tracker.Add(err)
-						debit.PartOuvriere = debit.PartOuvriere / 100
-						debit.PartPatronale, err = strconv.ParseFloat(row[partPatronaleIndex], 64)
-						tracker.Add(err)
-						debit.PartPatronale = debit.PartPatronale / 100
-						debit.NumeroHistoriqueEcartNegatif, err = strconv.Atoi(row[numeroHistoriqueEcartNegatifIndex])
-						tracker.Add(err)
-						debit.EtatCompte, err = strconv.Atoi(row[etatCompteIndex])
-						tracker.Add(err)
-						debit.Periode, err = marshal.UrssafToPeriod(row[periodeIndex])
-						tracker.Add(err)
-						debit.Recours, err = strconv.ParseBool(row[recoursIndex])
-						tracker.Add(err)
-						// debit.MontantMajorations, err = strconv.ParseFloat(row[montantMajorationsIndex], 64)
-						// tracker.Error(err)
-						// debit.MontantMajorations = debit.MontantMajorations / 100
-
-						if !tracker.HasErrorInCurrentCycle() {
-							outputChannel <- debit
-						}
-					} else {
-						tracker.Add(base.NewFilterError(err))
-						continue
+					debit := Debit{
+						key:                       siret,
+						NumeroCompte:              row[numeroCompteIndex],
+						NumeroEcartNegatif:        row[numeroEcartNegatifIndex],
+						CodeProcedureCollective:   row[codeProcedureCollectiveIndex],
+						CodeOperationEcartNegatif: row[codeOperationEcartNegatifIndex],
+						CodeMotifEcartNegatif:     row[codeMotifEcartNegatifIndex],
 					}
+
+					debit.DateTraitement, err = marshal.UrssafToDate(row[dateTraitementIndex])
+					tracker.Add(err)
+					debit.PartOuvriere, err = strconv.ParseFloat(row[partOuvriereIndex], 64)
+					tracker.Add(err)
+					debit.PartOuvriere = debit.PartOuvriere / 100
+					debit.PartPatronale, err = strconv.ParseFloat(row[partPatronaleIndex], 64)
+					tracker.Add(err)
+					debit.PartPatronale = debit.PartPatronale / 100
+					debit.NumeroHistoriqueEcartNegatif, err = strconv.Atoi(row[numeroHistoriqueEcartNegatifIndex])
+					tracker.Add(err)
+					debit.EtatCompte, err = strconv.Atoi(row[etatCompteIndex])
+					tracker.Add(err)
+					debit.Periode, err = marshal.UrssafToPeriod(row[periodeIndex])
+					tracker.Add(err)
+					debit.Recours, err = strconv.ParseBool(row[recoursIndex])
+					tracker.Add(err)
+					// debit.MontantMajorations, err = strconv.ParseFloat(row[montantMajorationsIndex], 64)
+					// tracker.Error(err)
+					// debit.MontantMajorations = debit.MontantMajorations / 100
+
+					if !tracker.HasErrorInCurrentCycle() {
+						outputChannel <- debit
+					}
+				} else {
+					tracker.Add(base.NewFilterError(err))
+					continue
 				}
 
 				if shouldBreak {

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -147,7 +147,7 @@ func ParserDebit(cache marshal.Cache, batch *base.AdminBatch) (chan marshal.Tupl
 					continue
 				}
 
-				justParse := true
+				justParse := false
 				if !justParse {
 					period, _ := marshal.UrssafToPeriod(row[periodeIndex])
 					date := period.Start


### PR DESCRIPTION
Extension de PR #182.

Objectif: que la personne en charge de l'importation sache le nombre _total_ d'erreurs rencontrées pendant le parsing des fichiers d'un batch avant son importation, même si ce nombre d'erreur excède 200. (valeur de `MaxParsingErrors`)

## Rendu

Rendu dans la sortie standard, lors de la vérification d'un gros fichier `debit`:

```
[...]
[GIN-debug] Listening and serving HTTP on :5000
Chargement des comptes urssaf
Reading csv line 553652
Reading csv line 1361631
Reading csv line 2081958
[...]
Reading csv line 101127890
```

... et, seulement dans le cas de l'import:

```
[...]
Reading csv line 55167603
Reached 200 parsing errors => stopping.
```

## Comment tester

Appliquer le `git patch` suivant:

```diff
diff --git a/tests/helpers/dbmongo-server.sh b/tests/helpers/dbmongo-server.sh
index 7bd0412b..cc3a5064 100755
--- a/tests/helpers/dbmongo-server.sh
+++ b/tests/helpers/dbmongo-server.sh
@@ -20,7 +20,7 @@ case ${COMMAND} in
     exit ;;
   start)
     cd dbmongo
-    bash -c "./dbmongo &>/dev/null &" # we run in a separate shell to hide the "terminated" message when the process is killed by trap
+    bash -c "./dbmongo &" # we run in a separate shell to hide the "terminated" message when the process is killed by trap
     sleep 2 # give some time for dbmongo to start
     exit ;;
   ?)
diff --git a/tests/test-api-check.sh b/tests/test-api-check.sh
index c0fe0fac..560184c0 100755
--- a/tests/test-api-check.sh
+++ b/tests/test-api-check.sh
@@ -40,7 +40,7 @@ tests/helpers/mongodb-container.sh run > /dev/null << CONTENTS
         "/../lib/urssaf/testData/comptesTestData.csv"
       ],
       "debit": [
-        "/../lib/urssaf/testData/debitCorrompuTestData.csv"
+        "/../../../opensignauxfaibles-corrupted-debit/029f33da3f9b32a7d75a961775400400.backup.bin"
       ]
     },
     "param" : {
diff --git a/tests/test-api-import.sh b/tests/test-api-import.sh
index e2d55af3..f30fed6f 100755
--- a/tests/test-api-import.sh
+++ b/tests/test-api-import.sh
@@ -40,8 +40,8 @@ tests/helpers/mongodb-container.sh run > /dev/null << CONTENTS
       "admin_urssaf": [
         "/../lib/urssaf/testData/comptesTestData.csv"
       ],
-      "delai": [
-        "/../lib/urssaf/testData/delaiTestData.csv"
+      "debit": [
+        "/../../../opensignauxfaibles-corrupted-debit/029f33da3f9b32a7d75a961775400400.backup.bin"
       ]
     },
     "param" : {
@@ -54,7 +54,7 @@ CONTENTS
 echo ""
 echo "💎 Parsing and importing data thru dbmongo API..."
 tests/helpers/dbmongo-server.sh start
-echo "- POST /api/data/import 👉 $(http --print=b --ignore-stdin :5000/api/data/import batch=1910 noFilter:=true parsers:='["delai"]')"
+echo "- POST /api/data/import 👉 $(http --print=b --ignore-stdin :5000/api/data/import batch=1910 noFilter:=true parsers:='["debit"]')"
 
 OUTPUT_GZ_FILE=dbmongo/$(http --print=b --ignore-stdin :5000/api/data/validate collection=ImportedData | tr -d '"')
 echo "- POST /api/data/validate 👉 ${OUTPUT_GZ_FILE}"
```

Puis lancer `$ tests/test-api-check.sh` et `$ tests/test-api-import.sh` pour obtenir le rendu ci-dessus.