### PR TITLE
fix(urssaf): Erreur "siret invalide" rapportée sur ligne hors mapping URSSAF

### DIFF
--- a/dbmongo/lib/marshal/mapping_test.go
+++ b/dbmongo/lib/marshal/mapping_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/base"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetSiret(t *testing.T) {
@@ -176,4 +177,26 @@ func TestGetCompteSiretMapping(t *testing.T) {
 			t.Fatalf("getSiretMapping failed test %d", ind)
 		}
 	}
+}
+
+func TestGetSiretFromComptesMapping(t *testing.T) {
+	t.Run("doit retourner une erreur si un compte n'est pas associé à un numéro de SIRET, à la date d'aujourd'hui", func(t *testing.T) {
+		comptes := MockComptesMapping(map[string]string{})
+		compteManquant := "636043216536562844"
+		// test
+		date := time.Now()
+		siret, err := GetSiretFromComptesMapping(compteManquant, &date, comptes)
+		assert.Equal(t, "", siret)
+		assert.Equal(t, "Pas de siret associé au compte "+compteManquant+" à la période "+date.String(), err.Error())
+	})
+
+	t.Run("doit retourner une erreur si un compte n'est pas associé à un numéro de SIRET, à une date passée", func(t *testing.T) {
+		comptes := MockComptesMapping(map[string]string{})
+		compteManquant := "636043216536562844"
+		// test
+		date := time.Time{}
+		siret, err := GetSiretFromComptesMapping(compteManquant, &date, comptes)
+		assert.Equal(t, "", siret)
+		assert.Equal(t, "Pas de siret associé au compte "+compteManquant+" à la période "+date.String(), err.Error())
+	})
 }

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -93,7 +93,7 @@ func runParserWithSirenFilter(parser Parser, filter *SirenFilter, filePath strin
 		for lineResult := range parsedLineChan {
 			filterError := lineResult.FilterError
 			if filterError != nil {
-				tracker.AddFilterError(filterError) // on rapporte le filtrage, même aucun tuple n'est transmis
+				tracker.AddFilterError(filterError) // on rapporte le filtrage même si aucun tuple n'est transmis par le parseur
 			}
 			for _, err := range lineResult.Errors {
 				tracker.AddParseError(err)

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -91,12 +91,15 @@ func runParserWithSirenFilter(parser Parser, filter *SirenFilter, filePath strin
 		parsedLineChan := make(chan ParsedLineResult)
 		go parser.ParseLines(parsedLineChan)
 		for lineResult := range parsedLineChan {
+			if lineResult.FilterError != nil {
+				tracker.AddFilterError(lineResult.FilterError) // on rapporte le filtrage, même aucun tuple n'est transmis
+			}
 			for _, err := range lineResult.Errors {
 				tracker.AddParseError(err)
 			}
 			for _, tuple := range lineResult.Tuples {
 				if lineResult.FilterError != nil {
-					tracker.AddFilterError(lineResult.FilterError)
+					continue // l'erreur de filtrage a déjà été rapportée => on se contente de passer au tuple suivant
 				} else if _, err := isValid(tuple); err != nil {
 					// Si le siret/siren est invalide, on jette le tuple,
 					// et on rapporte une erreur seulement si aucune n'a été

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -91,15 +91,13 @@ func runParserWithSirenFilter(parser Parser, filter *SirenFilter, filePath strin
 		parsedLineChan := make(chan ParsedLineResult)
 		go parser.ParseLines(parsedLineChan)
 		for lineResult := range parsedLineChan {
-			filterError := lineResult.FilterError
-			if filterError != nil {
-				tracker.AddFilterError(filterError)
-			}
 			for _, err := range lineResult.Errors {
 				tracker.AddParseError(err)
 			}
 			for _, tuple := range lineResult.Tuples {
-				if _, err := isValid(tuple); err != nil {
+				if lineResult.FilterError != nil {
+					tracker.AddFilterError(lineResult.FilterError)
+				} else if _, err := isValid(tuple); err != nil {
 					// Si le siret/siren est invalide, on jette le tuple,
 					// et on rapporte une erreur seulement si aucune n'a été
 					// rapportée par le parseur.

--- a/dbmongo/lib/marshal/parser.go
+++ b/dbmongo/lib/marshal/parser.go
@@ -91,14 +91,15 @@ func runParserWithSirenFilter(parser Parser, filter *SirenFilter, filePath strin
 		parsedLineChan := make(chan ParsedLineResult)
 		go parser.ParseLines(parsedLineChan)
 		for lineResult := range parsedLineChan {
-			if lineResult.FilterError != nil {
-				tracker.AddFilterError(lineResult.FilterError) // on rapporte le filtrage, même aucun tuple n'est transmis
+			filterError := lineResult.FilterError
+			if filterError != nil {
+				tracker.AddFilterError(filterError) // on rapporte le filtrage, même aucun tuple n'est transmis
 			}
 			for _, err := range lineResult.Errors {
 				tracker.AddParseError(err)
 			}
 			for _, tuple := range lineResult.Tuples {
-				if lineResult.FilterError != nil {
+				if filterError != nil {
 					continue // l'erreur de filtrage a déjà été rapportée => on se contente de passer au tuple suivant
 				} else if _, err := isValid(tuple); err != nil {
 					// Si le siret/siren est invalide, on jette le tuple,

--- a/dbmongo/lib/urssaf/urssaf_test.go
+++ b/dbmongo/lib/urssaf/urssaf_test.go
@@ -77,7 +77,6 @@ func TestCotisation(t *testing.T) {
 	var cache = makeCacheWithComptesMapping()
 	marshal.TestParserOutput(t, ParserCotisation, cache, testData, golden, *update)
 
-	// TODO: déplacer ce test dans un fichier marshal/parser_test.go ?
 	t.Run("toute ligne de cotisation d'un établissement hors périmètre doit être sautée silencieusement", func(t *testing.T) {
 		allowedSiren := "111111111" // SIREN correspondant à un des 3 comptes mentionnés dans le fichier testData
 		cache := makeCacheWithComptesMapping()
@@ -90,7 +89,6 @@ func TestCotisation(t *testing.T) {
 		assert.Equal(t, 1.0, reportData["linesValid"], "seule la ligne de cotisation liée à un établissement du périmètre doit être incluse")
 	})
 
-	// TODO: déplacer ce test dans un fichier marshal/parser_test.go ?
 	t.Run("toute ligne de cotisation d'un établissement non inclus dans les comptes urssaf doit être sautée silencieusement", func(t *testing.T) {
 		cache := marshal.NewCache()
 		cache.Set("comptes", marshal.MockComptesMapping(

--- a/dbmongo/lib/urssaf/urssaf_test.go
+++ b/dbmongo/lib/urssaf/urssaf_test.go
@@ -96,7 +96,7 @@ func TestCotisation(t *testing.T) {
 		cache.Set("comptes", marshal.MockComptesMapping(
 			map[string]string{
 				"111982477292496174": "00000000000000",
-				// "636043216536562844": "11111111111111",
+				// "636043216536562844": "11111111111111", // on retire volontairement ce mapping qui va être demandé par le parseur de cotisations
 				"450359886246036238": "22222222222222",
 			},
 		))
@@ -105,7 +105,7 @@ func TestCotisation(t *testing.T) {
 		reportData, _ := output.Events[0].ParseReport()
 		assert.Equal(t, false, reportData["isFatal"], "aucune erreur fatale ne doit être rapportée")
 		assert.Equal(t, []interface{}{}, reportData["headRejected"], "aucune erreur de parsing ne doit être rapportée")
-		assert.Equal(t, 1.0, reportData["linesValid"], "seule la ligne de cotisation liée à un établissement du périmètre doit être incluse")
+		assert.Equal(t, 1.0, reportData["linesSkipped"], "seule la ligne de cotisation liée à un établissement hors mapping doit être sautée")
 	})
 }
 


### PR DESCRIPTION
## Problème

Présence de lignes rejetées `siret invalide` dans le dernier journal d'import de `cotisation` (cf https://github.com/signaux-faibles/opensignauxfaibles/issues/248#issuecomment-738039462). Sachant que le SIRET en question est hors périmètre – et donc hors mapping de comptes URSSAF – l'entrée devrait être filtrée silencieusement, c.a.d. sans rapporter d'erreur de parsing comptée dans `nRejected` et `headRejected` du rapport de Journal.

## Modifications apportées

- `runParserWithSirenFilter()` ne rapportera pas d'erreur de parsing si la ligne a été rapportée comme étant _à filtrer_.
- ajout de tests unitaires pour parseur `cotisations` et `GetSiretFromComptesMapping()`