### PR TITLE
fix: Économiser la mémoire de stockage d'erreurs de parsing

### DIFF
--- a/dbmongo/go.mod
+++ b/dbmongo/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/gin-gonic/gin v1.6.2
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/pkg/errors v0.8.1
-	github.com/signaux-faibles/gournal v0.0.0-20201001084617-2ef7eb62eefe
 	github.com/spf13/viper v1.6.3
 	github.com/stretchr/testify v1.4.0
 	github.com/swaggo/gin-swagger v1.2.0

--- a/dbmongo/go.sum
+++ b/dbmongo/go.sum
@@ -177,8 +177,6 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/shabbyrobe/xmlwriter v0.0.0-20200208144257-9fca06d00ffa h1:2cO3RojjYl3hVTbEvJVqrMaFmORhL6O06qdW42toftk=
 github.com/shabbyrobe/xmlwriter v0.0.0-20200208144257-9fca06d00ffa/go.mod h1:Yjr3bdWaVWyME1kha7X0jsz3k2DgXNa1Pj3XGyUAbx8=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/signaux-faibles/gournal v0.0.0-20201001084617-2ef7eb62eefe h1:Hbg30lLVkVy3LHkvc4qLsgxL+4wXUW8Zg1PLnRp1UG8=
-github.com/signaux-faibles/gournal v0.0.0-20201001084617-2ef7eb62eefe/go.mod h1:x7m2yWqJu2K2oKL1QPmiBxBIPorLtnnjPQ8GMVcK+hA=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=

