### PR TITLE
fix: Refonte du filtrage SIREN d'entreprises + correction Effectif

### DIFF
--- a/dbmongo/lib/bdf/main.go
+++ b/dbmongo/lib/bdf/main.go
@@ -79,7 +79,7 @@ var field = map[string]int{
 	"fraisFinancier":      12,
 }
 
-func parseBdfLine(row []string, tracker *gournal.Tracker, filter map[string]bool) BDF {
+func parseBdfLine(row []string, tracker *gournal.Tracker, filter marshal.SirenFilter) BDF {
 	bdf := BDF{}
 	bdf.Siren = strings.Replace(row[field["siren"]], " ", "", -1)
 
@@ -167,7 +167,7 @@ func parseBdfLine(row []string, tracker *gournal.Tracker, filter map[string]bool
 	return bdf
 }
 
-func parseBdfFile(reader *csv.Reader, filter map[string]bool, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
+func parseBdfFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
 	// Lecture en-tête
 	_, err := reader.Read()
 	tracker.Add(err)

--- a/dbmongo/lib/bdf/main.go
+++ b/dbmongo/lib/bdf/main.go
@@ -89,7 +89,7 @@ func parseBdfLine(row []string, tracker *gournal.Tracker, filter marshal.SirenFi
 		return BDF{}
 	}
 
-	filtered, err := marshal.IsFiltered(bdf.Siren, filter)
+	filtered, err := filter.IsFiltered(bdf.Siren)
 	tracker.Add(err)
 	if filtered {
 		tracker.Add(base.NewFilterNotice())

--- a/dbmongo/lib/bdf/main_test.go
+++ b/dbmongo/lib/bdf/main_test.go
@@ -22,7 +22,7 @@ func TestBdfOutput(t *testing.T) {
 func TestBdfParser(t *testing.T) {
 	t.Run("Should return only the companies listed in the filter file", func(t *testing.T) {
 		var cache = marshal.NewCache()
-		cache.Set("filter", map[string]bool{"000111222": true, "000111224": true})
+		cache.Set("filter", marshal.SirenFilter{"000111222": true, "000111224": true})
 		var output = marshal.RunParser(Parser, cache, testData)
 		assert.Equal(t, 2, len(output.Tuples))
 		lastEvent := output.Events[len(output.Events)-1]

--- a/dbmongo/lib/ellisphere/main.go
+++ b/dbmongo/lib/ellisphere/main.go
@@ -58,7 +58,7 @@ func ParseFile(path string, cache *marshal.Cache, batch *base.AdminBatch, tracke
 	parseEllisphereSheet(xlsxFile.Sheets[0], filter, tracker, outputChannel)
 }
 
-func parseEllisphereSheet(sheet *xlsx.Sheet, filter map[string]bool, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
+func parseEllisphereSheet(sheet *xlsx.Sheet, filter marshal.SirenFilter, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
 	sheet.ForEachRow(
 		func(row *xlsx.Row) error {
 			var ellisphere Ellisphere

--- a/dbmongo/lib/ellisphere/main.go
+++ b/dbmongo/lib/ellisphere/main.go
@@ -64,7 +64,7 @@ func parseEllisphereSheet(sheet *xlsx.Sheet, filter marshal.SirenFilter, tracker
 			var ellisphere Ellisphere
 			err := row.ReadStruct(&ellisphere)
 
-			filtered, errFilter := marshal.IsFiltered(ellisphere.Siren, filter)
+			filtered, errFilter := filter.IsFiltered(ellisphere.Siren)
 			if errFilter != nil {
 				tracker.Add(errFilter)
 			}

--- a/dbmongo/lib/marshal/filter.go
+++ b/dbmongo/lib/marshal/filter.go
@@ -17,7 +17,7 @@ import (
 // SirenFilter liste les numéros SIREN d'entreprise et établissements à exclure des traitements.
 type SirenFilter map[string]bool
 
-// IsFiltered determines if the siret must be filtered or not
+// IsFiltered valide le numéro SIREN/SIRET puis retourne `true` si il est à exclure.
 func (filter SirenFilter) IsFiltered(id string) (bool, error) {
 
 	validSiret := sfregexp.RegexpDict["siret"].MatchString(id)
@@ -30,11 +30,11 @@ func (filter SirenFilter) IsFiltered(id string) (bool, error) {
 	if filter == nil {
 		return false, nil
 	}
-	return !filter.FilterHas(id), nil
+	return !filter.Includes(id), nil
 }
 
-// FilterHas tells if the siret/siren is listed in the filter, or not.
-func (filter SirenFilter) FilterHas(siretOrSiren string) bool {
+// Includes retourne `true` si le numéro SIREN/SIRET est inclus, c.a.d. à traiter.
+func (filter SirenFilter) Includes(siretOrSiren string) bool {
 	if len(siretOrSiren) >= 9 {
 		return filter[siretOrSiren[0:9]]
 	}

--- a/dbmongo/lib/marshal/filter.go
+++ b/dbmongo/lib/marshal/filter.go
@@ -30,11 +30,11 @@ func (filter SirenFilter) IsFiltered(id string) (bool, error) {
 	if filter == nil {
 		return false, nil
 	}
-	return !FilterHas(id, filter), nil
+	return !filter.FilterHas(id), nil
 }
 
 // FilterHas tells if the siret/siren is listed in the filter, or not.
-func FilterHas(siretOrSiren string, filter SirenFilter) bool {
+func (filter SirenFilter) FilterHas(siretOrSiren string) bool {
 	if len(siretOrSiren) >= 9 {
 		return filter[siretOrSiren[0:9]]
 	}

--- a/dbmongo/lib/marshal/filter.go
+++ b/dbmongo/lib/marshal/filter.go
@@ -18,7 +18,7 @@ import (
 type SirenFilter map[string]bool
 
 // IsFiltered determines if the siret must be filtered or not
-func IsFiltered(id string, filter SirenFilter) (bool, error) {
+func (filter *SirenFilter) IsFiltered(id string) (bool, error) {
 
 	validSiret := sfregexp.RegexpDict["siret"].MatchString(id)
 	validSiren := sfregexp.RegexpDict["siren"].MatchString(id)
@@ -30,7 +30,7 @@ func IsFiltered(id string, filter SirenFilter) (bool, error) {
 	if filter == nil {
 		return false, nil
 	}
-	return !FilterHas(id, filter), nil
+	return !FilterHas(id, *filter), nil
 }
 
 // FilterHas tells if the siret/siren is listed in the filter, or not.

--- a/dbmongo/lib/marshal/filter.go
+++ b/dbmongo/lib/marshal/filter.go
@@ -18,7 +18,7 @@ import (
 type SirenFilter map[string]bool
 
 // IsFiltered determines if the siret must be filtered or not
-func (filter *SirenFilter) IsFiltered(id string) (bool, error) {
+func (filter SirenFilter) IsFiltered(id string) (bool, error) {
 
 	validSiret := sfregexp.RegexpDict["siret"].MatchString(id)
 	validSiren := sfregexp.RegexpDict["siren"].MatchString(id)
@@ -30,7 +30,7 @@ func (filter *SirenFilter) IsFiltered(id string) (bool, error) {
 	if filter == nil {
 		return false, nil
 	}
-	return !FilterHas(id, *filter), nil
+	return !FilterHas(id, filter), nil
 }
 
 // FilterHas tells if the siret/siren is listed in the filter, or not.

--- a/dbmongo/lib/marshal/filter_test.go
+++ b/dbmongo/lib/marshal/filter_test.go
@@ -19,7 +19,6 @@ func TestIsFiltered(t *testing.T) {
 		expectError bool
 		expected    bool
 	}{
-		{"012345678", SirenFilter{"01234567891011": true}, true, false}, // siren non valide trouvé dans le fichier
 		{"012345678", SirenFilter{"012345678": true}, false, false},
 		{"01234567891011", SirenFilter{"012345678": true}, false, false},
 		{"0123", SirenFilter{"012345678": true}, true, true},

--- a/dbmongo/lib/marshal/filter_test.go
+++ b/dbmongo/lib/marshal/filter_test.go
@@ -15,16 +15,16 @@ func TestIsFiltered(t *testing.T) {
 
 	testCases := []struct {
 		siret       string
-		filter      map[string]bool
+		filter      SirenFilter
 		expectError bool
 		expected    bool
 	}{
-		{"012345678", map[string]bool{"012345678": true}, false, false},
-		{"01234567891011", map[string]bool{"012345678": true}, false, false},
-		{"0123", map[string]bool{"012345678": true}, true, true},
-		{"0123456789", map[string]bool{"012345678": true}, true, true},
-		{"876543210", map[string]bool{"012345678": true}, false, true},
-		{"87654321091011", map[string]bool{"012345678": true}, false, true},
+		{"012345678", SirenFilter{"012345678": true}, false, false},
+		{"01234567891011", SirenFilter{"012345678": true}, false, false},
+		{"0123", SirenFilter{"012345678": true}, true, true},
+		{"0123456789", SirenFilter{"012345678": true}, true, true},
+		{"876543210", SirenFilter{"012345678": true}, false, true},
+		{"87654321091011", SirenFilter{"012345678": true}, false, true},
 		{"012345678", nil, false, false},
 		{"0123", nil, true, true},
 	}
@@ -51,18 +51,18 @@ func TestGetSirenFilter(t *testing.T) {
 		cacheKey       string
 		cacheValue     interface{}
 		batch          base.AdminBatch
-		expectedFilter map[string]bool
+		expectedFilter SirenFilter
 	}{
 		{"existing cache",
-			"filter", map[string]bool{"012345678": true}, base.AdminBatch{}, map[string]bool{"012345678": true}},
+			"filter", SirenFilter{"012345678": true}, base.AdminBatch{}, SirenFilter{"012345678": true}},
 		{"No cache, no filter in batch 1",
 			"", "", base.AdminBatch{}, nil},
 		{"No cache, no filter in batch 2",
 			"", "", base.MockBatch("filter", nil), nil},
 		{"No cache, (mock)read from file",
-			"", "", base.MockBatch("filter", []string{"at least one"}), map[string]bool{"012345678": true}},
+			"", "", base.MockBatch("filter", []string{"at least one"}), SirenFilter{"012345678": true}},
 		{"Cache has precedence over file",
-			"filter", map[string]bool{"876543210": true}, base.MockBatch("filter", []string{"at least one"}), map[string]bool{"876543210": true}},
+			"filter", SirenFilter{"876543210": true}, base.MockBatch("filter", []string{"at least one"}), SirenFilter{"876543210": true}},
 	}
 
 	for ind, tc := range testCases {
@@ -83,7 +83,7 @@ func TestGetSirenFilter(t *testing.T) {
 		// cache has filter
 		if tc.expectedFilter != nil {
 			cacheFilter, err := cache.Get("filter")
-			cacheFilterTyped, ok := cacheFilter.(map[string]bool)
+			cacheFilterTyped, ok := cacheFilter.(SirenFilter)
 			if err != nil || !ok || !reflect.DeepEqual(cacheFilterTyped, tc.expectedFilter) {
 				t.Fatalf("Test %d failed: filter is missing from cache", ind)
 			}
@@ -91,21 +91,21 @@ func TestGetSirenFilter(t *testing.T) {
 	}
 }
 
-func mockReadFilter(string, []string) (map[string]bool, error) {
-	return map[string]bool{"012345678": true}, nil
+func mockReadFilter(string, []string) (SirenFilter, error) {
+	return SirenFilter{"012345678": true}, nil
 }
 
 func TestReadFilter(t *testing.T) {
-	var testFilter = make(map[string]bool)
+	var testFilter = make(SirenFilter)
 	err := readFilter(strings.NewReader("012345678\n876543210"), testFilter)
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
-	if !reflect.DeepEqual(testFilter, map[string]bool{"012345678": true, "876543210": true}) {
+	if !reflect.DeepEqual(testFilter, SirenFilter{"012345678": true, "876543210": true}) {
 		t.Fatalf("Filter not read as expected, failure")
 	}
 
-	testFilter = make(map[string]bool)
+	testFilter = make(SirenFilter)
 	err = readFilter(strings.NewReader("0123456789\n876543210"), testFilter)
 	if err == nil {
 		t.Fatalf("readFilter should fail on incorrect siren")

--- a/dbmongo/lib/marshal/filter_test.go
+++ b/dbmongo/lib/marshal/filter_test.go
@@ -30,7 +30,7 @@ func TestIsFiltered(t *testing.T) {
 	}
 
 	for ind, tc := range testCases {
-		actual, err := IsFiltered(tc.siret, tc.filter)
+		actual, err := tc.filter.IsFiltered(tc.siret)
 		if err != nil && !tc.expectError {
 			t.Fatalf("Unexpected error during cache request in test %d: %v", ind, err)
 		}

--- a/dbmongo/lib/marshal/filter_test.go
+++ b/dbmongo/lib/marshal/filter_test.go
@@ -19,6 +19,7 @@ func TestIsFiltered(t *testing.T) {
 		expectError bool
 		expected    bool
 	}{
+		{"012345678", SirenFilter{"01234567891011": true}, true, false}, // siren non valide trouvé dans le fichier
 		{"012345678", SirenFilter{"012345678": true}, false, false},
 		{"01234567891011", SirenFilter{"012345678": true}, false, false},
 		{"0123", SirenFilter{"012345678": true}, true, true},

--- a/dbmongo/lib/marshal/mapping.go
+++ b/dbmongo/lib/marshal/mapping.go
@@ -64,9 +64,8 @@ func GetCompteSiretMapping(cache Cache, batch *base.AdminBatch, mr mappingReader
 		comptes, ok := value.(Comptes)
 		if ok {
 			return comptes, nil
-		} else {
-			return nil, errors.New("Wrong format from existing field comptes in cache")
 		}
+		return nil, errors.New("Wrong format from existing field comptes in cache")
 	}
 
 	fmt.Println("Chargement des comptes urssaf")
@@ -167,7 +166,7 @@ func readSiretMapping(
 			return nil, err
 		}
 
-		filtered, err := IsFiltered(siret, filter)
+		filtered, err := filter.IsFiltered(siret)
 		if err != nil {
 			return nil, err
 		}

--- a/dbmongo/lib/marshal/mapping_test.go
+++ b/dbmongo/lib/marshal/mapping_test.go
@@ -77,7 +77,7 @@ func TestReadSiretMapping(t *testing.T) {
 	}
 
 	stdFilterCache := Cache{
-		"filter": map[string]bool{"012345678": true},
+		"filter": SirenFilter{"012345678": true},
 	}
 
 	testCases := []struct {

--- a/dbmongo/lib/reporder/reporder.go
+++ b/dbmongo/lib/reporder/reporder.go
@@ -63,7 +63,7 @@ func parseReporderFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *
 			tracker.Add(err)
 		} else {
 			reporder := parseReporderLine(row, tracker)
-			filtered, err := marshal.IsFiltered(reporder.Siret[0:9], filter)
+			filtered, err := filter.IsFiltered(reporder.Siret[0:9]) // TODO: remove [0:9]
 			tracker.Add(err)
 			if !tracker.HasErrorInCurrentCycle() && !filtered {
 				outputChannel <- reporder

--- a/dbmongo/lib/reporder/reporder.go
+++ b/dbmongo/lib/reporder/reporder.go
@@ -54,7 +54,7 @@ func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch, tr
 	parseReporderFile(reader, filter, tracker, outputChannel)
 }
 
-func parseReporderFile(reader *csv.Reader, filter map[string]bool, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
+func parseReporderFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
 	for {
 		row, err := reader.Read()
 		if err == io.EOF {

--- a/dbmongo/lib/reporder/reporder.go
+++ b/dbmongo/lib/reporder/reporder.go
@@ -63,7 +63,7 @@ func parseReporderFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *
 			tracker.Add(err)
 		} else {
 			reporder := parseReporderLine(row, tracker)
-			filtered, err := filter.IsFiltered(reporder.Siret[0:9]) // TODO: remove [0:9]
+			filtered, err := filter.IsFiltered(reporder.Siret)
 			tracker.Add(err)
 			if !tracker.HasErrorInCurrentCycle() && !filtered {
 				outputChannel <- reporder

--- a/dbmongo/lib/sirene/main.go
+++ b/dbmongo/lib/sirene/main.go
@@ -204,7 +204,7 @@ func parseSireneFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *go
 			if !validSiren {
 				tracker.Add(errors.New("siren invalide : " + row[f["siren"]]))
 			} else {
-				filtered, err := marshal.IsFiltered(row[f["siren"]], filter)
+				filtered, err := filter.IsFiltered(row[f["siren"]])
 				tracker.Add(err)
 				if !filtered {
 					outputChannel <- parseSireneLine(row, tracker)

--- a/dbmongo/lib/sirene/main.go
+++ b/dbmongo/lib/sirene/main.go
@@ -192,7 +192,7 @@ func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch, tr
 	parseSireneFile(reader, filter, tracker, outputChannel)
 }
 
-func parseSireneFile(reader *csv.Reader, filter map[string]bool, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
+func parseSireneFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
 	for {
 		row, err := reader.Read()
 		if err == io.EOF {

--- a/dbmongo/lib/sirene_ul/main.go
+++ b/dbmongo/lib/sirene_ul/main.go
@@ -83,7 +83,7 @@ func parseSireneULFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *
 			if !validSiren {
 				tracker.Add(errors.New("siren invalide : " + row[0]))
 			} else {
-				filtered, err := marshal.IsFiltered(row[0], filter)
+				filtered, err := filter.IsFiltered(row[0])
 				tracker.Add(err)
 				if !filtered {
 					outputChannel <- parseSireneUlLine(row, tracker)

--- a/dbmongo/lib/sirene_ul/main.go
+++ b/dbmongo/lib/sirene_ul/main.go
@@ -63,7 +63,7 @@ func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch, tr
 	parseSireneULFile(reader, filter, tracker, outputChannel)
 }
 
-func parseSireneULFile(reader *csv.Reader, filter map[string]bool, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
+func parseSireneULFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
 	_, err := reader.Read()
 	if err == io.EOF {
 		return

--- a/dbmongo/lib/urssaf/effectif.go
+++ b/dbmongo/lib/urssaf/effectif.go
@@ -103,7 +103,7 @@ func parseEffectifLine(periods []periodCol, row []string, idx colMapping, filter
 	validSiret := sfregexp.RegexpDict["siret"].MatchString(siret)
 	if !validSiret {
 		tracker.Add(base.NewRegularError(errors.New("Le siret/siren est invalide")))
-	} else if filter != nil || !filter.Includes(siret) {
+	} else if filter == nil || filter.Includes(siret) {
 		for _, period := range periods {
 			value := row[period.colIndex]
 			if value != "" {

--- a/dbmongo/lib/urssaf/effectif.go
+++ b/dbmongo/lib/urssaf/effectif.go
@@ -103,7 +103,7 @@ func parseEffectifLine(periods []periodCol, row []string, idx colMapping, filter
 	validSiret := sfregexp.RegexpDict["siret"].MatchString(siret)
 	if !validSiret {
 		tracker.Add(base.NewRegularError(errors.New("Le siret/siren est invalide")))
-	} else if filter != nil || !filter.FilterHas(siret) {
+	} else if filter != nil || !filter.Includes(siret) {
 		for _, period := range periods {
 			value := row[period.colIndex]
 			if value != "" {

--- a/dbmongo/lib/urssaf/effectif.go
+++ b/dbmongo/lib/urssaf/effectif.go
@@ -103,7 +103,7 @@ func parseEffectifLine(periods []periodCol, row []string, idx colMapping, filter
 	validSiret := sfregexp.RegexpDict["siret"].MatchString(siret)
 	if !validSiret {
 		tracker.Add(base.NewRegularError(errors.New("Le siret/siren est invalide")))
-	} else if filter != nil || !marshal.FilterHas(siret, filter) {
+	} else if filter != nil || !filter.FilterHas(siret) {
 		for _, period := range periods {
 			value := row[period.colIndex]
 			if value != "" {

--- a/dbmongo/lib/urssaf/effectif.go
+++ b/dbmongo/lib/urssaf/effectif.go
@@ -58,7 +58,7 @@ func ParseEffectifFile(filePath string, cache *marshal.Cache, batch *base.AdminB
 	parseEffectifFile(reader, filter, tracker, outputChannel)
 }
 
-func parseEffectifFile(reader *csv.Reader, filter map[string]bool, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
+func parseEffectifFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
 	fields, err := reader.Read()
 	if err != nil {
 		tracker.Add(err)
@@ -97,7 +97,7 @@ func parseEffectifFile(reader *csv.Reader, filter map[string]bool, tracker *gour
 	}
 }
 
-func parseEffectifLine(periods []periodCol, row []string, idx colMapping, filter map[string]bool, tracker *gournal.Tracker) []Effectif {
+func parseEffectifLine(periods []periodCol, row []string, idx colMapping, filter marshal.SirenFilter, tracker *gournal.Tracker) []Effectif {
 	var effectifs = []Effectif{}
 	siret := row[idx["siret"]]
 	validSiret := sfregexp.RegexpDict["siret"].MatchString(siret)

--- a/dbmongo/lib/urssaf/effectif_ent.go
+++ b/dbmongo/lib/urssaf/effectif_ent.go
@@ -109,7 +109,7 @@ func parseEffectifEntFile(reader *csv.Reader, filter marshal.SirenFilter, tracke
 func parseEffectifEntLine(periods []periodCol, row []string, idx colMapping, filter marshal.SirenFilter, tracker *gournal.Tracker) []EffectifEnt {
 	var effectifs = []EffectifEnt{}
 	siren := row[idx["siren"]]
-	filtered, err := marshal.IsFiltered(siren, filter)
+	filtered, err := filter.IsFiltered(siren)
 	tracker.Add(err)
 	if len(siren) != 9 {
 		tracker.Add(errors.New("Format de siren incorrect : " + siren))

--- a/dbmongo/lib/urssaf/effectif_ent.go
+++ b/dbmongo/lib/urssaf/effectif_ent.go
@@ -76,7 +76,7 @@ func ParseEffectifEntFile(filePath string, cache *marshal.Cache, batch *base.Adm
 	parseEffectifEntFile(reader, filter, tracker, outputChannel)
 }
 
-func parseEffectifEntFile(reader *csv.Reader, filter map[string]bool, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
+func parseEffectifEntFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *gournal.Tracker, outputChannel chan marshal.Tuple) {
 	fields, err := reader.Read()
 	if err != nil {
 		tracker.Add(err)
@@ -106,7 +106,7 @@ func parseEffectifEntFile(reader *csv.Reader, filter map[string]bool, tracker *g
 	}
 }
 
-func parseEffectifEntLine(periods []periodCol, row []string, idx colMapping, filter map[string]bool, tracker *gournal.Tracker) []EffectifEnt {
+func parseEffectifEntLine(periods []periodCol, row []string, idx colMapping, filter marshal.SirenFilter, tracker *gournal.Tracker) []EffectifEnt {
 	var effectifs = []EffectifEnt{}
 	siren := row[idx["siren"]]
 	filtered, err := marshal.IsFiltered(siren, filter)

--- a/dbmongo/lib/urssaf/urssaf_test.go
+++ b/dbmongo/lib/urssaf/urssaf_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/marshal"
+	"github.com/stretchr/testify/assert"
 )
 
 var update = flag.Bool("update", false, "Update the expected test values in golden file")
@@ -62,9 +63,16 @@ func TestProcol(t *testing.T) {
 
 func TestEffectif(t *testing.T) {
 	var golden = filepath.Join("testData", "expectedEffectif.json")
-	var testData = filepath.Join("testData", "effectifTestData.csv")
+	var testData = filepath.Join("testData", "effectifTestData.csv") // Données pour 3 établissements
 	cache := marshal.NewCache()
 	marshal.TestParserOutput(t, ParserEffectif, cache, testData, golden, *update)
+
+	t.Run("Effectif n'est importé que si inclus dans le filtre", func(t *testing.T) {
+		cache := marshal.NewCache()
+		cache.Set("filter", marshal.SirenFilter{"149285238": true}) // SIREN correspondant à un des 3 SIRETs mentionnés dans le fichier
+		output := marshal.RunParser(ParserEffectif, cache, testData)
+		assert.Equal(t, 111, len(output.Tuples))
+	})
 }
 
 func TestEffectifEnt(t *testing.T) {


### PR DESCRIPTION
## Changements apportés

Afin de faciliter l'utilisation et l'amélioration du Filtre d'entreprises dans les parseurs:

- encapsulation de la `map` dans un type dédié `SirenFilter`
- association des fonctions `IsFiltered()` et `Includes()` (anciennement `FilterHas()`) comme méthodes de ce type
- clarification de la documentation de ces méthodes
- correction d'un bug rencontré pendant le refactoring: le filtre ne s'appliquait pas aux données `Effectif` 😓 
- => ajout d'un test de non régression: "Effectif n'est importé que si inclus dans le filtre"

## Prochaines étapes envisagées

- ne plus valider le SIRET/SIREN au moment à chaque interrogation du filtre => laisser cette responsabilité à l'appelant => supprimer `IsFiltered()`, au profit de `Includes()`
- optimiser l'interrogation du filtre