### PR TITLE
feat(perf): Stockage de l'heure de début de traitement dans Journal

### DIFF
--- a/dbmongo/lib/apconso/testData/expectedApconso.json
+++ b/dbmongo/lib/apconso/testData/expectedApconso.json
@@ -25,6 +25,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/apdemande/testData/expectedApdemande.json
+++ b/dbmongo/lib/apdemande/testData/expectedApdemande.json
@@ -55,6 +55,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/bdf/testData/expectedBdfOutput.json
+++ b/dbmongo/lib/bdf/testData/expectedBdfOutput.json
@@ -43,6 +43,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/diane/testData/expectedDiane.json
+++ b/dbmongo/lib/diane/testData/expectedDiane.json
@@ -1480,6 +1480,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/ellisphere/testData/expectedEllisphere.json
+++ b/dbmongo/lib/ellisphere/testData/expectedEllisphere.json
@@ -79,6 +79,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/engine/event.go
+++ b/dbmongo/lib/engine/event.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"encoding/json"
 	"log"
+	"time"
 
 	"github.com/globalsign/mgo/bson"
 	"github.com/signaux-faibles/opensignauxfaibles/dbmongo/lib/base"
@@ -62,7 +63,7 @@ func messageDispatch() chan SocketMessage {
 }
 
 // RelayEvents transmet les messages
-func RelayEvents(eventChannel chan marshal.Event, reportType string) (lastReport string) {
+func RelayEvents(eventChannel chan marshal.Event, reportType string, startDate time.Time) (lastReport string) {
 	if eventChannel == nil {
 		return
 	}
@@ -73,6 +74,7 @@ func RelayEvents(eventChannel chan marshal.Event, reportType string) (lastReport
 			}
 		}
 		e.ReportType = reportType
+		e.StartDate = startDate
 		MainMessageChannel <- SocketMessage{
 			JournalEvent: e,
 		}

--- a/dbmongo/lib/marshal/event.go
+++ b/dbmongo/lib/marshal/event.go
@@ -27,6 +27,7 @@ type Code string
 type Event struct {
 	ID         bson.ObjectId `json:"-" bson:"_id"`
 	Date       time.Time     `json:"date" bson:"date"`
+	StartDate  time.Time     `json:"startDate" bson:"startDate"`
 	Comment    interface{}   `json:"event" bson:"event"`
 	Priority   Priority      `json:"priority" bson:"priority"`
 	Code       Code          `json:"parserCode" bson:"parserCode"`

--- a/dbmongo/lib/reporder/testData/expectedReporder.json
+++ b/dbmongo/lib/reporder/testData/expectedReporder.json
@@ -24,6 +24,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/sirene/testData/expectedSirene.json
+++ b/dbmongo/lib/sirene/testData/expectedSirene.json
@@ -52,6 +52,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/sirene_ul/testData/expectedSireneUL.json
+++ b/dbmongo/lib/sirene_ul/testData/expectedSireneUL.json
@@ -32,6 +32,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/urssaf/testData/expectedCcsf.json
+++ b/dbmongo/lib/urssaf/testData/expectedCcsf.json
@@ -19,6 +19,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/urssaf/testData/expectedCotisation.json
+++ b/dbmongo/lib/urssaf/testData/expectedCotisation.json
@@ -31,6 +31,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/urssaf/testData/expectedDebit.json
+++ b/dbmongo/lib/urssaf/testData/expectedDebit.json
@@ -55,6 +55,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/urssaf/testData/expectedDebitCorrompu.json
+++ b/dbmongo/lib/urssaf/testData/expectedDebitCorrompu.json
@@ -55,6 +55,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/urssaf/testData/expectedDelai.json
+++ b/dbmongo/lib/urssaf/testData/expectedDelai.json
@@ -43,6 +43,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/urssaf/testData/expectedEffectif.json
+++ b/dbmongo/lib/urssaf/testData/expectedEffectif.json
@@ -1579,6 +1579,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/urssaf/testData/expectedEffectifEnt.json
+++ b/dbmongo/lib/urssaf/testData/expectedEffectifEnt.json
@@ -1264,6 +1264,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],

--- a/dbmongo/lib/urssaf/testData/expectedProcol.json
+++ b/dbmongo/lib/urssaf/testData/expectedProcol.json
@@ -19,6 +19,7 @@
   "events": [
     {
       "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
       "event": {
         "batchKey": "",
         "headFatal": [],


### PR DESCRIPTION
Objectif: commencer à constituer un historique des durées de traitements en prod.

Prochaines étapes: faire pareil dans les autres traitements – notamment `reduce` et `public` – qui ne stockent pour l'instant rien dans Journal.