### PR TITLE
fix(filter): Retrait de IsFiltered() => validation siret/siren déléguée à l'appelant

### DIFF
--- a/dbmongo/lib/bdf/main.go
+++ b/dbmongo/lib/bdf/main.go
@@ -83,19 +83,17 @@ func parseBdfLine(row []string, tracker *gournal.Tracker, filter marshal.SirenFi
 	bdf := BDF{}
 	bdf.Siren = strings.Replace(row[field["siren"]], " ", "", -1)
 
-	validSiren := sfregexp.RegexpDict["siren"].MatchString(bdf.Siren)
-	if !validSiren {
+	if !sfregexp.ValidSiren(bdf.Siren) {
 		tracker.Add(errors.New("siren invalide : " + bdf.Siren))
 		return BDF{}
 	}
 
-	filtered, err := filter.IsFiltered(bdf.Siren)
-	tracker.Add(err)
-	if filtered {
+	if filter != nil && !filter.Includes(bdf.Siren) {
 		tracker.Add(base.NewFilterNotice())
 		return BDF{}
 	}
 
+	var err error
 	bdf.Annee, err = misc.ParsePInt(row[field["année"]])
 	tracker.Add(err)
 	var arrete = row[field["arrêtéBilan"]]

--- a/dbmongo/lib/bdf/main.go
+++ b/dbmongo/lib/bdf/main.go
@@ -88,7 +88,7 @@ func parseBdfLine(row []string, tracker *gournal.Tracker, filter marshal.SirenFi
 		return BDF{}
 	}
 
-	if filter != nil && !filter.Includes(bdf.Siren) {
+	if filter.Skips(bdf.Siren) {
 		tracker.Add(base.NewFilterNotice())
 		return BDF{}
 	}

--- a/dbmongo/lib/ellisphere/main.go
+++ b/dbmongo/lib/ellisphere/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/base"
 	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/marshal"
+	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/sfregexp"
 	"github.com/tealeg/xlsx/v3"
 
 	"github.com/signaux-faibles/gournal"
@@ -64,12 +65,10 @@ func parseEllisphereSheet(sheet *xlsx.Sheet, filter marshal.SirenFilter, tracker
 			var ellisphere Ellisphere
 			err := row.ReadStruct(&ellisphere)
 
-			filtered, errFilter := filter.IsFiltered(ellisphere.Siren)
-			if errFilter != nil {
-				tracker.Add(errFilter)
+			if !sfregexp.ValidSiren(ellisphere.Siren) {
+				tracker.Add(errors.New("siren invalide : " + ellisphere.Siren))
 			}
-
-			if err == nil && !filtered {
+			if err == nil && (filter == nil || filter.Includes(ellisphere.Siren)) {
 				outputChannel <- ellisphere
 			}
 			tracker.Add(err)

--- a/dbmongo/lib/ellisphere/main.go
+++ b/dbmongo/lib/ellisphere/main.go
@@ -68,7 +68,7 @@ func parseEllisphereSheet(sheet *xlsx.Sheet, filter marshal.SirenFilter, tracker
 			if !sfregexp.ValidSiren(ellisphere.Siren) {
 				tracker.Add(errors.New("siren invalide : " + ellisphere.Siren))
 			}
-			if err == nil && (filter == nil || filter.Includes(ellisphere.Siren)) {
+			if err == nil && !filter.Skips(ellisphere.Siren) {
 				outputChannel <- ellisphere
 			}
 			tracker.Add(err)

--- a/dbmongo/lib/ellisphere/testData/expectedEllisphere.json
+++ b/dbmongo/lib/ellisphere/testData/expectedEllisphere.json
@@ -92,7 +92,7 @@
         "filtered": 0,
         "headErrors": [],
         "headFatal": [
-          "Cycle 0: Le siret/siren est invalide",
+          "Cycle 0: siren invalide : FIL SIREN 9",
           "Cycle 0: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
         ],
         "headFilters": [],

--- a/dbmongo/lib/marshal/filter.go
+++ b/dbmongo/lib/marshal/filter.go
@@ -19,8 +19,8 @@ type SirenFilter map[string]bool
 
 // Skips retourne `false` si le numéro SIREN/SIRET peut être traité,
 // car il est inclus dans le Filtre, ou car il n'y a pas de filtre.
-func (filter *SirenFilter) Skips(siretOrSiren string) bool {
-	return *filter != nil && !filter.Includes(siretOrSiren)
+func (filter SirenFilter) Skips(siretOrSiren string) bool {
+	return filter != nil && !filter.Includes(siretOrSiren)
 }
 
 // Includes retourne `true` si le numéro SIREN/SIRET est inclus, c.a.d. à traiter.

--- a/dbmongo/lib/marshal/filter.go
+++ b/dbmongo/lib/marshal/filter.go
@@ -20,11 +20,11 @@ type SirenFilter map[string]bool
 // Skips retourne `false` si le numéro SIREN/SIRET peut être traité,
 // car il est inclus dans le Filtre, ou car il n'y a pas de filtre.
 func (filter SirenFilter) Skips(siretOrSiren string) bool {
-	return filter != nil && !filter.Includes(siretOrSiren)
+	return filter != nil && !filter.includes(siretOrSiren)
 }
 
-// Includes retourne `true` si le numéro SIREN/SIRET est inclus, c.a.d. à traiter.
-func (filter SirenFilter) Includes(siretOrSiren string) bool {
+// includes retourne `true` si le numéro SIREN/SIRET est inclus, c.a.d. à traiter.
+func (filter SirenFilter) includes(siretOrSiren string) bool {
 	if len(siretOrSiren) >= 9 {
 		return filter[siretOrSiren[0:9]]
 	}

--- a/dbmongo/lib/marshal/filter.go
+++ b/dbmongo/lib/marshal/filter.go
@@ -17,22 +17,6 @@ import (
 // SirenFilter liste les numéros SIREN d'entreprise et établissements à exclure des traitements.
 type SirenFilter map[string]bool
 
-// IsFiltered valide le numéro SIREN/SIRET puis retourne `true` si il est à exclure.
-func (filter SirenFilter) IsFiltered(id string) (bool, error) {
-
-	validSiret := sfregexp.RegexpDict["siret"].MatchString(id)
-	validSiren := sfregexp.RegexpDict["siren"].MatchString(id)
-	if !validSiret && !validSiren {
-		return true, errors.New("Le siret/siren est invalide") // TODO: retirer la validation de cette fonction
-	}
-
-	// if no filter, then all ids pass
-	if filter == nil {
-		return false, nil
-	}
-	return !filter.Includes(id), nil
-}
-
 // Includes retourne `true` si le numéro SIREN/SIRET est inclus, c.a.d. à traiter.
 func (filter SirenFilter) Includes(siretOrSiren string) bool {
 	if len(siretOrSiren) >= 9 {

--- a/dbmongo/lib/marshal/filter.go
+++ b/dbmongo/lib/marshal/filter.go
@@ -17,6 +17,12 @@ import (
 // SirenFilter liste les numéros SIREN d'entreprise et établissements à exclure des traitements.
 type SirenFilter map[string]bool
 
+// Skips retourne `false` si le numéro SIREN/SIRET peut être traité,
+// car il est inclus dans le Filtre, ou car il n'y a pas de filtre.
+func (filter *SirenFilter) Skips(siretOrSiren string) bool {
+	return *filter != nil && !filter.Includes(siretOrSiren)
+}
+
 // Includes retourne `true` si le numéro SIREN/SIRET est inclus, c.a.d. à traiter.
 func (filter SirenFilter) Includes(siretOrSiren string) bool {
 	if len(siretOrSiren) >= 9 {

--- a/dbmongo/lib/marshal/filter_test.go
+++ b/dbmongo/lib/marshal/filter_test.go
@@ -30,7 +30,7 @@ func TestIncludes(t *testing.T) {
 	}
 
 	for ind, tc := range testCases {
-		included := tc.filter.Includes(tc.siret)
+		included := tc.filter.includes(tc.siret)
 		expected := tc.expected
 		if included != expected {
 			t.Fatalf("Includes failed on test %d", ind)
@@ -109,14 +109,14 @@ func TestReadFilter(t *testing.T) {
 func TestNilFilter(t *testing.T) {
 	filter := GetSirenFilterFromCache(Cache{}) // => nil
 	assert.Equal(t, true, filter == nil)
-	assert.Equal(t, false, filter.Includes("012345678"))
+	assert.Equal(t, false, filter.includes("012345678"))
 	assert.Equal(t, false, filter.Skips("012345678"))
 	assert.Equal(t, false, filter.Skips("912345678"))
 	cache := Cache{}
 	cache.Set("filter", SirenFilter{"012345678": true})
 	filter = GetSirenFilterFromCache(cache) // => not nil
 	assert.Equal(t, false, filter == nil)
-	assert.Equal(t, true, filter.Includes("012345678"))
+	assert.Equal(t, true, filter.includes("012345678"))
 	assert.Equal(t, false, filter.Skips("012345678"))
 	assert.Equal(t, true, filter.Skips("912345678"))
 }

--- a/dbmongo/lib/marshal/filter_test.go
+++ b/dbmongo/lib/marshal/filter_test.go
@@ -11,35 +11,28 @@ import (
 
 var update = flag.Bool("update", false, "Update the expected test values in golden file") // please keep this line until https://github.com/kubernetes-sigs/service-catalog/issues/2319#issuecomment-425200065 is fixed
 
-func TestIsFiltered(t *testing.T) {
+func TestIncludes(t *testing.T) {
 
 	testCases := []struct {
-		siret       string
-		filter      SirenFilter
-		expectError bool
-		expected    bool
+		siret    string
+		filter   SirenFilter
+		expected bool
 	}{
-		{"012345678", SirenFilter{"012345678": true}, false, false},
-		{"01234567891011", SirenFilter{"012345678": true}, false, false},
-		{"0123", SirenFilter{"012345678": true}, true, true},
-		{"0123456789", SirenFilter{"012345678": true}, true, true},
-		{"876543210", SirenFilter{"012345678": true}, false, true},
-		{"87654321091011", SirenFilter{"012345678": true}, false, true},
-		{"012345678", nil, false, false},
-		{"0123", nil, true, true},
+		{"012345678", SirenFilter{"012345678": true}, true},       // siren inclus dans filtre
+		{"01234567891011", SirenFilter{"012345678": true}, true},  // siret inclus dans filtre
+		{"0123", SirenFilter{"012345678": true}, false},           // siren trop court
+		{"0123456789", SirenFilter{"012345678": true}, true},      // numéro invalide mais ayant comme prefixe un siret filtré
+		{"876543210", SirenFilter{"012345678": true}, false},      // siren non inclus dans filtre
+		{"87654321091011", SirenFilter{"012345678": true}, false}, // siret non inclus dans filtre
+		{"012345678", nil, false},                                 // pas de filtre
+		{"0123", nil, false},                                      // pas de filtre + numéro invalide
 	}
 
 	for ind, tc := range testCases {
-		actual, err := tc.filter.IsFiltered(tc.siret)
-		if err != nil && !tc.expectError {
-			t.Fatalf("Unexpected error during cache request in test %d: %v", ind, err)
-		}
-		if err == nil && tc.expectError {
-			t.Fatalf("Expected error missing during cache request in test %d: %v", ind, err)
-		}
+		included := tc.filter.Includes(tc.siret)
 		expected := tc.expected
-		if actual != expected {
-			t.Fatalf("IsFiltered failed on test %d", ind)
+		if included != expected {
+			t.Fatalf("Includes failed on test %d", ind)
 		}
 	}
 }

--- a/dbmongo/lib/marshal/filter_test.go
+++ b/dbmongo/lib/marshal/filter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/base"
+	"github.com/stretchr/testify/assert"
 )
 
 var update = flag.Bool("update", false, "Update the expected test values in golden file") // please keep this line until https://github.com/kubernetes-sigs/service-catalog/issues/2319#issuecomment-425200065 is fixed
@@ -103,4 +104,19 @@ func TestReadFilter(t *testing.T) {
 	if err == nil {
 		t.Fatalf("readFilter should fail on incorrect siren")
 	}
+}
+
+func TestNilFilter(t *testing.T) {
+	filter := GetSirenFilterFromCache(Cache{}) // => nil
+	assert.Equal(t, true, filter == nil)
+	assert.Equal(t, false, filter.Includes("012345678"))
+	assert.Equal(t, false, filter.Skips("012345678"))
+	assert.Equal(t, false, filter.Skips("912345678"))
+	cache := Cache{}
+	cache.Set("filter", SirenFilter{"012345678": true})
+	filter = GetSirenFilterFromCache(cache) // => not nil
+	assert.Equal(t, false, filter == nil)
+	assert.Equal(t, true, filter.Includes("012345678"))
+	assert.Equal(t, false, filter.Skips("012345678"))
+	assert.Equal(t, true, filter.Skips("912345678"))
 }

--- a/dbmongo/lib/marshal/mapping.go
+++ b/dbmongo/lib/marshal/mapping.go
@@ -162,7 +162,7 @@ func readSiretMapping(
 		compte := row[compteIndex]
 		siret := row[siretIndex]
 
-		if sfregexp.ValidSiret(siret) && (filter == nil || filter.Includes(siret)) {
+		if sfregexp.ValidSiret(siret) && !filter.Skips(siret) {
 			//siret valide
 			addSiretMapping[compte] = append(addSiretMapping[compte], SiretDate{siret, fermeture})
 			// Tri des sirets pour chaque compte par ordre croissant de date de fermeture

--- a/dbmongo/lib/marshal/mapping.go
+++ b/dbmongo/lib/marshal/mapping.go
@@ -122,6 +122,11 @@ func readSiretMapping(
 	batch *base.AdminBatch,
 ) (Comptes, error) {
 
+	filter, err := GetSirenFilter(cache, batch)
+	if err != nil {
+		return nil, err
+	}
+
 	var addSiretMapping = make(map[string][]SiretDate)
 
 	csvReader := csv.NewReader(reader)
@@ -157,21 +162,7 @@ func readSiretMapping(
 		compte := row[compteIndex]
 		siret := row[siretIndex]
 
-		if !sfregexp.RegexpDict["siret"].MatchString(siret) {
-			continue
-		}
-
-		filter, err := GetSirenFilter(cache, batch)
-		if err != nil {
-			return nil, err
-		}
-
-		filtered, err := filter.IsFiltered(siret)
-		if err != nil {
-			return nil, err
-		}
-
-		if sfregexp.RegexpDict["siret"].MatchString(siret) && !filtered {
+		if sfregexp.ValidSiret(siret) && (filter == nil || filter.Includes(siret)) {
 			//siret valide
 			addSiretMapping[compte] = append(addSiretMapping[compte], SiretDate{siret, fermeture})
 			// Tri des sirets pour chaque compte par ordre croissant de date de fermeture

--- a/dbmongo/lib/reporder/reporder.go
+++ b/dbmongo/lib/reporder/reporder.go
@@ -68,7 +68,7 @@ func parseReporderFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *
 			if !sfregexp.ValidSiret(reporder.Siret) {
 				tracker.Add(errors.New("siret invalide : " + reporder.Siret))
 			}
-			if !tracker.HasErrorInCurrentCycle() && (filter == nil || filter.Includes(reporder.Siret)) {
+			if !tracker.HasErrorInCurrentCycle() && !filter.Skips(reporder.Siret) {
 				outputChannel <- reporder
 			}
 		}

--- a/dbmongo/lib/sfregexp/regexp.go
+++ b/dbmongo/lib/sfregexp/regexp.go
@@ -9,3 +9,13 @@ var RegexpDict = map[string]*regexp.Regexp{
 	"notDigit": regexp.MustCompile("[^0-9]"),
 	"nil":      regexp.MustCompile(".*"),
 }
+
+// ValidSiret retourne `true` si le numéro SIRET est valide.
+func ValidSiret(siret string) bool {
+	return RegexpDict["siret"].MatchString(siret)
+}
+
+// ValidSiren retourne `true` si le numéro SIREN est valide.
+func ValidSiren(siren string) bool {
+	return RegexpDict["siren"].MatchString(siren)
+}

--- a/dbmongo/lib/sfregexp/regexp.go
+++ b/dbmongo/lib/sfregexp/regexp.go
@@ -1,13 +1,14 @@
 package sfregexp
 
-import "regexp"
+import (
+	"regexp"
+)
 
 // RegexpDict fournit des expressions régulières communes.
 var RegexpDict = map[string]*regexp.Regexp{
 	"siret":    regexp.MustCompile("^[0-9]{14}$"),
 	"siren":    regexp.MustCompile("^[0-9]{9}$"),
 	"notDigit": regexp.MustCompile("[^0-9]"),
-	"nil":      regexp.MustCompile(".*"),
 }
 
 // ValidSiret retourne `true` si le numéro SIRET est valide.

--- a/dbmongo/lib/sirene/main.go
+++ b/dbmongo/lib/sirene/main.go
@@ -201,7 +201,7 @@ func parseSireneFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *go
 			tracker.Add(err)
 		} else if !sfregexp.ValidSiren(row[f["siren"]]) {
 			tracker.Add(errors.New("siren invalide : " + row[f["siren"]]))
-		} else if filter == nil || filter.Includes(row[f["siren"]]) {
+		} else if !filter.Skips(row[f["siren"]]) {
 			outputChannel <- parseSireneLine(row, tracker)
 		}
 		tracker.Next()

--- a/dbmongo/lib/sirene/main.go
+++ b/dbmongo/lib/sirene/main.go
@@ -199,17 +199,10 @@ func parseSireneFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *go
 			break
 		} else if err != nil {
 			tracker.Add(err)
-		} else {
-			validSiren := sfregexp.RegexpDict["siren"].MatchString(row[f["siren"]])
-			if !validSiren {
-				tracker.Add(errors.New("siren invalide : " + row[f["siren"]]))
-			} else {
-				filtered, err := filter.IsFiltered(row[f["siren"]])
-				tracker.Add(err)
-				if !filtered {
-					outputChannel <- parseSireneLine(row, tracker)
-				}
-			}
+		} else if !sfregexp.ValidSiren(row[f["siren"]]) {
+			tracker.Add(errors.New("siren invalide : " + row[f["siren"]]))
+		} else if filter == nil || filter.Includes(row[f["siren"]]) {
+			outputChannel <- parseSireneLine(row, tracker)
 		}
 		tracker.Next()
 	}

--- a/dbmongo/lib/sirene_ul/main.go
+++ b/dbmongo/lib/sirene_ul/main.go
@@ -78,17 +78,10 @@ func parseSireneULFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *
 			break
 		} else if err != nil {
 			tracker.Add(err)
-		} else {
-			validSiren := sfregexp.RegexpDict["siren"].MatchString(row[0])
-			if !validSiren {
-				tracker.Add(errors.New("siren invalide : " + row[0]))
-			} else {
-				filtered, err := filter.IsFiltered(row[0])
-				tracker.Add(err)
-				if !filtered {
-					outputChannel <- parseSireneUlLine(row, tracker)
-				}
-			}
+		} else if !sfregexp.ValidSiren(row[0]) {
+			tracker.Add(errors.New("siren invalide : " + row[0]))
+		} else if filter == nil || filter.Includes(row[0]) {
+			outputChannel <- parseSireneUlLine(row, tracker)
 		}
 		tracker.Next()
 	}

--- a/dbmongo/lib/sirene_ul/main.go
+++ b/dbmongo/lib/sirene_ul/main.go
@@ -80,7 +80,7 @@ func parseSireneULFile(reader *csv.Reader, filter marshal.SirenFilter, tracker *
 			tracker.Add(err)
 		} else if !sfregexp.ValidSiren(row[0]) {
 			tracker.Add(errors.New("siren invalide : " + row[0]))
-		} else if filter == nil || filter.Includes(row[0]) {
+		} else if !filter.Skips(row[0]) {
 			outputChannel <- parseSireneUlLine(row, tracker)
 		}
 		tracker.Next()

--- a/dbmongo/lib/urssaf/effectif.go
+++ b/dbmongo/lib/urssaf/effectif.go
@@ -103,7 +103,7 @@ func parseEffectifLine(periods []periodCol, row []string, idx colMapping, filter
 	validSiret := sfregexp.RegexpDict["siret"].MatchString(siret)
 	if !validSiret {
 		tracker.Add(base.NewRegularError(errors.New("Le siret/siren est invalide")))
-	} else if filter == nil || filter.Includes(siret) {
+	} else if !filter.Skips(siret) {
 		for _, period := range periods {
 			value := row[period.colIndex]
 			if value != "" {

--- a/dbmongo/lib/urssaf/effectif_ent.go
+++ b/dbmongo/lib/urssaf/effectif_ent.go
@@ -109,11 +109,9 @@ func parseEffectifEntFile(reader *csv.Reader, filter marshal.SirenFilter, tracke
 func parseEffectifEntLine(periods []periodCol, row []string, idx colMapping, filter marshal.SirenFilter, tracker *gournal.Tracker) []EffectifEnt {
 	var effectifs = []EffectifEnt{}
 	siren := row[idx["siren"]]
-	filtered, err := filter.IsFiltered(siren)
-	tracker.Add(err)
-	if len(siren) != 9 {
+	if !sfregexp.ValidSiren(siren) {
 		tracker.Add(errors.New("Format de siren incorrect : " + siren))
-	} else if !filtered {
+	} else if filter == nil || filter.Includes(siren) {
 		for _, period := range periods {
 			value := row[period.colIndex]
 			if value != "" {

--- a/dbmongo/lib/urssaf/effectif_ent.go
+++ b/dbmongo/lib/urssaf/effectif_ent.go
@@ -111,7 +111,7 @@ func parseEffectifEntLine(periods []periodCol, row []string, idx colMapping, fil
 	siren := row[idx["siren"]]
 	if !sfregexp.ValidSiren(siren) {
 		tracker.Add(errors.New("Format de siren incorrect : " + siren))
-	} else if filter == nil || filter.Includes(siren) {
+	} else if !filter.Skips(siren) {
 		for _, period := range periods {
 			value := row[period.colIndex]
 			if value != "" {

--- a/tests/output-snapshots/test-api-import.golden.txt
+++ b/tests/output-snapshots/test-api-import.golden.txt
@@ -5168,7 +5168,7 @@
 			"headFilters" : [ ],
 			"headErrors" : [ ],
 			"headFatal" : [
-				"Cycle 0: Le siret/siren est invalide",
+				"Cycle 0: siren invalide : FIL SIREN 9",
 				"Cycle 0: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
 			],
 			"report" : "/../lib/ellisphere/testData/ellisphereTestData.excel: intégration terminée, 7 lignes traitées, 2 erreures fatales, 0 rejets, 0 lignes filtrées, 5 lignes valides",


### PR DESCRIPTION
Suite de #222.

Next:
- Appliquer `SirenFilter` sur les tuples retournés par tous les parseurs, à un seul endroit.