### PR TITLE
fix(compact): Détection d'entrée `undefined` en db pour prévenir interruption de compactage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,8 @@ jobs:
           sudo apt-get install git-secret # to decrypt golden master files, for tests
           sudo apt-get install dos2unix # called by convert_diane.sh
 
+      - run: ./tests/test-api-compact-failure.sh # relies on encrypted files
+
       - run: ./tests/test-api.sh
 
       - run: ./tests/test-api-import.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,8 +30,6 @@ jobs:
           sudo apt-get install git-secret # to decrypt golden master files, for tests
           sudo apt-get install dos2unix # called by convert_diane.sh
 
-      - run: ./tests/test-api-compact-failure.sh # relies on encrypted files
-
       - run: ./tests/test-api.sh
 
       - run: ./tests/test-api-import.sh
@@ -47,6 +45,8 @@ jobs:
       - run: ./tests/test-api-reduce.sh
 
       - run: ./tests/test-api-purge-batch.sh
+
+      - run: ./tests/test-api-compact-failure.sh
 
       - name: Reveal golden master files for tests
         env:

--- a/dbmongo/js/common/forEachPopulatedProp.ts
+++ b/dbmongo/js/common/forEachPopulatedProp.ts
@@ -1,6 +1,6 @@
 // Appelle fct() pour chaque propriété définie (non undefined) de obj.
 // Contrat: obj ne doit contenir que les clés définies dans son type.
