### PR TITLE
fix(parseurs): Imposer la qualification de chaque erreur de parsing

### DIFF
--- a/dbmongo/lib/apconso/main.go
+++ b/dbmongo/lib/apconso/main.go
@@ -94,7 +94,7 @@ func parseLines(reader *csv.Reader, idx colMapping, parsedLineChan chan marshal.
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else if len(row) > 0 {
 			parseApConsoLine(row, idx, &parsedLine)
 			if len(parsedLine.Errors) > 0 {
@@ -111,12 +111,12 @@ func parseApConsoLine(row []string, idx colMapping, parsedLine *marshal.ParsedLi
 	apconso.Siret = row[idx["Siret"]]
 	var err error
 	apconso.Periode, err = time.Parse("01/2006", row[idx["Periode"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apconso.HeureConsommee, err = misc.ParsePFloat(row[idx["HeureConsommee"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apconso.Montant, err = misc.ParsePFloat(row[idx["Montant"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apconso.Effectif, err = misc.ParsePInt(row[idx["Effectif"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	parsedLine.AddTuple(apconso)
 }

--- a/dbmongo/lib/apdemande/main.go
+++ b/dbmongo/lib/apdemande/main.go
@@ -118,9 +118,9 @@ func parseLines(reader *csv.Reader, idx colMapping, parsedLineChan chan marshal.
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else if row[idx["ETAB_SIRET"]] == "" {
-			parsedLine.AddError(base.NewRegularError(errors.New("invalidLine")))
+			parsedLine.AddRegularError(errors.New("invalidLine"))
 		} else {
 			parseApDemandeLine(row, idx, &parsedLine)
 			if len(parsedLine.Errors) > 0 {
@@ -137,29 +137,29 @@ func parseApDemandeLine(row []string, idx colMapping, parsedLine *marshal.Parsed
 	apdemande.Siret = row[idx["ETAB_SIRET"]]
 	var err error
 	apdemande.EffectifEntreprise, err = misc.ParsePInt(row[idx["EFF_ENT"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apdemande.Effectif, err = misc.ParsePInt(row[idx["EFF_ETAB"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apdemande.DateStatut, err = time.Parse("02/01/2006", row[idx["DATE_STATUT"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apdemande.Periode = misc.Periode{}
 	apdemande.Periode.Start, err = time.Parse("02/01/2006", row[idx["DATE_DEB"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apdemande.Periode.End, err = time.Parse("02/01/2006", row[idx["DATE_FIN"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apdemande.HTA, err = misc.ParsePFloat(row[idx["HTA"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apdemande.MTA, err = misc.ParsePFloat(strings.ReplaceAll(row[idx["MTA"]], ",", "."))
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apdemande.EffectifAutorise, err = misc.ParsePInt(row[idx["EFF_AUTO"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apdemande.MotifRecoursSE, err = misc.ParsePInt(row[idx["MOTIF_RECOURS_SE"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apdemande.HeureConsommee, err = misc.ParsePFloat(row[idx["S_HEURE_CONSOM_TOT"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apdemande.EffectifConsomme, err = misc.ParsePInt(row[idx["S_EFF_CONSOM_TOT"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	apdemande.MontantConsomme, err = misc.ParsePFloat(strings.ReplaceAll(row[idx["S_MONTANT_CONSOM_TOT"]], ",", "."))
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	parsedLine.AddTuple(apdemande)
 }

--- a/dbmongo/lib/base/errors.go
+++ b/dbmongo/lib/base/errors.go
@@ -12,14 +12,6 @@ type CriticError struct {
 	criticity string
 }
 
-// newCriticError creates an error with the provided criticity
-func newCriticError(err error, criticity string) CriticityError {
-	if err == nil {
-		return nil
-	}
-	return &CriticError{err, criticity}
-}
-
 // Criticity returns criticity
 func (pe *CriticError) Criticity() string {
 	if pe == nil {
@@ -32,9 +24,12 @@ func (pe *CriticError) Error() string {
 	return pe.err.Error()
 }
 
-// FilterError occurs when something goes wrong while filtering
-type FilterError struct {
-	*CriticError
+// newCriticError creates an error with the provided criticity
+func newCriticError(err error, criticity string) CriticityError {
+	if err == nil {
+		return nil
+	}
+	return &CriticError{err, criticity}
 }
 
 // NewFilterError returns a filter error

--- a/dbmongo/lib/base/errors.go
+++ b/dbmongo/lib/base/errors.go
@@ -32,17 +32,17 @@ func newCriticError(err error, criticity string) CriticityError {
 	return &CriticError{err, criticity}
 }
 
-// NewFilterError returns a filter error
-func NewFilterError(err error) error {
+// NewFilterError returns a filter error (occurs when something goes wrong while filtering)
+func NewFilterError(err error) CriticityError {
 	return newCriticError(err, "filter")
 }
 
 // NewRegularError creates a regular error
-func NewRegularError(err error) error {
+func NewRegularError(err error) CriticityError {
 	return newCriticError(err, "error")
 }
 
 // NewFatalError creates a fatal error
-func NewFatalError(err error) error {
+func NewFatalError(err error) CriticityError {
 	return newCriticError(err, "fatal")
 }

--- a/dbmongo/lib/base/errors.go
+++ b/dbmongo/lib/base/errors.go
@@ -1,9 +1,5 @@
 package base
 
-import (
-	"fmt"
-)
-
 // CriticityError object
 type CriticityError interface {
 	error
@@ -54,21 +50,4 @@ func NewRegularError(err error) error {
 // NewFatalError creates a fatal error
 func NewFatalError(err error) error {
 	return newCriticError(err, "fatal")
-}
-
-// MappingError occurs when something goes wrong while looking for a mapping
-type MappingError struct {
-	*CriticError
-}
-
-// NewMappingError return a mapping Error
-func NewMappingError(err error, criticity string) error {
-	if err == nil {
-		return nil
-	}
-	return &MappingError{newCriticError(err, criticity).(*CriticError)}
-}
-
-func (pe *MappingError) Error() string {
-	return fmt.Sprintf("Error while loading or applying the key mapping: %v", pe.err)
 }

--- a/dbmongo/lib/base/errors.go
+++ b/dbmongo/lib/base/errors.go
@@ -17,7 +17,7 @@ type CriticError struct {
 }
 
 // newCriticError creates an error with the provided criticity
-func newCriticError(err error, criticity string) error {
+func newCriticError(err error, criticity string) CriticityError {
 	if err == nil {
 		return nil
 	}

--- a/dbmongo/lib/bdf/main.go
+++ b/dbmongo/lib/bdf/main.go
@@ -78,7 +78,7 @@ func parseLines(reader *csv.Reader, parsedLineChan chan marshal.ParsedLineResult
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else {
 			parseBdfLine(row, &parsedLine)
 			if len(parsedLine.Errors) > 0 {
@@ -108,7 +108,7 @@ func parseBdfLine(row []string, parsedLine *marshal.ParsedLineResult) {
 	bdf := BDF{}
 	bdf.Siren = strings.Replace(row[field["siren"]], " ", "", -1)
 	bdf.Annee, err = misc.ParsePInt(row[field["année"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	var arrete = row[field["arrêtéBilan"]]
 	arrete = strings.Replace(arrete, "janv", "-01-", -1)
 	arrete = strings.Replace(arrete, "JAN", "-01-", -1)
@@ -135,42 +135,42 @@ func parseBdfLine(row []string, parsedLine *marshal.ParsedLineResult) {
 	arrete = strings.Replace(arrete, "déc", "-12-", -1)
 	arrete = strings.Replace(arrete, "DEC", "-12-", -1)
 	bdf.ArreteBilan, err = time.Parse("02-01-2006", arrete)
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	bdf.RaisonSociale = row[field["raisonSociale"]]
 	bdf.Secteur = row[field["secteur"]]
 	if len(row) > field["poidsFrng"] {
 		bdf.PoidsFrng, err = misc.ParsePFloat(row[field["poidsFrng"]])
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 	} else {
 		bdf.PoidsFrng = nil
 	}
 	if len(row) > field["tauxMarge"] {
 		bdf.TauxMarge, err = misc.ParsePFloat(row[field["tauxMarge"]])
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 	} else {
 		bdf.TauxMarge = nil
 	}
 	if len(row) > field["delaiFournisseur"] {
 		bdf.DelaiFournisseur, err = misc.ParsePFloat(row[field["delaiFournisseur"]])
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 	} else {
 		bdf.DelaiFournisseur = nil
 	}
 	if len(row) > field["detteFiscale"] {
 		bdf.DetteFiscale, err = misc.ParsePFloat(row[field["detteFiscale"]])
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 	} else {
 		bdf.DetteFiscale = nil
 	}
 	if len(row) > field["financierCourtTerme"] {
 		bdf.FinancierCourtTerme, err = misc.ParsePFloat(row[field["financierCourtTerme"]])
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 	} else {
 		bdf.FinancierCourtTerme = nil
 	}
 	if len(row) > field["fraisFinancier"] {
 		bdf.FraisFinancier, err = misc.ParsePFloat(row[field["fraisFinancier"]])
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 	} else {
 		bdf.FraisFinancier = nil
 	}

--- a/dbmongo/lib/diane/main.go
+++ b/dbmongo/lib/diane/main.go
@@ -192,9 +192,9 @@ func parseLines(reader *csv.Reader, parsedLineChan chan marshal.ParsedLineResult
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else if len(row) < 83 {
-			parsedLine.AddError(base.NewRegularError(errors.New("Ligne invalide")))
+			parsedLine.AddRegularError(errors.New("Ligne invalide"))
 		} else {
 			parseDianeLine(row, &parsedLine)
 		}

--- a/dbmongo/lib/ellisphere/main.go
+++ b/dbmongo/lib/ellisphere/main.go
@@ -70,7 +70,7 @@ func parseLines(sheet *xlsx.Sheet, parsedLineChan chan marshal.ParsedLineResult)
 			parsedLine := marshal.ParsedLineResult{}
 			var ellisphere Ellisphere
 			err := row.ReadStruct(&ellisphere)
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 			if len(parsedLine.Errors) == 0 {
 				parsedLine.AddTuple(ellisphere)
 			}

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/signaux-faibles/gournal"
 	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/base"
 	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/sfregexp"
 	"github.com/spf13/viper"
@@ -68,9 +67,7 @@ func ParseFilesFromBatch(cache Cache, batch *base.AdminBatch, parser Parser) (ch
 	filter := GetSirenFilterFromCache(cache)
 	go func() {
 		for _, path := range batch.Files[fileType] {
-			tracker := gournal.NewTracker(
-				map[string]string{"path": path, "batchKey": batch.ID.Key},
-				TrackerReports)
+			tracker := NewParsingTracker(batch.ID.Key, path)
 			filePath := viper.GetString("APP_DATA") + path
 			if err := parser.Init(&cache, batch); err != nil {
 				tracker.Add(base.NewFatalError(err))
@@ -84,7 +81,7 @@ func ParseFilesFromBatch(cache Cache, batch *base.AdminBatch, parser Parser) (ch
 	return outputChannel, eventChannel
 }
 
-func runParserWithSirenFilter(parser Parser, filter *SirenFilter, filePath string, tracker *gournal.Tracker, outputChannel chan Tuple) {
+func runParserWithSirenFilter(parser Parser, filter *SirenFilter, filePath string, tracker *ParsingTracker, outputChannel chan Tuple) {
 	err := parser.Open(filePath)
 	// Note: on ne passe plus le tracker aux parseurs afin de garder ici le controle de la numérotation des lignes où les erreurs sont trouvées
 	if err != nil {

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -34,7 +34,7 @@ type OpenFileResult struct {
 // ParsedLineResult est le résultat du parsing d'une ligne.
 type ParsedLineResult struct {
 	Tuples []Tuple
-	Errors []error // TODO: utiliser CriticError ici
+	Errors []base.CriticityError
 }
 
 // AddTuple permet au parseur d'ajouter un tuple extrait depuis la ligne en cours.

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -44,10 +44,17 @@ func (res *ParsedLineResult) AddTuple(tuple Tuple) {
 	}
 }
 
-// AddError permet au parseur d'ajouter un tuple extrait depuis la ligne en cours.
-func (res *ParsedLineResult) AddError(err error) { // TODO: utiliser CriticError ici
+// AddRegularError permet au parseur de rapporter une erreur d'extraction.
+func (res *ParsedLineResult) AddRegularError(err error) {
 	if err != nil {
-		res.Errors = append(res.Errors, err)
+		res.Errors = append(res.Errors, base.NewRegularError(err))
+	}
+}
+
+// AddFilterError permet au parseur de rapporter qu'une ligne a été filtrée.
+func (res *ParsedLineResult) AddFilterError(err error) {
+	if err != nil {
+		res.Errors = append(res.Errors, base.NewFilterError(err))
 	}
 }
 

--- a/dbmongo/lib/reporder/reporder.go
+++ b/dbmongo/lib/reporder/reporder.go
@@ -66,7 +66,7 @@ func parseLines(reader *csv.Reader, parsedLineChan chan marshal.ParsedLineResult
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else {
 			parseReporderLine(row, &parsedLine)
 			if len(parsedLine.Errors) > 0 {
@@ -79,9 +79,9 @@ func parseLines(reader *csv.Reader, parsedLineChan chan marshal.ParsedLineResult
 
 func parseReporderLine(row []string, parsedLine *marshal.ParsedLineResult) {
 	periode, err := time.Parse("2006-01-02", row[1])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	randomOrder, err := misc.ParsePFloat(row[2])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	parsedLine.AddTuple(RepeatableOrder{
 		Siret:       row[0],
 		Periode:     periode,

--- a/dbmongo/lib/sirene/main.go
+++ b/dbmongo/lib/sirene/main.go
@@ -205,7 +205,7 @@ func parseLines(reader *csv.Reader, parsedLineChan chan marshal.ParsedLineResult
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else {
 			parseLine(row, &parsedLine)
 		}
@@ -219,7 +219,7 @@ func parseLine(row []string, parsedLine *marshal.ParsedLineResult) {
 	sirene.Siren = row[f["siren"]]
 	sirene.Nic = row[f["nic"]]
 	sirene.Siege, err = strconv.ParseBool(row[f["etablissementSiege"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 
 	sirene.ComplementAdresse = row[f["complementAdresseEtablissement"]]
 	sirene.NumVoie = row[f["numeroVoieEtablissement"]]
@@ -246,7 +246,7 @@ func parseLine(row []string, parsedLine *marshal.ParsedLineResult) {
 		}
 		sirene.Departement = departement
 	} else {
-		parsedLine.AddError(base.NewRegularError(errors.New("Code postal est manquant ou de format incorrect")))
+		parsedLine.AddRegularError(errors.New("Code postal est manquant ou de format incorrect"))
 	}
 
 	if row[f["activitePrincipaleEtablissement"]] != "" {
@@ -266,14 +266,14 @@ func parseLine(row []string, parsedLine *marshal.ParsedLineResult) {
 	if err == nil {
 		sirene.Creation = &creation
 	}
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 
 	long, err := strconv.ParseFloat(row[f["longitude"]], 64)
 	if err == nil {
 		sirene.Longitude = long
 	}
 	if row[48] != "" {
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 	}
 
 	lat, err := strconv.ParseFloat(row[f["latitude"]], 64)
@@ -281,7 +281,7 @@ func parseLine(row []string, parsedLine *marshal.ParsedLineResult) {
 		sirene.Latitude = lat
 	}
 	if row[49] != "" {
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 	}
 	parsedLine.AddTuple(sirene)
 }

--- a/dbmongo/lib/sirene_ul/main.go
+++ b/dbmongo/lib/sirene_ul/main.go
@@ -76,7 +76,7 @@ func parseLines(reader *csv.Reader, parsedLineChan chan marshal.ParsedLineResult
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else {
 			parseSireneUlLine(row, &parsedLine)
 		}
@@ -99,6 +99,6 @@ func parseSireneUlLine(row []string, parsedLine *marshal.ParsedLineResult) {
 	if err == nil {
 		sireneul.Creation = &creation
 	}
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	parsedLine.AddTuple(sireneul)
 }

--- a/dbmongo/lib/urssaf/ccsf.go
+++ b/dbmongo/lib/urssaf/ccsf.go
@@ -81,7 +81,7 @@ func parseCcsfLines(reader *csv.Reader, comptes *marshal.Comptes, parsedLineChan
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else {
 			parseCcsfLine(row, comptes, &parsedLine)
 			if len(parsedLine.Errors) > 0 {
@@ -100,7 +100,7 @@ func parseCcsfLine(row []string, comptes *marshal.Comptes, parsedLine *marshal.P
 		ccsf.Action = row[idx["Action"]]
 		ccsf.Stade = row[idx["Stade"]]
 		ccsf.DateTraitement, err = marshal.UrssafToDate(row[idx["DateTraitement"]])
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 		if err != nil {
 			return
 		}
@@ -108,13 +108,13 @@ func parseCcsfLine(row []string, comptes *marshal.Comptes, parsedLine *marshal.P
 		ccsf.key, err = marshal.GetSiretFromComptesMapping(row[idx["NumeroCompte"]], &ccsf.DateTraitement, *comptes)
 		if err != nil {
 			// Compte filtré
-			parsedLine.AddError(base.NewFilterError(err))
+			parsedLine.AddFilterError(err)
 			return
 		}
 		ccsf.NumeroCompte = row[idx["NumeroCompte"]]
 
 	} else {
-		parsedLine.AddError(base.NewRegularError(errors.New("Ligne non conforme, moins de 4 champs")))
+		parsedLine.AddRegularError(errors.New("Ligne non conforme, moins de 4 champs"))
 	}
 	parsedLine.AddTuple(ccsf)
 }

--- a/dbmongo/lib/urssaf/compte.go
+++ b/dbmongo/lib/urssaf/compte.go
@@ -68,7 +68,7 @@ func parseCompteLines(periodes []time.Time, mapping *marshal.Comptes, parsedLine
 			compte.NumeroCompte = account
 			compte.Periode = p
 			compte.Siret, err = marshal.GetSiretFromComptesMapping(account, &p, *mapping)
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 			parsedLine.AddTuple(compte)
 		}
 		parsedLineChan <- parsedLine

--- a/dbmongo/lib/urssaf/cotisation.go
+++ b/dbmongo/lib/urssaf/cotisation.go
@@ -83,7 +83,7 @@ func parseCotisationLines(reader *csv.Reader, comptes *marshal.Comptes, parsedLi
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else {
 			parseCotisationLine(row, comptes, &parsedLine)
 			if len(parsedLine.Errors) > 0 {
@@ -100,20 +100,20 @@ func parseCotisationLine(row []string, comptes *marshal.Comptes, parsedLine *mar
 
 	periode, err := marshal.UrssafToPeriod(row[idx["Periode"]])
 	date := periode.Start
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 
 	siret, err := marshal.GetSiretFromComptesMapping(row[idx["NumeroCompte"]], &date, *comptes)
 	if err != nil {
-		parsedLine.AddError(base.NewFilterError(err))
+		parsedLine.AddFilterError(err)
 	} else {
 		cotisation.key = siret
 		cotisation.NumeroCompte = row[idx["NumeroCompte"]]
 		cotisation.Periode, err = marshal.UrssafToPeriod(row[idx["Periode"]])
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 		cotisation.Encaisse, err = strconv.ParseFloat(strings.Replace(row[idx["Encaisse"]], ",", ".", -1), 64)
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 		cotisation.Du, err = strconv.ParseFloat(strings.Replace(row[idx["Du"]], ",", ".", -1), 64)
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 	}
 	parsedLine.AddTuple(cotisation)
 }

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -122,7 +122,7 @@ func parseDebitLines(reader *csv.Reader, idx colMapping, comptes *marshal.Compte
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else {
 			period, _ := marshal.UrssafToPeriod(row[idx["periode"]])
 			date := period.Start
@@ -133,7 +133,7 @@ func parseDebitLines(reader *csv.Reader, idx colMapping, comptes *marshal.Compte
 					parsedLine.Tuples = []marshal.Tuple{}
 				}
 			} else {
-				parsedLine.AddError(base.NewFilterError(err))
+				parsedLine.AddFilterError(err)
 			}
 		}
 		parsedLineChan <- parsedLine
@@ -153,21 +153,21 @@ func parseDebitLine(siret string, row []string, idx colMapping, parsedLine *mars
 
 	var err error
 	debit.DateTraitement, err = marshal.UrssafToDate(row[idx["dateTraitement"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	debit.PartOuvriere, err = strconv.ParseFloat(row[idx["partOuvriere"]], 64)
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	debit.PartOuvriere = debit.PartOuvriere / 100
 	debit.PartPatronale, err = strconv.ParseFloat(row[idx["partPatronale"]], 64)
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	debit.PartPatronale = debit.PartPatronale / 100
 	debit.NumeroHistoriqueEcartNegatif, err = strconv.Atoi(row[idx["numeroHistoriqueEcartNegatif"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	debit.EtatCompte, err = strconv.Atoi(row[idx["etatCompte"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	debit.Periode, err = marshal.UrssafToPeriod(row[idx["periode"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	debit.Recours, err = strconv.ParseBool(row[idx["recours"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	// debit.MontantMajorations, err = strconv.ParseFloat(row[idx["montantMajorations"]], 64)
 	// tracker.Error(err)
 	// debit.MontantMajorations = debit.MontantMajorations / 100

--- a/dbmongo/lib/urssaf/delai.go
+++ b/dbmongo/lib/urssaf/delai.go
@@ -99,18 +99,18 @@ func parseDelaiLines(reader *csv.Reader, comptes *marshal.Comptes, parsedLineCha
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else {
 			date, err := time.Parse("02/01/2006", row[idx["DateCreation"]])
 			if err != nil {
-				parsedLine.AddError(base.NewRegularError(err))
+				parsedLine.AddRegularError(err)
 			} else if siret, err := marshal.GetSiretFromComptesMapping(row[idx["NumeroCompte"]], &date, *comptes); err == nil {
 				parseDelaiLine(row, idx, siret, &parsedLine)
 				if len(parsedLine.Errors) > 0 {
 					parsedLine.Tuples = []marshal.Tuple{}
 				}
 			} else {
-				parsedLine.AddError(base.NewFilterError(err))
+				parsedLine.AddFilterError(err)
 			}
 		}
 		parsedLineChan <- parsedLine
@@ -125,16 +125,16 @@ func parseDelaiLine(row []string, idx colMapping, siret string, parsedLine *mars
 	delai.NumeroCompte = row[idx["NumeroCompte"]]
 	delai.NumeroContentieux = row[idx["NumeroContentieux"]]
 	delai.DateCreation, err = time.ParseInLocation("02/01/2006", row[idx["DateCreation"]], loc)
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	delai.DateEcheance, err = time.ParseInLocation("02/01/2006", row[idx["DateEcheance"]], loc)
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	delai.DureeDelai, err = strconv.Atoi(row[idx["DureeDelai"]])
 	delai.Denomination = row[idx["Denomination"]]
 	delai.Indic6m = row[idx["Indic6m"]]
 	delai.AnneeCreation, err = strconv.Atoi(row[idx["AnneeCreation"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	delai.MontantEcheancier, err = strconv.ParseFloat(strings.Replace(row[idx["MontantEcheancier"]], ",", ".", -1), 64)
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	delai.Stade = row[idx["Stade"]]
 	delai.Action = row[idx["Action"]]
 	parsedLine.AddTuple(delai)

--- a/dbmongo/lib/urssaf/effectif.go
+++ b/dbmongo/lib/urssaf/effectif.go
@@ -100,7 +100,7 @@ func parseEffectifLines(reader *csv.Reader, idx colMapping, periods []periodCol,
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else {
 			parseEffectifLine(row, idx, periods, &parsedLine)
 		}
@@ -114,7 +114,7 @@ func parseEffectifLine(row []string, idx colMapping, periods []periodCol, parsed
 		if value != "" {
 			noThousandsSep := sfregexp.RegexpDict["notDigit"].ReplaceAllString(value, "")
 			e, err := strconv.Atoi(noThousandsSep)
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 			if e > 0 {
 				parsedLine.AddTuple(Effectif{
 					Siret:        row[idx["siret"]],

--- a/dbmongo/lib/urssaf/effectif_ent.go
+++ b/dbmongo/lib/urssaf/effectif_ent.go
@@ -107,7 +107,7 @@ func parseEffectifEntLines(reader *csv.Reader, idx colMapping, periods []periodC
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else {
 			parseEffectifEntLine(row, idx, periods, &parsedLine)
 		}
@@ -121,7 +121,7 @@ func parseEffectifEntLine(row []string, idx colMapping, periods []periodCol, par
 		if value != "" {
 			noThousandsSep := sfregexp.RegexpDict["notDigit"].ReplaceAllString(value, "")
 			s, err := strconv.ParseFloat(noThousandsSep, 64)
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 			e := int(s)
 			if e > 0 {
 				parsedLine.AddTuple(EffectifEnt{

--- a/dbmongo/lib/urssaf/procol.go
+++ b/dbmongo/lib/urssaf/procol.go
@@ -96,7 +96,7 @@ func parseProcolLines(reader *csv.Reader, idx colMapping, parsedLineChan chan ma
 			close(parsedLineChan)
 			break
 		} else if err != nil {
-			parsedLine.AddError(base.NewRegularError(err))
+			parsedLine.AddRegularError(err)
 		} else {
 			parseProcolLine(row, idx, &parsedLine)
 			if len(parsedLine.Errors) > 0 {
@@ -111,13 +111,13 @@ func parseProcolLine(row []string, idx colMapping, parsedLine *marshal.ParsedLin
 	var err error
 	procol := Procol{}
 	procol.DateEffet, err = time.Parse("02Jan2006", row[idx["dt_effet"]])
-	parsedLine.AddError(base.NewRegularError(err))
+	parsedLine.AddRegularError(err)
 	procol.Siret = row[idx["siret"]]
 	actionStade := row[idx["lib_actx_stdx"]]
 	splitted := strings.Split(strings.ToLower(actionStade), "_")
 	for i, v := range splitted {
 		r, err := regexp.Compile("liquidation|redressement|sauvegarde")
-		parsedLine.AddError(base.NewRegularError(err))
+		parsedLine.AddRegularError(err)
 		if match := r.MatchString(v); match {
 			procol.ActionProcol = v
 			procol.StadeProcol = strings.Join(append(splitted[:i], splitted[i+1:]...), "_")


### PR DESCRIPTION
Contribue à #167.

## Problèmes

- les parseurs pouvaient rapporter n'importe quelle erreur, en oubliant de spécifier un niveau de criticité
- les erreurs sans niveau de criticité étaient rapportées comme `fatal` par défaut, alors qu'on souhaite éviter de découvrir ce genre d'erreurs lors de l'importation de données

## Solution proposée

Pour éviter de se retrouver avec des erreurs `fatal` à cause d'oublis dans l'implémentation de parseurs, empêcher le développeur de rapporter des erreurs sans niveau de criticité.

## Implémentation

Encapsulation cachée de `gournal.Tracker` dans `ParsingTracker`, qui ne permet que l'ajout d'erreurs associées à un niveau de criticité.

## Étapes

- [x] empêcher les parseurs de rapporter des erreurs sans criticité
- [x] empêcher des erreurs sans criticité d'être ajoutées dans un `ParsedLineResult`
- [x] empêcher des erreurs sans criticité d'être passées à tracker.Add() => simplifier `reportAbstract()`