### PR TITLE
feat(reduce): Sauvegarde de Features avant (re)calcul des données

### DIFF
--- a/dbmongo/lib/engine/reduce.go
+++ b/dbmongo/lib/engine/reduce.go
@@ -141,9 +141,13 @@ func Reduce(batch base.AdminBatch, types []string) error {
 		{Name: "to", Value: viper.GetString("DB") + "." + backupColName},
 	}, res)
 	if err != nil {
-		return err
+		if err.Error() != "source namespace does not exist" {
+			return err
+		}
+		backupColName = ""
+	} else {
+		fmt.Fprintln(os.Stderr, "La collection Features actuelle a été sauvegardée dans: "+backupColName)
 	}
-	fmt.Fprintln(os.Stderr, "La collection Features actuelle a été sauvegardée dans: "+backupColName)
 
 	for _, dbTemp := range tempDBs {
 
@@ -172,7 +176,9 @@ func Reduce(batch base.AdminBatch, types []string) error {
 		return errors.New("erreurs constatées, consultez les journaux")
 	}
 
-	fmt.Fprintln(os.Stderr, "Vous pouvez supprimer la version précédente de la collection Features: "+backupColName)
+	if backupColName != "" {
+		fmt.Fprintln(os.Stderr, "Vous pouvez supprimer la version précédente de la collection Features: "+backupColName)
+	}
 
 	return nil
 }

--- a/dbmongo/lib/engine/reduce.go
+++ b/dbmongo/lib/engine/reduce.go
@@ -135,7 +135,6 @@ func Reduce(batch base.AdminBatch, types []string) error {
 	// Backup: renommer la collection Features actuelle, pour en créer une nouvelle version
 	backupColName := outCollection + "_" + time.Now().Format("2006-01-02_15-04-05")
 	var res interface{}
-	fmt.Fprintln(os.Stderr, viper.GetString("DB")+"."+outCollection)
 	err = db.DB("admin").Run(bson.D{
 		{Name: "renameCollection", Value: viper.GetString("DB") + "." + outCollection},
 		{Name: "to", Value: viper.GetString("DB") + "." + backupColName},

--- a/tests/test-api-reduce.sh
+++ b/tests/test-api-reduce.sh
@@ -32,6 +32,8 @@ sleep 1 # give some time for MongoDB to start
 tests/helpers/populate-from-objects.sh \
   | tests/helpers/mongodb-container.sh run
 
+echo "db.Features_TestData.insertOne({a:1})" | tests/helpers/mongodb-container.sh run # TODO: remove this
+
 echo ""
 echo "💎 Computing the Features collection thru dbmongo API..."
 tests/helpers/dbmongo-server.sh start

--- a/tests/test-api-reduce.sh
+++ b/tests/test-api-reduce.sh
@@ -41,8 +41,7 @@ echo "- POST /api/data/reduce 👉 $(http --print=b --ignore-stdin :5000/api/dat
 
 (tests/helpers/mongodb-container.sh run \
   > "${OUTPUT_FILE}" \
-) <<< 'printjson(db.Features_TestData.find().toArray());
-printjson(db.runCommand( { listCollections: 1.0, authorizedCollections: true, nameOnly: true } ))' # TODO: remove this
+) <<< 'printjson(db.Features_TestData.find().toArray());'
 
 # Display JS errors logged by MongoDB, if any
 tests/helpers/mongodb-container.sh exceptions || true

--- a/tests/test-api-reduce.sh
+++ b/tests/test-api-reduce.sh
@@ -32,8 +32,6 @@ sleep 1 # give some time for MongoDB to start
 tests/helpers/populate-from-objects.sh \
   | tests/helpers/mongodb-container.sh run
 
-echo "db.Features_TestData.insertOne({})" | tests/helpers/mongodb-container.sh run # TODO: remove this
-
 echo ""
 echo "💎 Computing the Features collection thru dbmongo API..."
 tests/helpers/dbmongo-server.sh start

--- a/tests/test-api-reduce.sh
+++ b/tests/test-api-reduce.sh
@@ -32,6 +32,8 @@ sleep 1 # give some time for MongoDB to start
 tests/helpers/populate-from-objects.sh \
   | tests/helpers/mongodb-container.sh run
 
+echo "db.Features_TestData.insertOne({})" | tests/helpers/mongodb-container.sh run # TODO: remove this
+
 echo ""
 echo "💎 Computing the Features collection thru dbmongo API..."
 tests/helpers/dbmongo-server.sh start
@@ -39,7 +41,8 @@ echo "- POST /api/data/reduce 👉 $(http --print=b --ignore-stdin :5000/api/dat
 
 (tests/helpers/mongodb-container.sh run \
   > "${OUTPUT_FILE}" \
-) <<< 'printjson(db.Features_TestData.find().toArray());'
+) <<< 'printjson(db.Features_TestData.find().toArray());
+printjson(db.runCommand( { listCollections: 1.0, authorizedCollections: true, nameOnly: true } ))' # TODO: remove this
 
 # Display JS errors logged by MongoDB, if any
 tests/helpers/mongodb-container.sh exceptions || true

--- a/tests/test-api-reduce.sh
+++ b/tests/test-api-reduce.sh
@@ -32,7 +32,8 @@ sleep 1 # give some time for MongoDB to start
 tests/helpers/populate-from-objects.sh \
   | tests/helpers/mongodb-container.sh run
 
-echo "db.Features_TestData.insertOne({a:1})" | tests/helpers/mongodb-container.sh run # TODO: remove this
+# We create a collection with dummy data which should not remain after the execution of Reduce
+echo "db.Features_TestData.insertOne({a:1})" | tests/helpers/mongodb-container.sh run
 
 echo ""
 echo "💎 Computing the Features collection thru dbmongo API..."


### PR DESCRIPTION
## Besoin

Avant son départ, Pierre préconisait l'usage suivant de la collection `Features` (généré par `reduce`):

- faire en sorte que seules données du dernier batch soient représentées dans `Features`, après l'appel à `reduce`
- permettre de restaurer la version précédente de ces données (ex: en cas d'incident)

## Solution apportée

Si celle-ci existe au moment de l'appel, la fonction `Reduce()` renomme désormais la collection de destination (`Features`) en employant un suffixe temporel (afin de prévenir l'écrasement de la sauvegarde précédente, en cas d'erreurs consécutives), puis la recréée lors de la fusion des résultats du map-reduce parallélisé.

Des messages sont affichés dans la sorties d'erreurs, pour informer la création de cette collection de sauvegarder, et pour inviter l'utilisateur a supprimer la sauvegarde à sa convenance.