### PR TITLE
fix(parseurs): Chaque parseur implémente l'interface Parser

### DIFF
--- a/dbmongo/lib/apconso/main.go
+++ b/dbmongo/lib/apconso/main.go
@@ -41,37 +41,37 @@ func (apconso APConso) Scope() string {
 var Parser = marshal.Parser{FileType: "apconso", FileParser: ParseFile}
 
 type apconsoReader struct {
-	reader   *csv.Reader
-	idx      colMapping
-	closeFct func() error
+	file   *os.File
+	reader *csv.Reader
+	idx    colMapping
 }
 
 func (parser apconsoReader) Close() error {
-	return parser.closeFct()
+	return parser.file.Close()
 }
 
 // ParseFile permet de lancer le parsing du fichier demandé.
 func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (marshal.FileReader, error) {
 	var idx colMapping
-	closeFct, reader, err := openFile(filePath)
+	file, reader, err := openFile(filePath)
 	if err == nil {
 		idx, err = parseColMapping(reader)
 	}
 	return apconsoReader{
-		closeFct: closeFct,
-		reader:   reader,
-		idx:      idx,
+		file:   file,
+		reader: reader,
+		idx:    idx,
 	}, err
 }
 
-func openFile(filePath string) (func() error, *csv.Reader, error) {
+func openFile(filePath string) (*os.File, *csv.Reader, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return file.Close, nil, err
+		return file, nil, err
 	}
 	reader := csv.NewReader(file)
 	reader.Comma = ','
-	return file.Close, reader, nil
+	return file, reader, nil
 }
 
 type colMapping map[string]int

--- a/dbmongo/lib/apconso/main.go
+++ b/dbmongo/lib/apconso/main.go
@@ -40,16 +40,6 @@ func (apconso APConso) Scope() string {
 // Parser expose le parseur et le type de fichier qu'il supporte.
 var Parser = marshal.Parser{FileType: "apconso", FileParser: ParseFile}
 
-type apconsoReader struct {
-	file   *os.File
-	reader *csv.Reader
-	idx    colMapping
-}
-
-func (parser apconsoReader) Close() error {
-	return parser.file.Close()
-}
-
 // ParseFile permet de lancer le parsing du fichier demandé.
 func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (marshal.FileReader, error) {
 	var idx colMapping
@@ -62,6 +52,16 @@ func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (m
 		reader: reader,
 		idx:    idx,
 	}, err
+}
+
+type apconsoReader struct {
+	file   *os.File
+	reader *csv.Reader
+	idx    colMapping
+}
+
+func (parser apconsoReader) Close() error {
+	return parser.file.Close()
 }
 
 func openFile(filePath string) (*os.File, *csv.Reader, error) {

--- a/dbmongo/lib/apconso/main.go
+++ b/dbmongo/lib/apconso/main.go
@@ -50,7 +50,9 @@ func (parser *apconsoParser) GetFileType() string {
 	return "apconso"
 }
 
-func (parser *apconsoParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
+func (parser *apconsoParser) Init(cache *marshal.Cache, batch *base.AdminBatch) error {
+	return nil
+}
 
 func (parser *apconsoParser) Open(filePath string) (err error) {
 	parser.file, parser.reader, err = openFile(filePath)

--- a/dbmongo/lib/apconso/main.go
+++ b/dbmongo/lib/apconso/main.go
@@ -46,7 +46,7 @@ type apconsoParser struct {
 	idx    colMapping
 }
 
-func (parser apconsoParser) GetFileType() string {
+func (parser *apconsoParser) GetFileType() string {
 	return "apconso"
 }
 

--- a/dbmongo/lib/apdemande/main.go
+++ b/dbmongo/lib/apdemande/main.go
@@ -60,7 +60,9 @@ func (parser *apdemandeParser) GetFileType() string {
 	return "apdemande"
 }
 
-func (parser *apdemandeParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
+func (parser *apdemandeParser) Init(cache *marshal.Cache, batch *base.AdminBatch) error {
+	return nil
+}
 
 func (parser *apdemandeParser) Open(filePath string) (err error) {
 	parser.file, parser.reader, err = openFile(filePath)

--- a/dbmongo/lib/apdemande/main.go
+++ b/dbmongo/lib/apdemande/main.go
@@ -51,30 +51,38 @@ func (apdemande APDemande) Scope() string {
 var Parser = marshal.Parser{FileType: "apdemande", FileParser: ParseFile}
 
 // ParseFile permet de lancer le parsing du fichier demandé.
-func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) marshal.OpenFileResult {
+func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (marshal.FileReader, error) {
 	var idx colMapping
-	closeFct, reader, err := openFile(filePath)
+	file, reader, err := openFile(filePath)
 	if err == nil {
 		idx, err = parseColMapping(reader)
 	}
-	return marshal.OpenFileResult{
-		Error: err,
-		ParseLines: func(parsedLineChan chan marshal.ParsedLineResult) {
-			parseLines(reader, idx, parsedLineChan)
-		},
-		Close: closeFct,
-	}
+	return apdemandeReader{
+		file:   file,
+		reader: reader,
+		idx:    idx,
+	}, err
 }
 
-func openFile(filePath string) (func() error, *csv.Reader, error) {
+type apdemandeReader struct {
+	file   *os.File
+	reader *csv.Reader
+	idx    colMapping
+}
+
+func (parser apdemandeReader) Close() error {
+	return parser.file.Close()
+}
+
+func openFile(filePath string) (*os.File, *csv.Reader, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return file.Close, nil, err
+		return file, nil, err
 	}
 	reader := csv.NewReader(file)
 	reader.Comma = ','
 	reader.LazyQuotes = true
-	return file.Close, reader, nil
+	return file, reader, nil
 }
 
 type colMapping map[string]int
@@ -110,19 +118,19 @@ func parseColMapping(reader *csv.Reader) (colMapping, error) {
 	return idx, nil
 }
 
-func parseLines(reader *csv.Reader, idx colMapping, parsedLineChan chan marshal.ParsedLineResult) {
+func (parser apdemandeReader) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
 	for {
 		parsedLine := marshal.ParsedLineResult{}
-		row, err := reader.Read()
+		row, err := parser.reader.Read()
 		if err == io.EOF {
 			close(parsedLineChan)
 			break
 		} else if err != nil {
 			parsedLine.AddError(base.NewRegularError(err))
-		} else if row[idx["ETAB_SIRET"]] == "" {
+		} else if row[parser.idx["ETAB_SIRET"]] == "" {
 			parsedLine.AddError(base.NewRegularError(errors.New("invalidLine")))
 		} else {
-			parseApDemandeLine(row, idx, &parsedLine)
+			parseApDemandeLine(row, parser.idx, &parsedLine)
 			if len(parsedLine.Errors) > 0 {
 				parsedLine.Tuples = []marshal.Tuple{}
 			}

--- a/dbmongo/lib/bdf/main.go
+++ b/dbmongo/lib/bdf/main.go
@@ -43,24 +43,26 @@ func (bdf BDF) Scope() string {
 	return "entreprise"
 }
 
-// Parser expose le parseur et le type de fichier qu'il supporte.
-var Parser = marshal.Parser{FileType: "bdf", FileParser: ParseFile}
+// Parser fournit une instance utilisable par ParseFilesFromBatch.
+var Parser = &bdfParser{}
 
-// ParseFile permet de lancer le parsing du fichier demandé.
-func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (marshal.FileReader, error) {
-	file, reader, err := openFile(filePath)
-	return bdfReader{
-		file:   file,
-		reader: reader,
-	}, err
-}
-
-type bdfReader struct {
+type bdfParser struct {
 	file   *os.File
 	reader *csv.Reader
 }
 
-func (parser bdfReader) Close() error {
+func (parser *bdfParser) GetFileType() string {
+	return "bdf"
+}
+
+func (parser *bdfParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
+
+func (parser *bdfParser) Open(filePath string) (err error) {
+	parser.file, parser.reader, err = openFile(filePath)
+	return err
+}
+
+func (parser *bdfParser) Close() error {
 	return parser.file.Close()
 }
 
@@ -76,7 +78,7 @@ func openFile(filePath string) (*os.File, *csv.Reader, error) {
 	return file, reader, err
 }
 
-func (parser bdfReader) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
+func (parser *bdfParser) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
 	for {
 		parsedLine := marshal.ParsedLineResult{}
 		row, err := parser.reader.Read()

--- a/dbmongo/lib/bdf/main.go
+++ b/dbmongo/lib/bdf/main.go
@@ -47,33 +47,39 @@ func (bdf BDF) Scope() string {
 var Parser = marshal.Parser{FileType: "bdf", FileParser: ParseFile}
 
 // ParseFile permet de lancer le parsing du fichier demandé.
-func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) marshal.OpenFileResult {
-	closeFct, reader, err := openFile(filePath)
-	return marshal.OpenFileResult{
-		Error: err,
-		ParseLines: func(parsedLineChan chan marshal.ParsedLineResult) {
-			parseLines(reader, parsedLineChan)
-		},
-		Close: closeFct,
-	}
+func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (marshal.FileReader, error) {
+	file, reader, err := openFile(filePath)
+	return bdfReader{
+		file:   file,
+		reader: reader,
+	}, err
 }
 
-func openFile(filePath string) (func() error, *csv.Reader, error) {
+type bdfReader struct {
+	file   *os.File
+	reader *csv.Reader
+}
+
+func (parser bdfReader) Close() error {
+	return parser.file.Close()
+}
+
+func openFile(filePath string) (*os.File, *csv.Reader, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return file.Close, nil, err
+		return file, nil, err
 	}
 	reader := csv.NewReader(bufio.NewReader(file))
 	reader.Comma = ';'
 	reader.LazyQuotes = true
 	_, err = reader.Read() // Sauter l'en-tête
-	return file.Close, reader, err
+	return file, reader, err
 }
 
-func parseLines(reader *csv.Reader, parsedLineChan chan marshal.ParsedLineResult) {
+func (parser bdfReader) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
 	for {
 		parsedLine := marshal.ParsedLineResult{}
-		row, err := reader.Read()
+		row, err := parser.reader.Read()
 		if err == io.EOF {
 			close(parsedLineChan)
 			break

--- a/dbmongo/lib/bdf/main.go
+++ b/dbmongo/lib/bdf/main.go
@@ -55,7 +55,9 @@ func (parser *bdfParser) GetFileType() string {
 	return "bdf"
 }
 
-func (parser *bdfParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
+func (parser *bdfParser) Init(cache *marshal.Cache, batch *base.AdminBatch) error {
+	return nil
+}
 
 func (parser *bdfParser) Open(filePath string) (err error) {
 	parser.file, parser.reader, err = openFile(filePath)

--- a/dbmongo/lib/diane/main.go
+++ b/dbmongo/lib/diane/main.go
@@ -128,7 +128,9 @@ func (parser *dianeParser) GetFileType() string {
 	return "diane"
 }
 
-func (parser *dianeParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
+func (parser *dianeParser) Init(cache *marshal.Cache, batch *base.AdminBatch) error {
+	return nil
+}
 
 func (parser *dianeParser) Open(filePath string) (err error) {
 	parser.closeFct, parser.reader, err = openFile(filePath)

--- a/dbmongo/lib/diane/main.go
+++ b/dbmongo/lib/diane/main.go
@@ -116,24 +116,25 @@ func (diane Diane) Scope() string {
 	return "entreprise"
 }
 
-// Parser expose le parseur et le type de fichier qu'il supporte.
-var Parser = marshal.Parser{FileType: "diane", FileParser: ParseFile}
+// Parser fournit une instance utilisable par ParseFilesFromBatch.
+var Parser = &dianeParser{}
 
-// ParseFile permet de lancer le parsing du fichier demandé.
-func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (marshal.FileReader, error) {
-	closeFct, reader, err := openFile(filePath)
-	return dianeReader{
-		closeFct: closeFct,
-		reader:   reader,
-	}, err
-}
-
-type dianeReader struct {
+type dianeParser struct {
 	closeFct func() error
 	reader   *csv.Reader
 }
 
-func (parser dianeReader) Close() error {
+func (parser *dianeParser) GetFileType() string {
+	return "diane"
+}
+
+func (parser *dianeParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
+
+func (parser *dianeParser) Open(filePath string) (err error) {
+	parser.closeFct, parser.reader, err = openFile(filePath)
+	return err
+}
+func (parser *dianeParser) Close() error {
 	return parser.closeFct()
 }
 
@@ -190,7 +191,7 @@ func openFile(filePath string) (func() error, *csv.Reader, error) {
 	return close, reader, nil
 }
 
-func (parser dianeReader) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
+func (parser *dianeParser) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
 	for {
 		parsedLine := marshal.ParsedLineResult{}
 		row, err := parser.reader.Read()

--- a/dbmongo/lib/ellisphere/main.go
+++ b/dbmongo/lib/ellisphere/main.go
@@ -38,22 +38,25 @@ func (ellisphere Ellisphere) Scope() string {
 	return "entreprise"
 }
 
-// Parser expose le parseur et le type de fichier qu'il supporte.
-var Parser = marshal.Parser{FileType: "ellisphere", FileParser: ParseFile}
+// Parser fournit une instance utilisable par ParseFilesFromBatch.
+var Parser = &ellisphereParser{}
 
-// ParseFile permet de lancer le parsing du fichier demandé.
-func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (marshal.FileReader, error) {
-	sheet, err := openFile(filePath)
-	return ellisphereReader{
-		sheet: sheet,
-	}, err
-}
-
-type ellisphereReader struct {
+type ellisphereParser struct {
 	sheet *xlsx.Sheet
 }
 
-func (parser ellisphereReader) Close() error {
+func (parser *ellisphereParser) GetFileType() string {
+	return "ellisphere"
+}
+
+func (parser *ellisphereParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
+
+func (parser *ellisphereParser) Open(filePath string) (err error) {
+	parser.sheet, err = openFile(filePath)
+	return err
+}
+
+func (parser *ellisphereParser) Close() error {
 	return nil
 }
 
@@ -68,7 +71,7 @@ func openFile(filePath string) (*xlsx.Sheet, error) {
 	return xlsxFile.Sheets[0], nil
 }
 
-func (parser ellisphereReader) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
+func (parser *ellisphereParser) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
 	parser.sheet.ForEachRow(
 		func(row *xlsx.Row) error {
 			parsedLine := marshal.ParsedLineResult{}

--- a/dbmongo/lib/ellisphere/main.go
+++ b/dbmongo/lib/ellisphere/main.go
@@ -52,23 +52,19 @@ func (parser *ellisphereParser) GetFileType() string {
 func (parser *ellisphereParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
 
 func (parser *ellisphereParser) Open(filePath string) (err error) {
-	parser.sheet, err = openFile(filePath)
-	return err
+	xlsxFile, err := xlsx.OpenFile(filePath)
+	if err != nil {
+		return err
+	}
+	if len(xlsxFile.Sheets) != 1 {
+		return errors.Errorf("the source has %d sheets, should have only 1", len(xlsxFile.Sheets))
+	}
+	parser.sheet = xlsxFile.Sheets[0]
+	return nil
 }
 
 func (parser *ellisphereParser) Close() error {
 	return nil
-}
-
-func openFile(filePath string) (*xlsx.Sheet, error) {
-	xlsxFile, err := xlsx.OpenFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-	if len(xlsxFile.Sheets) != 1 {
-		return nil, errors.Errorf("the source has %d sheets, should have only 1", len(xlsxFile.Sheets))
-	}
-	return xlsxFile.Sheets[0], nil
 }
 
 func (parser *ellisphereParser) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {

--- a/dbmongo/lib/ellisphere/main.go
+++ b/dbmongo/lib/ellisphere/main.go
@@ -49,7 +49,9 @@ func (parser *ellisphereParser) GetFileType() string {
 	return "ellisphere"
 }
 
-func (parser *ellisphereParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
+func (parser *ellisphereParser) Init(cache *marshal.Cache, batch *base.AdminBatch) error {
+	return nil
+}
 
 func (parser *ellisphereParser) Open(filePath string) (err error) {
 	xlsxFile, err := xlsx.OpenFile(filePath)

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -16,7 +16,7 @@ import (
 // Parser fournit les fonctions de parsing d'un type de fichier donné.
 type Parser interface {
 	GetFileType() string
-	Init(cache *Cache, batch *base.AdminBatch)
+	Init(cache *Cache, batch *base.AdminBatch) error
 	Open(filePath string) error
 	ParseLines(parsedLineChan chan ParsedLineResult)
 	Close() error

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -65,7 +65,9 @@ func ParseFilesFromBatch(cache Cache, batch *base.AdminBatch, parser Parser) (ch
 				map[string]string{"path": path, "batchKey": batch.ID.Key},
 				TrackerReports)
 			filePath := viper.GetString("APP_DATA") + path
-			parser.Init(&cache, batch)
+			if err := parser.Init(&cache, batch); err != nil {
+				tracker.Add(base.NewFatalError(err))
+			}
 			runParserWithSirenFilter(parser, &filter, filePath, &tracker, outputChannel)
 			event.Info(tracker.Report("abstract"))
 		}

--- a/dbmongo/lib/marshal/testing.go
+++ b/dbmongo/lib/marshal/testing.go
@@ -43,7 +43,7 @@ func RunParser(
 	cache Cache,
 	inputFile string,
 ) (output tuplesAndEvents) {
-	batch := base.MockBatch(parser.FileType, []string{inputFile})
+	batch := base.MockBatch(parser.GetFileType(), []string{inputFile})
 	tuples, events := ParseFilesFromBatch(cache, &batch, parser)
 
 	// intercepter et afficher les évènements pendant l'importation

--- a/dbmongo/lib/reporder/reporder.go
+++ b/dbmongo/lib/reporder/reporder.go
@@ -45,7 +45,9 @@ func (parser *reporderParser) GetFileType() string {
 	return "reporder"
 }
 
-func (parser *reporderParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
+func (parser *reporderParser) Init(cache *marshal.Cache, batch *base.AdminBatch) error {
+	return nil
+}
 
 func (parser *reporderParser) Open(filePath string) (err error) {
 	parser.file, err = os.Open(filePath)

--- a/dbmongo/lib/sirene/main.go
+++ b/dbmongo/lib/sirene/main.go
@@ -183,7 +183,9 @@ func (parser *sireneParser) GetFileType() string {
 	return "sirene"
 }
 
-func (parser *sireneParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
+func (parser *sireneParser) Init(cache *marshal.Cache, batch *base.AdminBatch) error {
+	return nil
+}
 
 func (parser *sireneParser) Close() error {
 	return parser.file.Close()

--- a/dbmongo/lib/sirene/main.go
+++ b/dbmongo/lib/sirene/main.go
@@ -175,32 +175,38 @@ func (sirene Sirene) Scope() string {
 var Parser = marshal.Parser{FileType: "sirene", FileParser: ParseFile}
 
 // ParseFile permet de lancer le parsing du fichier demandé.
-func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) marshal.OpenFileResult {
-	closeFct, reader, err := openFile(filePath)
-	return marshal.OpenFileResult{
-		Error: err,
-		ParseLines: func(parsedLineChan chan marshal.ParsedLineResult) {
-			parseLines(reader, parsedLineChan)
-		},
-		Close: closeFct,
-	}
+func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (marshal.FileReader, error) {
+	file, reader, err := openFile(filePath)
+	return sireneReader{
+		file:   file,
+		reader: reader,
+	}, err
 }
 
-func openFile(filePath string) (func() error, *csv.Reader, error) {
+type sireneReader struct {
+	file   *os.File
+	reader *csv.Reader
+}
+
+func (parser sireneReader) Close() error {
+	return parser.file.Close()
+}
+
+func openFile(filePath string) (*os.File, *csv.Reader, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return file.Close, nil, err
+		return file, nil, err
 	}
 	reader := csv.NewReader(file)
 	reader.Comma = ','
 	reader.LazyQuotes = true
-	return file.Close, reader, nil
+	return file, reader, nil
 }
 
-func parseLines(reader *csv.Reader, parsedLineChan chan marshal.ParsedLineResult) {
+func (parser sireneReader) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
 	for {
 		parsedLine := marshal.ParsedLineResult{}
-		row, err := reader.Read()
+		row, err := parser.reader.Read()
 		if err == io.EOF {
 			close(parsedLineChan)
 			break

--- a/dbmongo/lib/sirene_ul/main.go
+++ b/dbmongo/lib/sirene_ul/main.go
@@ -45,33 +45,39 @@ func (sirene_ul SireneUL) Scope() string {
 var Parser = marshal.Parser{FileType: "sirene_ul", FileParser: ParseFile}
 
 // ParseFile permet de lancer le parsing du fichier demandé.
-func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) marshal.OpenFileResult {
-	closeFct, reader, err := openFile(filePath)
-	return marshal.OpenFileResult{
-		Error: err,
-		ParseLines: func(parsedLineChan chan marshal.ParsedLineResult) {
-			parseLines(reader, parsedLineChan)
-		},
-		Close: closeFct,
-	}
+func ParseFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (marshal.FileReader, error) {
+	file, reader, err := openFile(filePath)
+	return sireneUlReader{
+		file:   file,
+		reader: reader,
+	}, err
 }
 
-func openFile(filePath string) (func() error, *csv.Reader, error) {
+type sireneUlReader struct {
+	file   *os.File
+	reader *csv.Reader
+}
+
+func (parser sireneUlReader) Close() error {
+	return parser.file.Close()
+}
+
+func openFile(filePath string) (*os.File, *csv.Reader, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return file.Close, nil, err
+		return file, nil, err
 	}
 	reader := csv.NewReader(file)
 	reader.Comma = ','
 	reader.LazyQuotes = true
 	_, err = reader.Read() // skip header
-	return file.Close, reader, err
+	return file, reader, err
 }
 
-func parseLines(reader *csv.Reader, parsedLineChan chan marshal.ParsedLineResult) {
+func (parser sireneUlReader) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
 	for {
 		parsedLine := marshal.ParsedLineResult{}
-		row, err := reader.Read()
+		row, err := parser.reader.Read()
 		if err == io.EOF {
 			close(parsedLineChan)
 			break

--- a/dbmongo/lib/sirene_ul/main.go
+++ b/dbmongo/lib/sirene_ul/main.go
@@ -53,7 +53,9 @@ func (parser *sireneUlParser) GetFileType() string {
 	return "sirene_ul"
 }
 
-func (parser *sireneUlParser) Init(cache *marshal.Cache, batch *base.AdminBatch) {}
+func (parser *sireneUlParser) Init(cache *marshal.Cache, batch *base.AdminBatch) error {
+	return nil
+}
 
 func (parser *sireneUlParser) Close() error {
 	return parser.file.Close()

--- a/dbmongo/lib/urssaf/compte.go
+++ b/dbmongo/lib/urssaf/compte.go
@@ -50,7 +50,7 @@ func (parser *comptesParser) Init(cache *marshal.Cache, batch *base.AdminBatch) 
 	return err
 }
 
-func (parser *comptesParser) Open() error {
+func (parser *comptesParser) Open(filePath string) error {
 	// Ce parseur produit des tuples à partir des mappings compte<->siret déjà
 	// parsés par marshal.GetCompteSiretMapping(). => pas de fichier à ouvrir.
 	return nil

--- a/dbmongo/lib/urssaf/cotisation.go
+++ b/dbmongo/lib/urssaf/cotisation.go
@@ -46,6 +46,10 @@ type cotisationParser struct {
 	comptes marshal.Comptes
 }
 
+func (parser *cotisationParser) GetFileType() string {
+	return "cotisation"
+}
+
 func (parser *cotisationParser) Close() error {
 	return parser.file.Close()
 }

--- a/dbmongo/lib/urssaf/delai.go
+++ b/dbmongo/lib/urssaf/delai.go
@@ -46,42 +46,37 @@ func (delai Delai) Type() string {
 	return "delai"
 }
 
-// ParserDelai expose le parseur et le type de fichier qu'il supporte.
-var ParserDelai = marshal.Parser{FileType: "delai", FileParser: ParseDelaiFile}
+// ParserDelai fournit une instance utilisable par ParseFilesFromBatch.
+var ParserDelai = &delaiParser{}
 
-// ParseDelaiFile permet de lancer le parsing du fichier demandé.
-func ParseDelaiFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (marshal.FileReader, error) {
-	var comptes marshal.Comptes
-	file, reader, err := openDelaiFile(filePath)
-	if err == nil {
-		comptes, err = marshal.GetCompteSiretMapping(*cache, batch, marshal.OpenAndReadSiretMapping)
-	}
-	return delaiReader{
-		file:    file,
-		reader:  reader,
-		comptes: &comptes,
-	}, err
-}
-
-type delaiReader struct {
+type delaiParser struct {
 	file    *os.File
 	reader  *csv.Reader
-	comptes *marshal.Comptes
+	comptes marshal.Comptes
 }
 
-func (parser delaiReader) Close() error {
+func (parser *delaiParser) GetFileType() string {
+	return "delai"
+}
+
+func (parser *delaiParser) Close() error {
 	return parser.file.Close()
 }
 
-func openDelaiFile(filePath string) (*os.File, *csv.Reader, error) {
+func (parser *delaiParser) Init(cache *marshal.Cache, batch *base.AdminBatch) (err error) {
+	parser.comptes, err = marshal.GetCompteSiretMapping(*cache, batch, marshal.OpenAndReadSiretMapping)
+	return err
+}
+
+func (parser *delaiParser) Open(filePath string) (err error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return file, nil, err
+		return err
 	}
 	reader := csv.NewReader(bufio.NewReader(file))
 	reader.Comma = ';'
 	_, err = reader.Read() // Sauter l'en-tête
-	return file, reader, err
+	return err
 }
 
 var idxDelai = colMapping{
@@ -98,7 +93,7 @@ var idxDelai = colMapping{
 	"Action":            12,
 }
 
-func (parser delaiReader) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
+func (parser *delaiParser) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
 	idx := idxDelai
 	for {
 		parsedLine := marshal.ParsedLineResult{}
@@ -112,7 +107,7 @@ func (parser delaiReader) ParseLines(parsedLineChan chan marshal.ParsedLineResul
 			date, err := time.Parse("02/01/2006", row[idx["DateCreation"]])
 			if err != nil {
 				parsedLine.AddError(base.NewRegularError(err))
-			} else if siret, err := marshal.GetSiretFromComptesMapping(row[idx["NumeroCompte"]], &date, *parser.comptes); err == nil {
+			} else if siret, err := marshal.GetSiretFromComptesMapping(row[idx["NumeroCompte"]], &date, parser.comptes); err == nil {
 				parseDelaiLine(row, idx, siret, &parsedLine)
 				if len(parsedLine.Errors) > 0 {
 					parsedLine.Tuples = []marshal.Tuple{}

--- a/dbmongo/lib/urssaf/delai.go
+++ b/dbmongo/lib/urssaf/delai.go
@@ -69,13 +69,13 @@ func (parser *delaiParser) Init(cache *marshal.Cache, batch *base.AdminBatch) (e
 }
 
 func (parser *delaiParser) Open(filePath string) (err error) {
-	file, err := os.Open(filePath)
+	parser.file, err = os.Open(filePath)
 	if err != nil {
 		return err
 	}
-	reader := csv.NewReader(bufio.NewReader(file))
-	reader.Comma = ';'
-	_, err = reader.Read() // Sauter l'en-tête
+	parser.reader = csv.NewReader(bufio.NewReader(parser.file))
+	parser.reader.Comma = ';'
+	_, err = parser.reader.Read() // Sauter l'en-tête
 	return err
 }
 

--- a/dbmongo/lib/urssaf/effectif_ent.go
+++ b/dbmongo/lib/urssaf/effectif_ent.go
@@ -63,11 +63,11 @@ func (parser *effectifEntParser) Init(cache *marshal.Cache, batch *base.AdminBat
 func (parser *effectifEntParser) Open(filePath string) (err error) {
 	parser.file, err = os.Open(filePath)
 	if err == nil {
-		parser.idx, parser.periods, err = parseEffectifEntColMapping(parser.reader)
-	}
-	if err == nil {
 		parser.reader = csv.NewReader(bufio.NewReader(parser.file))
 		parser.reader.Comma = ';'
+	}
+	if err == nil {
+		parser.idx, parser.periods, err = parseEffectifEntColMapping(parser.reader)
 	}
 	return err
 }

--- a/dbmongo/lib/urssaf/procol.go
+++ b/dbmongo/lib/urssaf/procol.go
@@ -42,34 +42,38 @@ func (procol Procol) Type() string {
 var ParserProcol = marshal.Parser{FileType: "procol", FileParser: ParseProcolFile}
 
 // ParseProcolFile permet de lancer le parsing du fichier demandé.
-func ParseProcolFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) marshal.OpenFileResult {
+func ParseProcolFile(filePath string, cache *marshal.Cache, batch *base.AdminBatch) (marshal.FileReader, error) {
 	var idx colMapping
-	// var comptes marshal.Comptes
-	closeFct, reader, err := openProcolFile(filePath)
+	file, reader, err := openProcolFile(filePath)
 	if err == nil {
 		idx, err = parseProcolColMapping(reader)
 	}
-	// if err == nil {
-	// 	comptes, err = marshal.GetCompteSiretMapping(*cache, batch, marshal.OpenAndReadSiretMapping)
-	// }
-	return marshal.OpenFileResult{
-		Error: err,
-		ParseLines: func(parsedLineChan chan marshal.ParsedLineResult) {
-			parseProcolLines(reader, idx, parsedLineChan)
-		},
-		Close: closeFct,
-	}
+	return procolReader{
+		file:   file,
+		reader: reader,
+		idx:    idx,
+	}, err
 }
 
-func openProcolFile(filePath string) (func() error, *csv.Reader, error) {
+type procolReader struct {
+	file   *os.File
+	reader *csv.Reader
+	idx    colMapping
+}
+
+func (parser procolReader) Close() error {
+	return parser.file.Close()
+}
+
+func openProcolFile(filePath string) (*os.File, *csv.Reader, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return file.Close, nil, err
+		return file, nil, err
 	}
 	reader := csv.NewReader(bufio.NewReader(file))
 	reader.Comma = ';'
 	reader.LazyQuotes = true
-	return file.Close, reader, err
+	return file, reader, err
 }
 
 func parseProcolColMapping(reader *csv.Reader) (colMapping, error) {
@@ -88,17 +92,17 @@ func parseProcolColMapping(reader *csv.Reader) (colMapping, error) {
 	return idx, nil
 }
 
-func parseProcolLines(reader *csv.Reader, idx colMapping, parsedLineChan chan marshal.ParsedLineResult) {
+func (parser procolReader) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
 	for {
 		parsedLine := marshal.ParsedLineResult{}
-		row, err := reader.Read()
+		row, err := parser.reader.Read()
 		if err == io.EOF {
 			close(parsedLineChan)
 			break
 		} else if err != nil {
 			parsedLine.AddError(base.NewRegularError(err))
 		} else {
-			parseProcolLine(row, idx, &parsedLine)
+			parseProcolLine(row, parser.idx, &parsedLine)
 			if len(parsedLine.Errors) > 0 {
 				parsedLine.Tuples = []marshal.Tuple{}
 			}


### PR DESCRIPTION
Suite de PR #225.

Inspiré par une suggestion de Pierre, cette PR exposer la méthode `ParseLines()` via une interface au lieu de la retourner comme propriété d'une structure.