### PR TITLE
fix(logsReport): Ordre chronologique dans les graphiques

### DIFF
--- a/tools/logsReport/make_report.Rmd
+++ b/tools/logsReport/make_report.Rmd
@@ -12,9 +12,9 @@ params:
   include_fatal: FALSE
   interactive: FALSE
   mongo_collection: "Journal"
-  mongo_db: "test"
   mongo_url: "mongodb://labbdd"
   debug_mode: FALSE
+  mongo_db: "prod"
 ---
 
 ```{css, echo=FALSE}
@@ -56,7 +56,7 @@ journal$info()
 
 ```{r read-data, echo=params$debug_mode}
 query = sprintf('{"date": { "$gte" : { "$date" :  "%s"}}}', params$startdate) #TODO: filter on parser here instead of within dplyr (?)
-dta = journal$find(query)
+dta = journal$find(query, sort = '{"date": 1}')
 
 # create logs dataset
 logs <- dta %>%
@@ -116,7 +116,7 @@ last_imports %>%
 
 df_for_plotting <- logs %>% 
   gather(key = "data", value = "value", c("n_lignes_traitees", "n_lignes_valides", "n_lignes_rejetees", "n_lignes_filtrees")) %>% 
-  mutate(batch_unique = paste0(batch, as.character(date)))
+  mutate(batch_unique = sprintf("%s \n (%s)", as.character(date), batch))
 
 new_factor_order <- c("n_lignes_traitees", "n_lignes_valides", "n_lignes_filtrees", "n_lignes_rejetees")
 


### PR DESCRIPTION
Règle une des anomalies observées dans https://github.com/signaux-faibles/opensignauxfaibles/issues/248#issuecomment-738039462.

## Problème

Les données représentées sur les graphiques de `logsReport` (tableau de bord des résultats d'import de données) n'étaient pas rangées dans l'ordre chronologique, à cause du préfixage des dates par le nom du batch.

## Solution proposée

- Spécifier l'ordre au moment de la requête `find`
- Passage du batch en suffixe, pour que `ggplot` se base bien sur la date (en début de chaine de caractères) pour effectuer son tri.

## Avant

![image](https://user-images.githubusercontent.com/531781/101371844-852fd680-38ab-11eb-8cad-593d2e17e7fc.png)

## Après

![image](https://user-images.githubusercontent.com/531781/101371871-8a8d2100-38ab-11eb-8f6e-637d688713b7.png)
