### PR TITLE
fix(compact): Optim sur compactage d'un batch couvert par 2 documents

### DIFF
--- a/dbmongo/js/compact/reduce.ts
+++ b/dbmongo/js/compact/reduce.ts
@@ -23,7 +23,7 @@ export function reduce(
   // batchs. Sinon, juste fusion des attributs
   const auxBatchSet = new Set()
   const severalBatches = values.some((value) => {
-    auxBatchSet.add(Object.keys(value.batch || {}))
+    Object.keys(value.batch || {}).forEach((batch) => auxBatchSet.add(batch))
     return auxBatchSet.size > 1
   })
 

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -479,7 +479,7 @@ function reduce(key, values // chaque element contient plusieurs batches pour ce
     // batchs. Sinon, juste fusion des attributs
     const auxBatchSet = new Set();
     const severalBatches = values.some((value) => {
-        auxBatchSet.add(Object.keys(value.batch || {}));
+        Object.keys(value.batch || {}).forEach((batch) => auxBatchSet.add(batch));
         return auxBatchSet.size > 1;
     });
     // Fusion batch par batch des types de données sans se préoccuper des doublons.


### PR DESCRIPTION
Problème: `severalBatches` est vrai même si on a qu'un seul batch réparti entre deux 2 documents `ImportedData`. (comme vu dans le test de PR #217.

Ce défaut empêche `reduce()` de se terminer de manière anticipée.