### PR TITLE
fix(parsing): Réduction d'empreinte mémoire lors du parsing de lignes filtrées

### DIFF
--- a/dbmongo/lib/apconso/testData/expectedApconso.json
+++ b/dbmongo/lib/apconso/testData/expectedApconso.json
@@ -29,7 +29,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 3,
         "linesRejected": 0,

--- a/dbmongo/lib/apdemande/testData/expectedApdemande.json
+++ b/dbmongo/lib/apdemande/testData/expectedApdemande.json
@@ -59,7 +59,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 3,
         "linesRejected": 0,

--- a/dbmongo/lib/base/errors.go
+++ b/dbmongo/lib/base/errors.go
@@ -1,5 +1,7 @@
 package base
 
+import "errors"
+
 // CriticityError object
 type CriticityError interface {
 	error
@@ -33,8 +35,8 @@ func newCriticError(err error, criticity string) CriticityError {
 }
 
 // NewFilterError returns a filter error (occurs when something goes wrong while filtering)
-func NewFilterError(err error) CriticityError {
-	return newCriticError(err, "filter")
+func NewFilterError() CriticityError {
+	return newCriticError(errors.New(""), "filter")
 }
 
 // NewRegularError creates a regular error

--- a/dbmongo/lib/bdf/testData/expectedBdfOutput.json
+++ b/dbmongo/lib/bdf/testData/expectedBdfOutput.json
@@ -47,7 +47,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 3,
         "linesRejected": 0,

--- a/dbmongo/lib/diane/testData/expectedDiane.json
+++ b/dbmongo/lib/diane/testData/expectedDiane.json
@@ -1484,7 +1484,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 18,
         "linesRejected": 0,

--- a/dbmongo/lib/ellisphere/testData/expectedEllisphere.json
+++ b/dbmongo/lib/ellisphere/testData/expectedEllisphere.json
@@ -85,7 +85,6 @@
         "headRejected": [
           "Cycle 0: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
         ],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 7,
         "linesRejected": 1,

--- a/dbmongo/lib/marshal/mapping_test.go
+++ b/dbmongo/lib/marshal/mapping_test.go
@@ -14,9 +14,9 @@ func TestGetSiret(t *testing.T) {
 	stdTime1, _ := time.Parse("2006-02-01", "2015-01-01")
 	stdTime2, _ := time.Parse("2006-02-01", "2016-01-01")
 	var stdMapping = map[string][]SiretDate{
-		"abc": []SiretDate{
-			SiretDate{"01234567891011", stdTime1},
-			SiretDate{"87654321091011", stdTime2},
+		"abc": {
+			{"01234567891011", stdTime1},
+			{"87654321091011", stdTime2},
 		},
 	}
 	var batch = base.AdminBatch{}
@@ -62,17 +62,17 @@ func TestReadSiretMapping(t *testing.T) {
 	stdTime1, _ := time.Parse("2006-02-01", "2899-01-01")
 	stdTime2, _ := time.Parse("2006-02-01", "2015-01-01")
 	stdExpected1 := Comptes{
-		"abc": []SiretDate{SiretDate{"01234567891011", stdTime1}},
+		"abc": []SiretDate{{"01234567891011", stdTime1}},
 	}
 
 	stdExpected2 := Comptes{
-		"abc": []SiretDate{SiretDate{"01234567891011", stdTime2}},
+		"abc": []SiretDate{{"01234567891011", stdTime2}},
 	}
 
 	stdExpected3 := Comptes{
 		"abc": []SiretDate{
-			SiretDate{"01234567891011", stdTime2},
-			SiretDate{"87654321091011", stdTime1},
+			{"01234567891011", stdTime2},
+			{"87654321091011", stdTime1},
 		},
 	}
 
@@ -98,7 +98,7 @@ func TestReadSiretMapping(t *testing.T) {
 		// With two entries, including excluded siret
 		{`0;1;2;3;4;5;6;7
 		;;"abc";;;"01234567891011";;"1150101"
-		;;"abc";;;"87654321091011";;""`, stdFilterCache, false, stdExpected2},
+		;;"abc";;;"87654321091011";;""`, stdFilterCache, false, stdExpected2}, // i.e. no mapping stored for 87654321091011, because it's not included by Filter
 		// With two entries 1
 		{`0;1;2;3;4;5;6;7
 		;;"abc";;;"01234567891011";;"1150101"
@@ -133,10 +133,10 @@ func TestGetCompteSiretMapping(t *testing.T) {
 	stdTime1, _ := time.Parse("2006-02-01", "2899-01-01")
 	stdTime2, _ := time.Parse("2006-02-01", "2016-01-01")
 	stdExpected1 := Comptes{
-		"abc": []SiretDate{SiretDate{"01234567891011", stdTime1}},
+		"abc": []SiretDate{{"01234567891011", stdTime1}},
 	}
 	stdExpected2 := Comptes{
-		"abc": []SiretDate{SiretDate{"01234567891011", stdTime2}},
+		"abc": []SiretDate{{"01234567891011", stdTime2}},
 	}
 
 	// When file is read, returnd stdExpected1

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -44,7 +44,7 @@ func (res *ParsedLineResult) AddRegularError(err error) {
 // AddFilterError permet au parseur de rapporter qu'une ligne a été filtrée.
 func (res *ParsedLineResult) AddFilterError(err error) {
 	if err != nil {
-		res.Errors = append(res.Errors, base.NewFilterError(err))
+		res.Errors = append(res.Errors, base.NewFilterError())
 	}
 }
 
@@ -102,7 +102,7 @@ func runParserWithSirenFilter(parser Parser, filter *SirenFilter, filePath strin
 						tracker.Add(base.NewRegularError(err))
 					}
 				} else if filter.Skips(tuple.Key()) {
-					tracker.Add(base.NewFilterError(errors.New("ligne filtrée")))
+					tracker.Add(base.NewFilterError())
 				} else {
 					outputChannel <- tuple
 				}

--- a/dbmongo/lib/marshal/tracker.go
+++ b/dbmongo/lib/marshal/tracker.go
@@ -120,7 +120,6 @@ func reportAbstract(tracker gournal.Tracker) interface{} {
 		"linesSkipped":  nFiltered,
 		"linesRejected": nError,
 		"isFatal":       nFatal > 0,
-		"headSkipped":   filterErrors,
 		"headRejected":  errorErrors,
 		"headFatal":     fatalErrors,
 	}

--- a/dbmongo/lib/reporder/testData/expectedReporder.json
+++ b/dbmongo/lib/reporder/testData/expectedReporder.json
@@ -28,7 +28,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 4,
         "linesRejected": 0,

--- a/dbmongo/lib/sirene/testData/expectedSirene.json
+++ b/dbmongo/lib/sirene/testData/expectedSirene.json
@@ -58,7 +58,6 @@
         "headRejected": [
           "Cycle 1: parsing time \"\" as \"2006-01-02\": cannot parse \"\" as \"2006\""
         ],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 3,
         "linesRejected": 1,

--- a/dbmongo/lib/sirene_ul/testData/expectedSireneUL.json
+++ b/dbmongo/lib/sirene_ul/testData/expectedSireneUL.json
@@ -38,7 +38,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 4,
         "linesRejected": 0,

--- a/dbmongo/lib/urssaf/testData/expectedCcsf.json
+++ b/dbmongo/lib/urssaf/testData/expectedCcsf.json
@@ -23,7 +23,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 3,
         "linesRejected": 0,

--- a/dbmongo/lib/urssaf/testData/expectedCotisation.json
+++ b/dbmongo/lib/urssaf/testData/expectedCotisation.json
@@ -35,7 +35,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 3,
         "linesRejected": 0,

--- a/dbmongo/lib/urssaf/testData/expectedDebit.json
+++ b/dbmongo/lib/urssaf/testData/expectedDebit.json
@@ -59,7 +59,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 3,
         "linesRejected": 0,

--- a/dbmongo/lib/urssaf/testData/expectedDebitCorrompu.json
+++ b/dbmongo/lib/urssaf/testData/expectedDebitCorrompu.json
@@ -62,7 +62,6 @@
           "Cycle 1: record on line 3: wrong number of fields",
           "Cycle 3: parse error on line 5, column 1: bare \" in non-quoted-field"
         ],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 5,
         "linesRejected": 2,

--- a/dbmongo/lib/urssaf/testData/expectedDelai.json
+++ b/dbmongo/lib/urssaf/testData/expectedDelai.json
@@ -47,7 +47,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 3,
         "linesRejected": 0,

--- a/dbmongo/lib/urssaf/testData/expectedEffectif.json
+++ b/dbmongo/lib/urssaf/testData/expectedEffectif.json
@@ -1583,7 +1583,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 3,
         "linesRejected": 0,

--- a/dbmongo/lib/urssaf/testData/expectedEffectifEnt.json
+++ b/dbmongo/lib/urssaf/testData/expectedEffectifEnt.json
@@ -1268,7 +1268,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 3,
         "linesRejected": 0,

--- a/dbmongo/lib/urssaf/testData/expectedProcol.json
+++ b/dbmongo/lib/urssaf/testData/expectedProcol.json
@@ -23,7 +23,6 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [],
-        "headSkipped": [],
         "isFatal": false,
         "linesParsed": 3,
         "linesRejected": 0,

--- a/tests/output-snapshots/test-api-check.golden.txt
+++ b/tests/output-snapshots/test-api-check.golden.txt
@@ -2,7 +2,7 @@
 [
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [
 				"Cycle 1: record on line 3: wrong number of fields",
 				"Cycle 3: parse error on line 5, column 1: bare \" in non-quoted-field"

--- a/tests/output-snapshots/test-api-check.golden.txt
+++ b/tests/output-snapshots/test-api-check.golden.txt
@@ -2,12 +2,12 @@
 [
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [
 				"Cycle 1: record on line 3: wrong number of fields",
 				"Cycle 3: parse error on line 5, column 1: bare \" in non-quoted-field"
 			],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/urssaf/testData/debitCorrompuTestData.csv: intégration terminée, 5 lignes traitées, 0 erreurs fatales, 2 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},

--- a/tests/output-snapshots/test-api-import.golden.txt
+++ b/tests/output-snapshots/test-api-import.golden.txt
@@ -4940,7 +4940,6 @@
 [
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [
 				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-01-01 00:00:00 +0000 UTC",
 				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-02-01 00:00:00 +0000 UTC",
@@ -4967,6 +4966,7 @@
 				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-11-01 00:00:00 +0000 UTC"
 			],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/urssaf/testData/comptesTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 1 lignes rejetées, 0 lignes filtrées, 2 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -4975,9 +4975,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/apconso/testData/apconsoTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -4986,9 +4986,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/apdemande/testData/apdemandeTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -4997,9 +4997,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/bdf/testData/bdfTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5008,9 +5008,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/urssaf/testData/ccsfTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5019,9 +5019,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/urssaf/testData/cotisationTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5030,9 +5030,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/urssaf/testData/debitTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5041,9 +5041,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 1,
 			"summary" : "/../lib/urssaf/testData/delaiTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 1 lignes filtrées, 2 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5052,9 +5052,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/diane/testData/dianeTestData.txt: intégration terminée, 18 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 18 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5063,9 +5063,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/urssaf/testData/effectifTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5074,9 +5074,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/urssaf/testData/effectifEntTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5085,11 +5085,11 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [
 				"Cycle 0: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
 			],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/ellisphere/testData/ellisphereTestData.excel: intégration terminée, 7 lignes traitées, 0 erreurs fatales, 1 lignes rejetées, 0 lignes filtrées, 6 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5098,9 +5098,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/urssaf/testData/procolTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5109,11 +5109,11 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [
 				"Cycle 1: parsing time \"\" as \"2006-01-02\": cannot parse \"\" as \"2006\""
 			],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/sirene/testData/sireneTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 1 lignes rejetées, 0 lignes filtrées, 2 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5122,9 +5122,9 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
+			"linesSkipped" : 0,
 			"summary" : "/../lib/sirene_ul/testData/sireneULTestData.csv: intégration terminée, 4 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 4 lignes valides",
 			"batchKey" : "1910"
 		},

--- a/tests/output-snapshots/test-api-import.golden.txt
+++ b/tests/output-snapshots/test-api-import.golden.txt
@@ -4940,7 +4940,7 @@
 [
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [
 				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-01-01 00:00:00 +0000 UTC",
 				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-02-01 00:00:00 +0000 UTC",
@@ -4975,7 +4975,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/apconso/testData/apconsoTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
@@ -4986,7 +4986,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/apdemande/testData/apdemandeTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
@@ -4997,7 +4997,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/bdf/testData/bdfTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
@@ -5008,7 +5008,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/urssaf/testData/ccsfTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
@@ -5019,7 +5019,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/urssaf/testData/cotisationTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
@@ -5030,7 +5030,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/urssaf/testData/debitTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
@@ -5041,9 +5041,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [
-				"Cycle 2: "
-			],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/urssaf/testData/delaiTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 1 lignes filtrées, 2 lignes valides",
@@ -5054,7 +5052,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/diane/testData/dianeTestData.txt: intégration terminée, 18 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 18 lignes valides",
@@ -5065,7 +5063,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/urssaf/testData/effectifTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
@@ -5076,7 +5074,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/urssaf/testData/effectifEntTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
@@ -5087,7 +5085,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [
 				"Cycle 0: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
 			],
@@ -5100,7 +5098,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/urssaf/testData/procolTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
@@ -5111,7 +5109,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [
 				"Cycle 1: parsing time \"\" as \"2006-01-02\": cannot parse \"\" as \"2006\""
 			],
@@ -5124,7 +5122,7 @@
 	},
 	{
 		"event" : {
-			"headSkipped" : [ ],
+			"headSkipped" : undefined,
 			"headRejected" : [ ],
 			"headFatal" : [ ],
 			"summary" : "/../lib/sirene_ul/testData/sireneULTestData.csv: intégration terminée, 4 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 4 lignes valides",

--- a/tests/output-snapshots/test-api-import.golden.txt
+++ b/tests/output-snapshots/test-api-import.golden.txt
@@ -5042,7 +5042,7 @@
 	{
 		"event" : {
 			"headSkipped" : [
-				"Cycle 2: Pas de siret associé au compte 450359886246036238 à la période 2019-01-23 00:00:00 +0000 UTC"
+				"Cycle 2: "
 			],
 			"headRejected" : [ ],
 			"headFatal" : [ ],

--- a/tests/test-api-check.sh
+++ b/tests/test-api-check.sh
@@ -63,9 +63,9 @@ print("// Documents from db.Journal:");
 printjson(db.Journal.find().toArray().map(doc => ({
   // note: we use map() to force the order of properties at every run of this test
   event: {
-    headSkipped: doc.event.headSkipped,
     headRejected: doc.event.headRejected,
     headFatal: doc.event.headFatal,
+    linesSkipped: doc.event.linesSkipped,
     summary: doc.event.summary,
     batchKey: doc.event.batchKey
   },

--- a/tests/test-api-import.sh
+++ b/tests/test-api-import.sh
@@ -97,9 +97,9 @@ print("// Reports from db.Journal:");
 // on classe les données par type, de manière à ce que l'ordre soit stable
 printjson(db.Journal.find().sort({ parserCode: 1 }).toArray().map(doc => ({
   event: {
-    headSkipped: doc.event.headSkipped,
     headRejected: doc.event.headRejected,
     headFatal: doc.event.headFatal,
+    linesSkipped: doc.event.linesSkipped,
     summary: doc.event.summary,
     batchKey: doc.event.batchKey
   },


### PR DESCRIPTION
Fix #210.

## Changements apportés

- Pour réduire la consommation mémoire de l'import, en cas de filtrage _agressif_: ne pas plus stocker de message d'erreur pour chaque ligne ignorée (cf tableau `headFilter` du rapport gournal)
- Bonus: ajout et réécriture de quelques tests liés au parsing
- Bonus: simplification de code redondant détecté par le linter.
