### PR TITLE
fix: correction d'un bug dans le traitement des procédures collectives

### DIFF
--- a/dbmongo/js/RawDataTypes.ts
+++ b/dbmongo/js/RawDataTypes.ts
@@ -68,7 +68,14 @@ export type BatchValueProps = {
 
 export type EntréeDefaillances = {
   action_procol: "liquidation" | "redressement" | "sauvegarde"
-  stade_procol: "abandon_procedure" | "solde_procedure" | "fin_procedure" | "plan_continuation" | "ouverture" | "inclusion_autre_procedure" | "cloture_insuffisance_actif"
+  stade_procol:
+    | "abandon_procedure"
+    | "solde_procedure"
+    | "fin_procedure"
+    | "plan_continuation"
+    | "ouverture"
+    | "inclusion_autre_procedure"
+    | "cloture_insuffisance_actif"
   date_effet: Date
 }
 

--- a/dbmongo/js/RawDataTypes.ts
+++ b/dbmongo/js/RawDataTypes.ts
@@ -67,9 +67,8 @@ export type BatchValueProps = {
 // Détail des types de données
 
 export type EntréeDefaillances = {
-  code_evenement: string
   action_procol: "liquidation" | "redressement" | "sauvegarde"
-  stade_procol: "abandon_procedure" | "fin_procedure" | "plan_continuation"
+  stade_procol: "abandon_procedure" | "solde_procedure" | "fin_procedure" | "plan_continuation" | "ouverture" | "inclusion_autre_procedure" | "cloture_insuffisance_actif"
   date_effet: Date
 }
 

--- a/dbmongo/js/reduce.algo2/dealWithProcols.ts
+++ b/dbmongo/js/reduce.algo2/dealWithProcols.ts
@@ -52,7 +52,7 @@ export function dealWithProcols(
       )
     )
     const time_til_last = Object.keys(output_indexed).filter((val) => {
-      return val >= periode_effet.toString()
+      return val >= periode_effet.toISOString().split("T")[0]
     })
 
     time_til_last.forEach((time) => {

--- a/dbmongo/js/reduce.algo2/dealWithProcols_tests.ts
+++ b/dbmongo/js/reduce.algo2/dealWithProcols_tests.ts
@@ -1,0 +1,39 @@
+import test from "ava"
+import { dealWithProcols, InputEvent } from "./dealWithProcols"
+import { ParHash } from "../RawDataTypes"
+
+
+
+test("Une entrée en liquidation est prise en compte dans la période courante et les suivantes", (t) => {
+  const output_indexed =  {
+    ["2018-01-01"]: {},
+    ["2018-02-01"]: {},
+    ["2018-03-01"]: {}
+  }
+
+  const date_proc_collective = new Date("2018-02-12")
+  const data_source = {
+    ["123"]: {
+      action_procol: "liquidation",
+      stade_procol: "ouverture",
+      date_effet: date_proc_collective
+    }
+  } as ParHash<InputEvent>
+
+  dealWithProcols(data_source, output_indexed)
+  const expected = {
+    ["2018-01-01"]: {},
+    ["2018-02-01"]: {
+      date_proc_collective: date_proc_collective,
+      etat_proc_collective: "liquidation",
+      tag_failure: true
+    },
+    ["2018-03-01"]: {
+      date_proc_collective: date_proc_collective,
+      etat_proc_collective: "liquidation",
+      tag_failure: true
+    }
+  }
+
+  t.deepEqual(output_indexed, expected)
+})

--- a/dbmongo/js/reduce.algo2/dealWithProcols_tests.ts
+++ b/dbmongo/js/reduce.algo2/dealWithProcols_tests.ts
@@ -2,13 +2,11 @@ import test from "ava"
 import { dealWithProcols, InputEvent } from "./dealWithProcols"
 import { ParHash } from "../RawDataTypes"
 
-
-
 test("Une entrée en liquidation est prise en compte dans la période courante et les suivantes", (t) => {
-  const output_indexed =  {
+  const output_indexed = {
     ["2018-01-01"]: {},
     ["2018-02-01"]: {},
-    ["2018-03-01"]: {}
+    ["2018-03-01"]: {},
   }
 
   const date_proc_collective = new Date("2018-02-12")
@@ -16,23 +14,23 @@ test("Une entrée en liquidation est prise en compte dans la période courante e
     ["123"]: {
       action_procol: "liquidation",
       stade_procol: "ouverture",
-      date_effet: date_proc_collective
-    }
+      date_effet: date_proc_collective,
+    },
   } as ParHash<InputEvent>
 
   dealWithProcols(data_source, output_indexed)
   const expected = {
     ["2018-01-01"]: {},
     ["2018-02-01"]: {
-      date_proc_collective: date_proc_collective,
+      date_proc_collective,
       etat_proc_collective: "liquidation",
-      tag_failure: true
+      tag_failure: true,
     },
     ["2018-03-01"]: {
-      date_proc_collective: date_proc_collective,
+      date_proc_collective,
       etat_proc_collective: "liquidation",
-      tag_failure: true
-    }
+      tag_failure: true,
+    },
   }
 
   t.deepEqual(output_indexed, expected)

--- a/dbmongo/lib/engine/jsFunctions.go
+++ b/dbmongo/lib/engine/jsFunctions.go
@@ -1222,7 +1222,7 @@ function cotisationsdettes(vCotisation, vDebit, periodes, finPériode // corresp
     codes.forEach((event) => {
         const periode_effet = new Date(Date.UTC(event.date_proc_col.getFullYear(), event.date_proc_col.getUTCMonth(), 1, 0, 0, 0, 0));
         const time_til_last = Object.keys(output_indexed).filter((val) => {
-            return val >= periode_effet.toString();
+            return val >= periode_effet.toISOString().split("T")[0];
         });
         time_til_last.forEach((time) => {
             if (time in output_indexed) {


### PR DESCRIPTION
- Ajout d'un test unitaire pour la fonction `dealWithProcol` qui n'était visiblement pas non plus testée par les tests de bout en bout. 
- Complétion du type "EntréeDéfaillance" avec toutes les modalités possibles. 
- Correction d'un bug (cf commentaire)

**Questions**
Est-ce qu'il y a une raison particulière de faire un alias `export type InputEvent = EntréeDefaillances` dans `reduce.algo2/dealWithProcol.ts` ? 
De même avec la fonction `defaillances` dans `reduce.algo2/defaillances.ts` qui se contente d'appeler `dealWithProcols` ?


**Étape suivante:** 
- Ajout d'un test unitaire avec ouverture puis clotûre d'une procédure collective (redressement ou sauvegarde)