--- a/dbmongo/lib/base/errors.go
+++ b/dbmongo/lib/base/errors.go
@@ -36,7 +36,7 @@ func newCriticError(err error, criticity string) CriticityError {
 
 // NewFilterError returns a filter error (occurs when something goes wrong while filtering)
 func NewFilterError() CriticityError {
-	return newCriticError(errors.New(""), "filter")
+	return newCriticError(errors.New("(filtered)"), "filter")
 }
 
 // NewRegularError creates a regular error

--- a/dbmongo/lib/ellisphere/testData/expectedEllisphere.json
+++ b/dbmongo/lib/ellisphere/testData/expectedEllisphere.json
@@ -83,7 +83,7 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [
-          "Line 8: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
+          "Line 1: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
         ],
         "isFatal": false,
         "linesParsed": 7,

--- a/dbmongo/lib/ellisphere/testData/expectedEllisphere.json
+++ b/dbmongo/lib/ellisphere/testData/expectedEllisphere.json
@@ -83,7 +83,7 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [
-          "Cycle 0: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
+          "Line 8: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
         ],
         "isFatal": false,
         "linesParsed": 7,

--- a/dbmongo/lib/marshal/tracker.go
+++ b/dbmongo/lib/marshal/tracker.go
@@ -20,7 +20,7 @@ type parseError struct {
 type ParsingTracker struct {
 	filePath       string
 	batchKey       string
-	currentLine    int
+	currentLine    int // Note: line 1 is the first line of data (excluding the header) read from a file
 	nbSkippedLines int
 	fatalErrors    []error
 	parseErrors    []parseError

--- a/dbmongo/lib/marshal/tracker.go
+++ b/dbmongo/lib/marshal/tracker.go
@@ -33,7 +33,7 @@ func (tracker *ParsingTracker) Add(err base.CriticityError) {
 	} else if err.Criticity() == "filter" {
 		// TODO: make sure that we never add more than 1 filter error per line
 		tracker.nbSkippedLines++
-		fmt.Fprintf(os.Stderr, "Line %d: %v", tracker.currentLine, err.Error())
+		fmt.Fprintf(os.Stderr, "Line %d: %v\n", tracker.currentLine, err.Error())
 	} else {
 		tracker.parseErrors = append(tracker.parseErrors, parseError{
 			line: tracker.currentLine,

--- a/dbmongo/lib/marshal/tracker.go
+++ b/dbmongo/lib/marshal/tracker.go
@@ -54,7 +54,7 @@ func (tracker *ParsingTracker) Report(code string) interface{} {
 	var headFatal = []string{}
 	for _, err := range tracker.fatalErrors {
 		if len(headFatal) < MaxParsingErrors {
-			rendered := fmt.Sprintf("Line %d: %v", tracker.currentLine, err.Error())
+			rendered := fmt.Sprintf("Fatal: %v", err.Error())
 			headFatal = append(headFatal, rendered)
 		}
 	}
@@ -67,7 +67,7 @@ func (tracker *ParsingTracker) Report(code string) interface{} {
 			lastLineWithError = err.line
 		}
 		if len(headRejected) < MaxParsingErrors {
-			rendered := fmt.Sprintf("Line %d: %v", tracker.currentLine, err.err.Error())
+			rendered := fmt.Sprintf("Line %d: %v", err.line, err.err.Error())
 			headRejected = append(headRejected, rendered)
 		}
 	}

--- a/dbmongo/lib/marshal/tracker.go
+++ b/dbmongo/lib/marshal/tracker.go
@@ -2,125 +2,92 @@ package marshal
 
 import (
 	"fmt"
-	"sort"
+	"os"
 
 	"github.com/globalsign/mgo/bson"
-	"github.com/signaux-faibles/gournal"
 	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/base"
 )
 
 // MaxParsingErrors is the number of parsing errors to report per file.
 var MaxParsingErrors = 200
 
+type parseError struct {
+	cycle int
+	err   error
+}
+
 // ParsingTracker permet de collecter puis rapporter des erreurs de parsing.
 type ParsingTracker struct {
-	gournalTracker gournal.Tracker
+	filePath       string
+	batchKey       string
+	currentCycle   int
+	nbSkippedLines int
+	fatalErrors    []error
+	parseErrors    []parseError
 }
 
 // Add rapporte une erreur de parsing à la ligne en cours.
 func (tracker *ParsingTracker) Add(err base.CriticityError) {
-	tracker.gournalTracker.Add(err)
+	if err.Criticity() == "fatal" {
+		tracker.fatalErrors = append(tracker.fatalErrors, err)
+	} else if err.Criticity() == "filter" {
+		// TODO: make sure that we never add more than 1 filter error per line/cycle
+		tracker.nbSkippedLines++
+		fmt.Fprintf(os.Stderr, "Cycle %d: %v", tracker.currentCycle, err.Error())
+	} else {
+		tracker.parseErrors = append(tracker.parseErrors, parseError{
+			cycle: tracker.currentCycle,
+			err:   err,
+		})
+	}
 }
 
 // Next informe le Tracker qu'on passe à la ligne suivante.
 func (tracker *ParsingTracker) Next() {
-	tracker.gournalTracker.Next()
+	tracker.currentCycle++
 }
 
 // Report génère un rapport de parsing à partir des erreurs rapportées.
 func (tracker *ParsingTracker) Report(code string) interface{} {
-	return tracker.gournalTracker.Report(code)
+	var nbRejectedLines = 0
+
+	var lastCycleWithError = -1
+	for cycle, err := range tracker.parseErrors {
+		if err.cycle != lastCycleWithError {
+			nbRejectedLines++
+			lastCycleWithError = cycle
+		}
+	}
+
+	nbValidLines := tracker.currentCycle - nbRejectedLines - tracker.nbSkippedLines
+
+	report := fmt.Sprintf(
+		"%s: intégration terminée, %d lignes traitées, %d erreurs fatales, %d lignes rejetées, %d lignes filtrées, %d lignes valides",
+		tracker.filePath,
+		tracker.currentCycle,
+		len(tracker.fatalErrors),
+		nbRejectedLines,
+		tracker.nbSkippedLines,
+		nbValidLines,
+	)
+
+	return bson.M{
+		"batchKey":      tracker.batchKey,
+		"summary":       report,
+		"linesParsed":   tracker.currentCycle,
+		"linesValid":    nbValidLines,
+		"linesSkipped":  tracker.nbSkippedLines,
+		"linesRejected": nbRejectedLines,
+		"isFatal":       len(tracker.fatalErrors) > 0,
+		"headRejected":  tracker.parseErrors,
+		"headFatal":     tracker.fatalErrors,
+	}
 }
 
 // NewParsingTracker retourne une instance pour rapporter les erreurs de parsing.
 func NewParsingTracker(batchKey string, filePath string) ParsingTracker {
-	// fonctions de reporting du moteur
-	trackerReports := map[string]gournal.ReportFunction{
-		"abstract": reportAbstract,
-	}
-	context := map[string]string{
-		"path":     filePath,
-		"batchKey": batchKey,
-	}
 	return ParsingTracker{
-		gournalTracker: gournal.NewTracker(context, trackerReports),
-	}
-}
-
-func reportAbstract(tracker gournal.Tracker) interface{} {
-
-	var nError = 0
-	var nFiltered = 0
-	var nFatal = 0
-
-	var fatalErrors = []string{}
-	var filterErrors = []string{}
-	var errorErrors = []string{}
-
-	// En Golang, l'ordre des clés d'un map n'est pas garanti. (https://blog.golang.org/maps)
-	// => On ordonne les erreurs par numéro de cycle, pour permettre la reproductibilité.
-	// cf https://github.com/signaux-faibles/opensignauxfaibles/issues/181
-	var cycles []int
-	for cycle := range tracker.Errors {
-		cycles = append(cycles, cycle)
-	}
-	sort.Ints(cycles)
-
-	// pour chaque cycle qui a au moins une erreur
-	for _, cycle := range cycles {
-		var lineRejected = false
-		// pour chaque erreur du cycle
-		cycleErrors := tracker.Errors[cycle]
-		for _, err := range cycleErrors {
-			switch err.(base.CriticityError).Criticity() {
-			case "fatal":
-				nFatal++
-				if len(fatalErrors) < MaxParsingErrors {
-					fatalErrors = append(fatalErrors, fmt.Sprintf("Cycle %d: %v", cycle, err))
-				}
-			case "error":
-				lineRejected = true
-				if len(errorErrors) < MaxParsingErrors {
-					errorErrors = append(errorErrors, fmt.Sprintf("Cycle %d: %v", cycle, err))
-				}
-			case "filter":
-				nFiltered++
-				if len(filterErrors) < MaxParsingErrors {
-					filterErrors = append(filterErrors, fmt.Sprintf("Cycle %d: %v", cycle, err))
-				}
-			}
-		}
-		if lineRejected {
-			nError++
-		}
-	}
-
-	var nValid int
-	if nFatal > 0 {
-		nValid = 0
-	} else {
-		nValid = tracker.Count - nError - nFiltered
-	}
-
-	report := fmt.Sprintf(
-		"%s: intégration terminée, %d lignes traitées, %d erreurs fatales, %d lignes rejetées, %d lignes filtrées, %d lignes valides",
-		tracker.Context["path"],
-		tracker.Count,
-		nFatal,
-		nError,
-		nFiltered,
-		nValid,
-	)
-
-	return bson.M{
-		"batchKey":      tracker.Context["batchKey"],
-		"summary":       report,
-		"linesParsed":   tracker.Count,
-		"linesValid":    nValid,
-		"linesSkipped":  nFiltered,
-		"linesRejected": nError,
-		"isFatal":       nFatal > 0,
-		"headRejected":  errorErrors,
-		"headFatal":     fatalErrors,
+		filePath: filePath,
+		batchKey: batchKey,
 	}
 }

--- a/dbmongo/lib/marshal/tracker.go
+++ b/dbmongo/lib/marshal/tracker.go
@@ -51,11 +51,24 @@ func (tracker *ParsingTracker) Next() {
 func (tracker *ParsingTracker) Report(code string) interface{} {
 	var nbRejectedLines = 0
 
+	var headFatal = []string{}
+	for _, err := range tracker.fatalErrors {
+		if len(headFatal) < MaxParsingErrors {
+			rendered := fmt.Sprintf("Cycle %d: %v", tracker.currentCycle, err.Error())
+			headFatal = append(headFatal, rendered)
+		}
+	}
+
+	var headRejected = []string{}
 	var lastCycleWithError = -1
-	for cycle, err := range tracker.parseErrors {
+	for _, err := range tracker.parseErrors {
 		if err.cycle != lastCycleWithError {
 			nbRejectedLines++
-			lastCycleWithError = cycle
+			lastCycleWithError = err.cycle
+		}
+		if len(headRejected) < MaxParsingErrors {
+			rendered := fmt.Sprintf("Cycle %d: %v", tracker.currentCycle, err.err.Error())
+			headRejected = append(headRejected, rendered)
 		}
 	}
 
@@ -79,8 +92,8 @@ func (tracker *ParsingTracker) Report(code string) interface{} {
 		"linesSkipped":  tracker.nbSkippedLines,
 		"linesRejected": nbRejectedLines,
 		"isFatal":       len(tracker.fatalErrors) > 0,
-		"headRejected":  tracker.parseErrors,
-		"headFatal":     tracker.fatalErrors,
+		"headRejected":  headRejected,
+		"headFatal":     headFatal,
 	}
 }
 

--- a/dbmongo/lib/sirene/testData/expectedSirene.json
+++ b/dbmongo/lib/sirene/testData/expectedSirene.json
@@ -56,7 +56,7 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [
-          "Line 4: parsing time \"\" as \"2006-01-02\": cannot parse \"\" as \"2006\""
+          "Line 2: parsing time \"\" as \"2006-01-02\": cannot parse \"\" as \"2006\""
         ],
         "isFatal": false,
         "linesParsed": 3,

--- a/dbmongo/lib/sirene/testData/expectedSirene.json
+++ b/dbmongo/lib/sirene/testData/expectedSirene.json
@@ -56,7 +56,7 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [
-          "Cycle 1: parsing time \"\" as \"2006-01-02\": cannot parse \"\" as \"2006\""
+          "Line 4: parsing time \"\" as \"2006-01-02\": cannot parse \"\" as \"2006\""
         ],
         "isFatal": false,
         "linesParsed": 3,

--- a/dbmongo/lib/urssaf/debit.go
+++ b/dbmongo/lib/urssaf/debit.go
@@ -118,8 +118,8 @@ func parseDebitColMapping(reader *csv.Reader) (colMapping, error) {
 }
 
 func (parser *debitParser) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
-	var lineNumber = 0 // starting with the header
-	stopProgressLogger := marshal.LogProgress(&lineNumber)
+	var lineNumber = 0                                     // starting with the header
+	stopProgressLogger := marshal.LogProgress(&lineNumber) // TODO: move this call to runParserWithSirenFilter()
 	defer stopProgressLogger()
 
 	for {

--- a/dbmongo/lib/urssaf/testData/expectedDebitCorrompu.json
+++ b/dbmongo/lib/urssaf/testData/expectedDebitCorrompu.json
@@ -59,8 +59,8 @@
         "batchKey": "",
         "headFatal": [],
         "headRejected": [
-          "Cycle 1: record on line 3: wrong number of fields",
-          "Cycle 3: parse error on line 5, column 1: bare \" in non-quoted-field"
+          "Line 2: record on line 3: wrong number of fields",
+          "Line 4: parse error on line 5, column 1: bare \" in non-quoted-field"
         ],
         "isFatal": false,
         "linesParsed": 5,

--- a/tests/output-snapshots/test-api-check.golden.txt
+++ b/tests/output-snapshots/test-api-check.golden.txt
@@ -3,8 +3,8 @@
 	{
 		"event" : {
 			"headRejected" : [
-				"Cycle 1: record on line 3: wrong number of fields",
-				"Cycle 3: parse error on line 5, column 1: bare \" in non-quoted-field"
+				"Line 2: record on line 3: wrong number of fields",
+				"Line 4: parse error on line 5, column 1: bare \" in non-quoted-field"
 			],
 			"headFatal" : [ ],
 			"linesSkipped" : 0,

--- a/tests/output-snapshots/test-api-import.golden.txt
+++ b/tests/output-snapshots/test-api-import.golden.txt
@@ -4941,29 +4941,29 @@
 	{
 		"event" : {
 			"headRejected" : [
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-01-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-02-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-03-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-04-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-05-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-06-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-07-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-08-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-09-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-10-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-11-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2019-12-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-01-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-02-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-03-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-04-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-05-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-06-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-07-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-08-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-09-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-10-01 00:00:00 +0000 UTC",
-				"Cycle 1: Pas de siret associé au compte 450359886246036238 à la période 2020-11-01 00:00:00 +0000 UTC"
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-01-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-02-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-03-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-04-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-05-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-06-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-07-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-08-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-09-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-10-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-11-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-12-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2020-01-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2020-02-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2020-03-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2020-04-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2020-05-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2020-06-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2020-07-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2020-08-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2020-09-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2020-10-01 00:00:00 +0000 UTC",
+				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2020-11-01 00:00:00 +0000 UTC"
 			],
 			"headFatal" : [ ],
 			"linesSkipped" : 0,
@@ -5086,7 +5086,7 @@
 	{
 		"event" : {
 			"headRejected" : [
-				"Cycle 0: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
+				"Line 1: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
 			],
 			"headFatal" : [ ],
 			"linesSkipped" : 0,
@@ -5110,7 +5110,7 @@
 	{
 		"event" : {
 			"headRejected" : [
-				"Cycle 1: parsing time \"\" as \"2006-01-02\": cannot parse \"\" as \"2006\""
+				"Line 2: parsing time \"\" as \"2006-01-02\": cannot parse \"\" as \"2006\""
 			],
 			"headFatal" : [ ],
 			"linesSkipped" : 0,


### PR DESCRIPTION
## Problème

Un import de données volumineuses (fichiers stock URSSAF) a échoué en production à cause d'un manque de mémoire.

L'analyse effectuée par Christophe a montré que `gournal` occupait plusieurs GO de RAM pendant l'import des fichiers.

## Solutions proposées

- Afficher les avertissements liés au filtrage, au lieu de les stocker en mémoire.
- => Remplacement de `gournal` par un tracker interne.
- Bonus: afficher `Line x: ...` au lieu de `Cycle x: ...` dans le logs du Journal
- => Mise à jour des golden files

## Prochaines étapes proposées

- Ne stocker que les 200 premières erreurs de parsing, au lieu de les sélectionner en fin de parsing.
- Simplification/refactoring: supprimer `lib/base/errors.go` => remplacer les fonctions `NewXxxError()` par des méthodes `AddXxxError()` au sein du `tracker`
- Puis faire en sorte qu'il soit impossible de déclarer plus d'une erreur/avertissement de filtrage par line.