### PR TITLE
feat(api): Comptage et suppression d'entités qui auraient du être filtrées

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,8 @@ jobs:
           sudo apt-get install -y httpie
           sudo apt-get install git-secret # to decrypt golden master files, for tests
 
+      - run: ./tests/test-api-prune-entities.sh
+
       - run: ./tests/test-api.sh
 
       - run: ./tests/test-api-import.sh

--- a/dbmongo/handlers.go
+++ b/dbmongo/handlers.go
@@ -133,6 +133,26 @@ func purgeNotCompactedHandler(c *gin.Context) {
 	c.JSON(200, result)
 }
 
+// Count – then delete – companies from RawData that should have been
+// excluded by the SIREN Filter.
+func pruneEntitiesHandler(c *gin.Context) {
+	var params struct {
+		BatchKey string `json:"batch"`
+		// TODO: DeleteEntities bool     `json:"delete"`
+	}
+	err := c.ShouldBind(&params)
+	if err != nil {
+		c.JSON(400, "Requête malformée: "+err.Error())
+		return
+	}
+	count, err := engine.PruneEntities(params.BatchKey)
+	if err != nil {
+		c.JSON(500, err.Error())
+		return
+	}
+	c.JSON(200, bson.M{"count": count})
+}
+
 // RegisteredParsers liste des parsers disponibles
 var registeredParsers = map[string]marshal.Parser{
 	"debit":        urssaf.ParserDebit,

--- a/dbmongo/handlers.go
+++ b/dbmongo/handlers.go
@@ -138,14 +138,14 @@ func purgeNotCompactedHandler(c *gin.Context) {
 func pruneEntitiesHandler(c *gin.Context) {
 	var params struct {
 		BatchKey string `json:"batch"`
-		// TODO: DeleteEntities bool     `json:"delete"`
+		Delete   bool   `json:"delete"`
 	}
 	err := c.ShouldBind(&params)
 	if err != nil {
 		c.JSON(400, "Requête malformée: "+err.Error())
 		return
 	}
-	count, err := engine.PruneEntities(params.BatchKey)
+	count, err := engine.PruneEntities(params.BatchKey, params.Delete)
 	if err != nil {
 		c.JSON(500, err.Error())
 		return

--- a/dbmongo/lib/engine/data.go
+++ b/dbmongo/lib/engine/data.go
@@ -59,7 +59,7 @@ func PurgeNotCompacted() error {
 
 // PruneEntities permet de compter puis supprimer les entités de RawData
 // qui auraient du être exclues par le Filtre de périmètre SIREN.
-func PruneEntities(batchKey string) (int, error) {
+func PruneEntities(batchKey string, delete bool) (int, error) {
 	// Récupérer le batch
 	batch := base.AdminBatch{}
 	err := Load(&batch, batchKey)
@@ -84,6 +84,10 @@ func PruneEntities(batchKey string) (int, error) {
 	// Compter les entités de RawData qui ne figurent pas dans le filtre
 	query := bson.M{"_id": bson.M{"$not": bson.M{"$regex": perimeterRegex}}}
 	count, err := Db.DB.C("RawData").Find(query).Count()
+	// Éventuellement, supprimer ces entités
+	if delete == true && err == nil {
+		_, err = Db.DB.C("RawData").RemoveAll(query)
+	}
 	return count, err
 }
 

--- a/dbmongo/lib/engine/data.go
+++ b/dbmongo/lib/engine/data.go
@@ -94,6 +94,7 @@ func PruneEntities(batchKey string, delete bool) (int, error) {
 		},
 		{
 			"$project": bson.M{
+				"_id":   true,
 				"siren": false,
 			},
 		},

--- a/dbmongo/lib/engine/data.go
+++ b/dbmongo/lib/engine/data.go
@@ -103,17 +103,10 @@ func PruneEntities(batchKey string, delete bool) (int, error) {
 	if delete == true {
 		// Enregistrer la liste d'entités dans la collection temporaire "EntitiesToPrune"
 		tmpCollection := "EntitiesToPrune"
+		pipeline = append(pipeline, bson.M{"$out": tmpCollection})
 		iterator := Db.DB.C("RawData").Pipe(pipeline).AllowDiskUse().Iter()
 		var item struct {
 			ID string `json:"id"   bson:"_id"`
-		}
-		for iterator.Next(&item) {
-			if err := iterator.Err(); err != nil {
-				return -1, err
-			}
-			if err = Db.DB.C(tmpCollection).Insert(bson.M{"_id": item.ID}); err != nil {
-				return -1, err
-			}
 		}
 		// Supprimer les entités en itérant sur "EntitiesToPrune"
 		var nbDeleted = 0

--- a/dbmongo/main.go
+++ b/dbmongo/main.go
@@ -59,6 +59,7 @@ func main() {
 		api.POST("/data/compact", compactHandler)
 		api.POST("/data/reduce", reduceHandler)
 		api.POST("/data/public", publicHandler)
+		api.POST("/data/pruneEntities", pruneEntitiesHandler)
 
 		api.GET("/data/purgeNotCompacted", purgeNotCompactedHandler)
 

--- a/test-all.sh
+++ b/test-all.sh
@@ -48,6 +48,9 @@ heading "go generate"
 heading "go build"
 (killall dbmongo 2>/dev/null || true; cd ./dbmongo && go build && echo "📦 dbmongo/dbmongo") 2>&1 | indent
 
+heading "test-api-prune-entities.sh"
+./tests/test-api-prune-entities.sh $@ 2>&1 | indent
+
 heading "test-api.sh"
 ./tests/test-api.sh $@ 2>&1 | indent
 

--- a/tests/test-api-prune-entities.sh
+++ b/tests/test-api-prune-entities.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Test de bout en bout de l'API "/data/pruneEntities". Inspiré de test-api-purge-batch.sh.
+# Ce script doit être exécuté depuis la racine du projet. Ex: par test-all.sh.
+
+tests/helpers/mongodb-container.sh stop
+
+set -e # will stop the script if any command fails with a non-zero exit code
+
+# Setup
+TMP_DIR="tests/tmp-test-execution-files"
+FILTER_FILE="${TMP_DIR}/test-api-prune-entities.filter.csv"
+mkdir -p "${TMP_DIR}"
+
+# Clean up on exit
+function teardown {
+    tests/helpers/dbmongo-server.sh stop || true # keep tearing down, even if "No matching processes belonging to you were found"
+    tests/helpers/mongodb-container.sh stop
+}
+trap teardown EXIT
+
+PORT="27016" tests/helpers/mongodb-container.sh start
+
+MONGODB_PORT="27016" tests/helpers/dbmongo-server.sh setup
+
+echo ""
+echo "📝 Inserting test data..."
+sleep 1 # give some time for MongoDB to start
+echo "222222222" > "${FILTER_FILE}"
+tests/helpers/mongodb-container.sh run >/dev/null << CONTENT
+  db.RawData.insertMany([
+    {
+      _id: "111111111",
+      value: { key: "111111111", scope: "entreprise", batch: { "2007": {} } },
+    },
+    {
+      _id: "11111111100000",
+      value: { key: "11111111100000", scope: "etablissement", batch: { "2007": {} } },
+    },
+    {
+      _id: "222222222",
+      value: { key: "222222222", scope: "entreprise", batch: { "2007": {} } },
+    },
+    {
+      _id: "22222222200000",
+      value: { key: "22222222200000", scope: "etablissement", batch: { "2007": {} } },
+    },
+    {
+      _id: "333333333",
+      value: { key: "333333333", scope: "entreprise", batch: { "2007": {} } },
+    },
+  ]);
+  db.Admin.insertOne({
+    _id: { key: "2010", type: "batch" },
+    files: {
+      filter: [ "/../../${FILTER_FILE}" ],
+    },
+  });
+CONTENT
+
+echo ""
+echo "💎 Test: count and prune entities from RawData..."
+tests/helpers/dbmongo-server.sh start
+COUNT=$(http --print=b --ignore-stdin :5000/api/data/pruneEntities batch=2010)
+echo "- POST /api/data/pruneEntities 👉 count: ${COUNT} (expected: 3)"
+echo "- POST /api/data/pruneEntities delete=true 👉 $(http --print=b --ignore-stdin :5000/api/data/pruneEntities batch=2010 delete=true)"
+
+# Display JS errors logged by MongoDB, if any
+tests/helpers/mongodb-container.sh exceptions || true
+
+function test {
+  RESULT=$(tests/helpers/mongodb-container.sh run <<< "print('$1:', $2)")
+  (grep --color=always 'false' <<< "${RESULT}") || true # will display test if it contains 'false'
+  grep 'true' <<< "${RESULT}" # test will fail if result does not contain 'true'
+}
+
+test "222222222 was not pruned" 'db.RawData.find({_id: "222222222"}).count() === 1'
+test "22222222200000 was not pruned" 'db.RawData.find({_id: "22222222200000"}).count() === 1'
+test "111111111 was pruned" 'db.RawData.find({_id: "111111111"}).count() === 0'
+test "11111111100000 was pruned" 'db.RawData.find({_id: "11111111100000"}).count() === 0'
+test "333333333 was pruned" 'db.RawData.find({_id: "333333333"}).count() === 0'
+
+rm -rf "${TMP_DIR}"
+# Now, the "trap" commands will clean up the rest.

--- a/tests/test-api-prune-entities.sh
+++ b/tests/test-api-prune-entities.sh
@@ -26,7 +26,8 @@ MONGODB_PORT="27016" tests/helpers/dbmongo-server.sh setup
 echo ""
 echo "📝 Inserting test data..."
 sleep 1 # give some time for MongoDB to start
-echo "222222222" > "${FILTER_FILE}"
+echo "333333333" > "${FILTER_FILE}"
+echo "111111111" >> "${FILTER_FILE}"
 tests/helpers/mongodb-container.sh run >/dev/null << CONTENT
   db.RawData.insertMany([
     {
@@ -62,7 +63,7 @@ echo ""
 echo "💎 Test: count and prune entities from RawData..."
 tests/helpers/dbmongo-server.sh start
 COUNT=$(http --print=b --ignore-stdin :5000/api/data/pruneEntities batch=2010)
-echo "- POST /api/data/pruneEntities 👉 count: ${COUNT} (expected: 3)"
+echo "- POST /api/data/pruneEntities 👉 count: ${COUNT} (expected: 2)"
 echo "- POST /api/data/pruneEntities delete=true 👉 $(http --print=b --ignore-stdin :5000/api/data/pruneEntities batch=2010 delete=true)"
 
 # Display JS errors logged by MongoDB, if any
@@ -74,11 +75,11 @@ function test {
   grep 'true' <<< "${RESULT}" # test will fail if result does not contain 'true'
 }
 
-test "222222222 was not pruned" 'db.RawData.find({_id: "222222222"}).count() === 1'
-test "22222222200000 was not pruned" 'db.RawData.find({_id: "22222222200000"}).count() === 1'
-test "111111111 was pruned" 'db.RawData.find({_id: "111111111"}).count() === 0'
-test "11111111100000 was pruned" 'db.RawData.find({_id: "11111111100000"}).count() === 0'
-test "333333333 was pruned" 'db.RawData.find({_id: "333333333"}).count() === 0'
+test "333333333 was not pruned" 'db.RawData.find({_id: "333333333"}).count() === 1'
+test "111111111 was not pruned" 'db.RawData.find({_id: "111111111"}).count() === 1'
+test "11111111100000 was not pruned" 'db.RawData.find({_id: "11111111100000"}).count() === 1'
+test "222222222 was pruned" 'db.RawData.find({_id: "222222222"}).count() === 0'
+test "22222222200000 was pruned" 'db.RawData.find({_id: "22222222200000"}).count() === 0'
 
 rm -rf "${TMP_DIR}"
 # Now, the "trap" commands will clean up the rest.


### PR DESCRIPTION
Contribue à #199.

## Changements apportés

La route `POST /api/data/pruneEntities` compte puis supprime dans la collection `RawData` les entités (établissements et entreprises) non listés dans le filtre de périmètre du batch spécifié.

## Exemples d'appels

```sh
http :5000/api/data/pruneEntities batch=2010 # dry-run, pour compter les entités à supprimer
http :5000/api/data/pruneEntities batch=2010 delete:=true
```

## Test

```sh
(cd dbmongo && go build) && tests/test-api-prune-entities.sh
```