-export function forEachPopulatedProp<T>(
+export function forEachPopulatedProp<T extends Record<string, unknown>>(
   obj: T,
   fct: (key: keyof T, val: Required<T>[keyof T]) => unknown
 ): void {

--- a/dbmongo/js/compact/reduce_tests.ts
+++ b/dbmongo/js/compact/reduce_tests.ts
@@ -432,6 +432,7 @@ test.serial(
     // définition des valeurs de paramètres globaux utilisés par les fonctions de "compact"
     const batchKeyWithInvalidData = "2009"
     const fromBatchKey = "2008"
+    const oldBatchKey = "2007"
     setGlobals({
       fromBatchKey,
       batches: [fromBatchKey],
@@ -441,7 +442,7 @@ test.serial(
     const previousRawDataValue = {
       key,
       scope: "etablissement",
-      batch: {},
+      batch: { [oldBatchKey]: {} },
     } as CompanyDataValues
     const importedDataValue: CompanyDataValues = {
       key,

--- a/dbmongo/js/compact/reduce_tests.ts
+++ b/dbmongo/js/compact/reduce_tests.ts
@@ -451,7 +451,9 @@ test.serial(
     }
     // exécution du test
     const reducedData = reduce(key, [importedDataValue])
-    const mergeOutput = reduce(key, [previousRawDataValue, reducedData])
-    t.truthy(mergeOutput.batch)
+    const error = t.throws(() => {
+      /*const mergeOutput =*/ reduce(key, [previousRawDataValue, reducedData])
+    })
+    t.regex(error.message, /Cannot convert undefined or null to object/)
   }
 )

--- a/dbmongo/js/compact/reduce_tests.ts
+++ b/dbmongo/js/compact/reduce_tests.ts
@@ -1,7 +1,7 @@
 import test, { ExecutionContext } from "ava"
 import { reduce } from "./reduce"
 import { setGlobals } from "../test/helpers/setGlobals"
-import { DataType, BatchKey } from "../RawDataTypes"
+import { DataType, BatchKey, CompanyDataValues } from "../RawDataTypes"
 import { CompanyDataValuesWithCompact } from "./applyPatchesToBatch"
 
 const REDUCE_KEY = "123"
@@ -423,5 +423,34 @@ test.serial(
     // test sur les données compactées de cotisation
     const cotisations = reduceResults.batch[batchId].cotisation || {}
     t.deepEqual(Object.keys(cotisations), hashCotisation)
+  }
+)
+
+test.serial(
+  `reduce crashe quand une entrée de donnée est indéfinie`,
+  (t: ExecutionContext) => {
+    // définition des valeurs de paramètres globaux utilisés par les fonctions de "compact"
+    const batchKeyWithInvalidData = "2009"
+    const fromBatchKey = "2008"
+    setGlobals({
+      fromBatchKey,
+      batches: [fromBatchKey],
+      completeTypes: { [fromBatchKey]: [] },
+    })
+    const key = "01234567891011"
+    const previousRawDataValue = {
+      key,
+      scope: "etablissement",
+      batch: {},
+    } as CompanyDataValues
+    const importedDataValue: CompanyDataValues = {
+      key,
+      scope: "etablissement",
+      batch: { [batchKeyWithInvalidData]: { cotisation: undefined } },
+    }
+    // exécution du test
+    const reducedData = reduce(key, [importedDataValue])
+    const mergeOutput = reduce(key, [previousRawDataValue, reducedData])
+    t.truthy(mergeOutput.batch)
   }
 )

--- a/dbmongo/lib/engine/data.go
+++ b/dbmongo/lib/engine/data.go
@@ -147,9 +147,9 @@ func Compact(fromBatchKey string) error {
 	// Traitement MR
 	job := &mgo.MapReduce{
 		Map:      functions["map"].Code,
-		Reduce:   functions["reduce"].Code,
+		Reduce:   functions["reduce"].Code, // 1st pass: reduce() will be called on the documents of ImportedData
 		Finalize: functions["finalize"].Code,
-		Out:      bson.M{"reduce": "RawData"},
+		Out:      bson.M{"reduce": "RawData"}, // 2nd pass: for each siret/siren, reduce() will be called on the current RawData document and the result of the 1st pass, to merge the the new data with the existing data
 		Scope: bson.M{
 			"f":             functions,
 			"batches":       batchesID,

--- a/dbmongo/lib/engine/data_validation.go
+++ b/dbmongo/lib/engine/data_validation.go
@@ -59,8 +59,13 @@ func LoadJSONSchemaFiles() (jsonSchema map[string]bson.M, err error) {
 	return jsonSchema, nil
 }
 
+// GetUndefinedDataValidationPipeline produit un pipeline pour détecter les entrées `undefined` depuis RawData ou ImportedData.
+func GetUndefinedDataValidationPipeline() (pipeline []bson.M, err error) {
+	return parseJSONArray("validation/detect_invalid_entries.pipeline.json")
+}
+
 // GetDataValidationPipeline produit un pipeline pour retourner la listes des documents invalides depuis RawData ou ImportedData.
-func GetDataValidationPipeline(jsonSchema map[string]bson.M, collection string) (pipeline []bson.M, err error) {
+func GetDataValidationPipeline(jsonSchema map[string]bson.M) (pipeline []bson.M, err error) {
 
 	flattenPipeline, err := parseJSONArray("validation/flatten_data_entries.pipeline.json")
 	if err != nil {

--- a/dbmongo/validation/detect_invalid_entries.pipeline.json
+++ b/dbmongo/validation/detect_invalid_entries.pipeline.json
@@ -1,0 +1,23 @@
+[
+  { "$project": { "_id": 1, "batches": { "$objectToArray": "$value.batch" } } },
+  { "$unwind": { "path": "$batches", "preserveNullAndEmptyArrays": false } },
+  {
+    "$project": {
+      "_id": 1,
+      "batchKey": "$batches.k",
+      "dataPerHash": { "$objectToArray": "$batches.v" }
+    }
+  },
+  {
+    "$unwind": { "path": "$dataPerHash", "preserveNullAndEmptyArrays": false }
+  },
+  {
+    "$project": {
+      "_id": 1,
+      "batchKey": 1,
+      "dataType": "$dataPerHash.k",
+      "dataPerHash": "$dataPerHash.v"
+    }
+  },
+  { "$match": { "dataPerHash": { "$not": { "$type": 3 } } } }
+]

--- a/test-all.sh
+++ b/test-all.sh
@@ -48,6 +48,9 @@ heading "go generate"
 heading "go build"
 (killall dbmongo 2>/dev/null || true; cd ./dbmongo && go build && echo "📦 dbmongo/dbmongo") 2>&1 | indent
 
+heading "test-api-compact-failure.sh"
+./tests/test-api-compact-failure.sh $@ 2>&1 | indent
+
 heading "test-api.sh"
 ./tests/test-api.sh $@ 2>&1 | indent
 

--- a/test-all.sh
+++ b/test-all.sh
@@ -48,9 +48,6 @@ heading "go generate"
 heading "go build"
 (killall dbmongo 2>/dev/null || true; cd ./dbmongo && go build && echo "📦 dbmongo/dbmongo") 2>&1 | indent
 
-heading "test-api-compact-failure.sh"
-./tests/test-api-compact-failure.sh $@ 2>&1 | indent
-
 heading "test-api.sh"
 ./tests/test-api.sh $@ 2>&1 | indent
 
@@ -65,6 +62,9 @@ heading "test-api-import.sh"
 
 heading "test-api-compact.sh"
 ./tests/test-api-compact.sh $@ 2>&1 | indent
+
+heading "test-api-compact-failure.sh"
+./tests/test-api-compact-failure.sh $@ 2>&1 | indent
 
 heading "test-api-public.sh"
 ./tests/test-api-public.sh $@ 2>&1 | indent

--- a/tests/test-api-compact-failure.sh
+++ b/tests/test-api-compact-failure.sh
@@ -69,10 +69,11 @@ diff <(echo -n '') <(zcat < "${OUTPUT_GZ_FILE}")
 
 OUTPUT_GZ_FILE=dbmongo/$(http --print=b --ignore-stdin :5000/api/data/validate collection=ImportedData | tr -d '"')
 echo "- POST /api/data/validate ImportedData 👉 ${OUTPUT_GZ_FILE}"
-diff <(echo '{"_id":"5f9192703029a1f7d4b1773b","batchKey":"2009","dataPerHash":{},"dataType":"cotisation"}') <(zcat < "${OUTPUT_GZ_FILE}") # we expect an invalid data entry to be listed
+grep --quiet '{"_id":"5f9192703029a1f7d4b1773b","batchKey":"2009","dataPerHash":{},"dataType":"cotisation"}' <(zcat < "${OUTPUT_GZ_FILE}") # we expect an invalid data entry to be listed
 
-echo "- POST /api/data/compact => diff:"
-diff <(echo -n '"ok"') <(http --print=b --ignore-stdin :5000/api/data/compact fromBatchKey=2008) # will fail with "TypeError: can't convert undefined to object"
-echo "✅ No diff => OK"
+echo "- POST /api/data/compact should fail"
+grep --quiet "TypeError: can't convert undefined to object" <(http --print=b --ignore-stdin :5000/api/data/compact fromBatchKey=2008) # will fail with "TypeError: can't convert undefined to object"
+
+echo "✅ OK"
 
 # Now, the "trap" commands will clean up the rest.

--- a/tests/test-api-compact-failure.sh
+++ b/tests/test-api-compact-failure.sh
@@ -85,6 +85,8 @@ echo "💎 Compacting RawData thru dbmongo API..."
 tests/helpers/dbmongo-server.sh start
 echo "- POST /api/data/compact => diff:"
 
-diff <(echo "ok") <(http --print=b --ignore-stdin :5000/api/data/compact fromBatchKey=2009) # will fail with "TypeError: can't convert undefined to object"
+diff <(echo -n '"ok"') <(http --print=b --ignore-stdin :5000/api/data/compact fromBatchKey=2009) # will fail with "TypeError: can't convert undefined to object"
+
+echo "✅ No diff => OK"
 
 # Now, the "trap" commands will clean up the rest.

--- a/tests/test-api-compact-failure.sh
+++ b/tests/test-api-compact-failure.sh
@@ -28,19 +28,12 @@ tests/helpers/mongodb-container.sh run << CONTENTS
       "_id" : {
         "key" : "2008",
         "type" : "batch"
-      },
-      "param" : {
-        "date_debut" : ISODate("2014-01-01T00:00:00.000+0000"),
-        "date_fin" : ISODate("2016-01-01T00:00:00.000+0000"),
-        "date_fin_effectif" : ISODate("2016-03-01T00:00:00.000+0000")
-      },
-      "name" : "TestData"
+      }
     }
   ])
 
   db.ImportedData.insertMany([
     {
-      "_id": "import1",
       "value": {
         "key": "01234567891011",
         "scope": "etablissement",
@@ -48,9 +41,6 @@ tests/helpers/mongodb-container.sh run << CONTENTS
           "2009": {
             "cotisation": undefined
           }
-        },
-        "index": {
-          "algo2": true
         }
       }
     }

--- a/tests/test-api-compact-failure.sh
+++ b/tests/test-api-compact-failure.sh
@@ -83,7 +83,8 @@ CONTENTS
 echo ""
 echo "💎 Compacting RawData thru dbmongo API..."
 tests/helpers/dbmongo-server.sh start
-echo "- POST /api/data/compact"
-http --print=b --ignore-stdin :5000/api/data/compact fromBatchKey=2009 # will fail with "TypeError: can't convert undefined to object"
+echo "- POST /api/data/compact => diff:"
+
+diff <(echo "ok") <(http --print=b --ignore-stdin :5000/api/data/compact fromBatchKey=2009) # will fail with "TypeError: can't convert undefined to object"
 
 # Now, the "trap" commands will clean up the rest.

--- a/tests/test-api-compact-failure.sh
+++ b/tests/test-api-compact-failure.sh
@@ -26,19 +26,7 @@ tests/helpers/mongodb-container.sh run << CONTENTS
   db.Admin.insertMany([
     {
       "_id" : {
-        "key" : "2009",
-        "type" : "batch"
-      },
-      "param" : {
-        "date_debut" : ISODate("2014-01-01T00:00:00.000+0000"),
-        "date_fin" : ISODate("2016-01-01T00:00:00.000+0000"),
-        "date_fin_effectif" : ISODate("2016-03-01T00:00:00.000+0000")
-      },
-      "name" : "TestData"
-    },
-    {
-      "_id" : {
-        "key" : "2010",
+        "key" : "2008",
         "type" : "batch"
       },
       "param" : {
@@ -85,7 +73,7 @@ echo "💎 Compacting RawData thru dbmongo API..."
 tests/helpers/dbmongo-server.sh start
 echo "- POST /api/data/compact => diff:"
 
-diff <(echo -n '"ok"') <(http --print=b --ignore-stdin :5000/api/data/compact fromBatchKey=2009) # will fail with "TypeError: can't convert undefined to object"
+diff <(echo -n '"ok"') <(http --print=b --ignore-stdin :5000/api/data/compact fromBatchKey=2008) # will fail with "TypeError: can't convert undefined to object"
 
 echo "✅ No diff => OK"
 

--- a/tests/test-api-compact-failure.sh
+++ b/tests/test-api-compact-failure.sh
@@ -61,10 +61,17 @@ CONTENTS
 echo ""
 echo "💎 Compacting RawData thru dbmongo API..."
 tests/helpers/dbmongo-server.sh start
+
+OUTPUT_GZ_FILE=dbmongo/$(http --print=b --ignore-stdin :5000/api/data/validate collection=RawData | tr -d '"')
+echo "- POST /api/data/validate RawData 👉 ${OUTPUT_GZ_FILE}"
+diff <(echo -n '') <(zcat < "${OUTPUT_GZ_FILE}")
+
+OUTPUT_GZ_FILE=dbmongo/$(http --print=b --ignore-stdin :5000/api/data/validate collection=ImportedData | tr -d '"')
+echo "- POST /api/data/validate ImportedData 👉 ${OUTPUT_GZ_FILE}, contents:"
+diff <(echo '(invalid data entry)') <(zcat < "${OUTPUT_GZ_FILE}") # we expect an invalid data entry to be listed
+
 echo "- POST /api/data/compact => diff:"
-
 diff <(echo -n '"ok"') <(http --print=b --ignore-stdin :5000/api/data/compact fromBatchKey=2008) # will fail with "TypeError: can't convert undefined to object"
-
 echo "✅ No diff => OK"
 
 # Now, the "trap" commands will clean up the rest.

--- a/tests/test-api-compact-failure.sh
+++ b/tests/test-api-compact-failure.sh
@@ -34,6 +34,7 @@ tests/helpers/mongodb-container.sh run << CONTENTS
 
   db.ImportedData.insertMany([
     {
+      "_id": "5f9192703029a1f7d4b1773b",
       "value": {
         "key": "01234567891011",
         "scope": "etablissement",
@@ -67,8 +68,8 @@ echo "- POST /api/data/validate RawData 👉 ${OUTPUT_GZ_FILE}"
 diff <(echo -n '') <(zcat < "${OUTPUT_GZ_FILE}")
 
 OUTPUT_GZ_FILE=dbmongo/$(http --print=b --ignore-stdin :5000/api/data/validate collection=ImportedData | tr -d '"')
-echo "- POST /api/data/validate ImportedData 👉 ${OUTPUT_GZ_FILE}, contents:"
-diff <(echo '(invalid data entry)') <(zcat < "${OUTPUT_GZ_FILE}") # we expect an invalid data entry to be listed
+echo "- POST /api/data/validate ImportedData 👉 ${OUTPUT_GZ_FILE}"
+diff <(echo '{"_id":"5f9192703029a1f7d4b1773b","batchKey":"2009","dataPerHash":{},"dataType":"cotisation"}') <(zcat < "${OUTPUT_GZ_FILE}") # we expect an invalid data entry to be listed
 
 echo "- POST /api/data/compact => diff:"
 diff <(echo -n '"ok"') <(http --print=b --ignore-stdin :5000/api/data/compact fromBatchKey=2008) # will fail with "TypeError: can't convert undefined to object"

--- a/tests/test-api-compact-failure.sh
+++ b/tests/test-api-compact-failure.sh
@@ -52,7 +52,7 @@ tests/helpers/mongodb-container.sh run << CONTENTS
       "value" : {
         "key" : "01234567891011", 
         "scope" : "etablissement", 
-        "batch" : {}
+        "batch" : { "2007": {} }
       }
     }
   ])

--- a/tests/test-api-compact-failure.sh
+++ b/tests/test-api-compact-failure.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Test de bout en bout de l'API "compact".
+# Ce script doit être exécuté depuis la racine du projet. Ex: par test-all.sh.
+
+tests/helpers/mongodb-container.sh stop
+
+set -e # will stop the script if any command fails with a non-zero exit code
+
+# Clean up on exit
+function teardown {
+    tests/helpers/dbmongo-server.sh stop || true # keep tearing down, even if "No matching processes belonging to you were found"
+    tests/helpers/mongodb-container.sh stop
+}
+trap teardown EXIT
+
+PORT="27016" tests/helpers/mongodb-container.sh start
+
+MONGODB_PORT="27016" tests/helpers/dbmongo-server.sh setup
+
+echo ""
+echo "📝 Inserting test data..."
+sleep 1 # give some time for MongoDB to start
+
+tests/helpers/mongodb-container.sh run << CONTENTS
+  db.Admin.insertMany([
+    {
+      "_id" : {
+        "key" : "2009",
+        "type" : "batch"
+      },
+      "param" : {
+        "date_debut" : ISODate("2014-01-01T00:00:00.000+0000"),
+        "date_fin" : ISODate("2016-01-01T00:00:00.000+0000"),
+        "date_fin_effectif" : ISODate("2016-03-01T00:00:00.000+0000")
+      },
+      "name" : "TestData"
+    },
+    {
+      "_id" : {
+        "key" : "2010",
+        "type" : "batch"
+      },
+      "param" : {
+        "date_debut" : ISODate("2014-01-01T00:00:00.000+0000"),
+        "date_fin" : ISODate("2016-01-01T00:00:00.000+0000"),
+        "date_fin_effectif" : ISODate("2016-03-01T00:00:00.000+0000")
+      },
+      "name" : "TestData"
+    }
+  ])
+
+  db.ImportedData.insertMany([
+    {
+      "_id": "import1",
+      "value": {
+        "key": "01234567891011",
+        "scope": "etablissement",
+        "batch": {
+          "2009": {
+            "cotisation": undefined
+          }
+        },
+        "index": {
+          "algo2": true
+        }
+      }
+    }
+  ])
+
+  db.RawData.insertMany([
+    { 
+      "_id" : "01234567891011", 
+      "value" : {
+        "key" : "01234567891011", 
+        "scope" : "etablissement", 
+        "batch" : {}
+      }
+    }
+  ])
+CONTENTS
+
+echo ""
+echo "💎 Compacting RawData thru dbmongo API..."
+tests/helpers/dbmongo-server.sh start
+echo "- POST /api/data/compact"
+http --print=b --ignore-stdin :5000/api/data/compact fromBatchKey=2009 # will fail with "TypeError: can't convert undefined to object"
+
+# Now, the "trap" commands will clean up the rest.


### PR DESCRIPTION
cf https://github.com/signaux-faibles/opensignauxfaibles/issues/211#issuecomment-713539433

## Problème

Tel que décrit dans #211, une opération de compactage en production a été interrompue prématurément avec un message d'erreur javascript `can't convert undefined to object`.

## Diagnostic

Après quelques recherches, il s'avère que ce cas peut arriver quand le `reduce()` de l'API `/compact` s'applique sur un batch contenant une entrée de données de type `undefined` (au lieu de `object`).

## Solution proposée

Afin d'éviter que cette erreur ne puisse se produire à nouveau, j'ai ajouté une agrégation MongoDB dans l'API `/validate` qui retourne tout document de `ImportedData` ou `RawData` contenant une entrée `undefined`. => Je suggère qu'on appelle cette API sur les collections `ImportedData` et `RawData` avant de lancer un compactage. (similairement à `/check` avant de lancer un import de données)

## Modifications apportées

- Ajout d'un test unitaire simulant l'étape `merge` (deuxième passe) du compactage pour reproduire le crash.
- Ajout d'un test de bout en bout pour reproduire le crash mais surtout vérifier que l'API de validation rapporte bien l'entrée `undefined`, en amont.
- Refactoring des fonctions d'execution d'agrégations MongoDB, pour réduire la duplication de code.

## Prochaines étapes

Après revue de cette PR:

- [ ] recommander l'usage de `/check` (avant `/import`) et `/validate` (avant `/compact`) dans la documentation de Signaux Faibles