### PR TITLE
fix(CLI): Simplification d'usage des canaux, suite à PR #266

### DIFF
--- a/lib/engine/event.go
+++ b/lib/engine/event.go
@@ -16,16 +16,6 @@ type SocketMessage struct {
 	JournalEvent marshal.Event     `json:"journalEvent" bson:"journalEvent"`
 	Batches      []base.AdminBatch `json:"batches,omitempty" bson:"batches,omitempty"`
 	Features     []string          `json:"features,omitempty" bson:"features,omitempty"`
-	Channel      chan SocketMessage
-}
-
-// MarshalJSON fournit un objet serialisable
-func (message SocketMessage) MarshalJSON() ([]byte, error) {
-	var tmp SocketMessage
-	tmp.JournalEvent = message.JournalEvent
-	tmp.Batches = message.Batches
-	tmp.Features = message.Features
-	return json.Marshal(tmp)
 }
 
 var relaying sync.WaitGroup

--- a/lib/engine/event.go
+++ b/lib/engine/event.go
@@ -10,14 +10,9 @@ import (
 	"github.com/signaux-faibles/opensignauxfaibles/lib/marshal"
 )
 
-// SocketMessage permet la diffusion d'information vers tous les clients
-type SocketMessage struct {
-	JournalEvent marshal.Event `json:"journalEvent" bson:"journalEvent"`
-}
-
 var relaying sync.WaitGroup
 
-type messageChannel chan SocketMessage
+type messageChannel chan marshal.Event
 
 var messageClientChannels = []messageChannel{}
 
@@ -35,16 +30,16 @@ func MessageSocketAddClient() {
 }
 
 // journal dispatch un event vers les clients et l'enregistre dans la bdd
-func messageDispatch() chan SocketMessage {
+func messageDispatch() chan marshal.Event {
 	relaying.Add(1)
 	channel := make(messageChannel)
 	go func() {
 		defer relaying.Done()
 		for event := range channel {
-			err := Db.DBStatus.C("Journal").Insert(event.JournalEvent)
+			err := Db.DBStatus.C("Journal").Insert(event)
 			if err != nil {
 				log.Print("Erreur critique d'insertion dans la base de données: " + err.Error())
-				log.Print(json.Marshal(event.JournalEvent))
+				log.Print(json.Marshal(event))
 			}
 			for _, clientChannel := range messageClientChannels {
 				clientChannel <- event
@@ -67,9 +62,7 @@ func RelayEvents(eventChannel chan marshal.Event, reportType string, startDate t
 		}
 		e.ReportType = reportType
 		e.StartDate = startDate
-		MainMessageChannel <- SocketMessage{
-			JournalEvent: e,
-		}
+		MainMessageChannel <- e
 	}
 	return lastReport
 }
@@ -79,9 +72,7 @@ func LogOperationEvent(reportType string, startDate time.Time) {
 	event := marshal.CreateEvent()
 	event.StartDate = startDate
 	event.ReportType = reportType
-	MainMessageChannel <- SocketMessage{
-		JournalEvent: event,
-	}
+	MainMessageChannel <- event
 }
 
 // FlushEventQueue finalise l'insertion des événements dans Journal.

--- a/lib/engine/event.go
+++ b/lib/engine/event.go
@@ -7,15 +7,12 @@ import (
 	"time"
 
 	"github.com/globalsign/mgo/bson"
-	"github.com/signaux-faibles/opensignauxfaibles/lib/base"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/marshal"
 )
 
 // SocketMessage permet la diffusion d'information vers tous les clients
 type SocketMessage struct {
-	JournalEvent marshal.Event     `json:"journalEvent" bson:"journalEvent"`
-	Batches      []base.AdminBatch `json:"batches,omitempty" bson:"batches,omitempty"`
-	Features     []string          `json:"features,omitempty" bson:"features,omitempty"`
+	JournalEvent marshal.Event `json:"journalEvent" bson:"journalEvent"`
 }
 
 var relaying sync.WaitGroup

--- a/lib/marshal/event.go
+++ b/lib/marshal/event.go
@@ -26,13 +26,21 @@ type Event struct {
 }
 
 // CreateEvent initialise un évènement avec les valeurs par défaut.
-func CreateEvent() (event Event) {
+func CreateEvent() Event {
 	return Event{
 		ID:       bson.NewObjectId(),
 		Date:     time.Now(),
 		Priority: Priority("info"),
 		Code:     Code("unknown"),
 	}
+}
+
+// CreateReportEvent initialise un évènement contenant un rapport de parsing.
+func CreateReportEvent(fileType string, report interface{}) Event {
+	event := CreateEvent()
+	event.Code = Code(fileType)
+	event.Comment = report
+	return event
 }
 
 // ParseReport permet d'accéder aux propriétés d'un rapport de parsing.

--- a/lib/marshal/event.go
+++ b/lib/marshal/event.go
@@ -13,12 +13,6 @@ type Priority string
 // Code test
 type Code string
 
-// EventInChannel envelope un objet de journal avec sa destination
-type EventInChannel struct {
-	ActualEvent Event
-	Channel     chan Event
-}
-
 // Event est un objet de journal
 // swagger:ignore
 type Event struct {
@@ -37,23 +31,8 @@ func CreateEvent() (event Event) {
 		ID:       bson.NewObjectId(),
 		Date:     time.Now(),
 		Priority: Priority("info"),
+		Code:     Code("unknown"),
 	}
-}
-
-func (event EventInChannel) throw(comment interface{}, logLevel string) {
-	event.ActualEvent.ID = bson.NewObjectId()
-	event.ActualEvent.Date = time.Now()
-	event.ActualEvent.Comment = comment
-	if event.ActualEvent.Code == "" {
-		event.ActualEvent.Code = Code("unknown")
-	}
-	event.ActualEvent.Priority = Priority("info")
-	event.Channel <- event.ActualEvent
-}
-
-// Info produit un évènement de niveau Info
-func (event EventInChannel) Info(comment interface{}) {
-	event.throw(comment, "info")
 }
 
 // ParseReport permet d'accéder aux propriétés d'un rapport de parsing.

--- a/lib/marshal/parser.go
+++ b/lib/marshal/parser.go
@@ -61,8 +61,10 @@ func ParseFilesFromBatch(cache Cache, batch *base.AdminBatch, parser Parser) (ch
 	outputChannel := make(chan Tuple)
 	eventChannel := make(chan Event)
 	fileType := parser.GetFileType()
-	event := Event{
-		Code:    Code(fileType),
+	event := EventInChannel{
+		ActualEvent: Event{
+			Code: Code(fileType),
+		},
 		Channel: eventChannel,
 	}
 	filter := GetSirenFilterFromCache(cache)

--- a/lib/marshal/parser.go
+++ b/lib/marshal/parser.go
@@ -70,10 +70,7 @@ func ParseFilesFromBatch(cache Cache, batch *base.AdminBatch, parser Parser) (ch
 				tracker.AddFatalError(err)
 			}
 			runParserWithSirenFilter(parser, &filter, filePath, &tracker, outputChannel)
-			event := CreateEvent()
-			event.Code = Code(fileType)
-			event.Comment = tracker.Report(batch.ID.Key, path) // abstract
-			eventChannel <- event
+			eventChannel <- CreateReportEvent(fileType, tracker.Report(batch.ID.Key, path)) // abstract
 		}
 		close(outputChannel)
 		close(eventChannel)

--- a/tests/test-api-import.sh
+++ b/tests/test-api-import.sh
@@ -94,7 +94,7 @@ printjson(db.ImportedData.find().sort({"value.key":1}).toArray().map(doc => ({
 
 print("// Reports from db.Journal:");
 // on classe les données par type, de manière à ce que l'ordre soit stable
-printjson(db.Journal.find().sort({ parserCode: 1 }).toArray().map(doc => (doc.event ? {
+printjson(db.Journal.find().sort({ reportType: -1, parserCode: 1 }).toArray().map(doc => (doc.event ? {
   event: {
     headRejected: doc.event.headRejected,
     headFatal: doc.event.headFatal,


### PR DESCRIPTION
## Améliorations apportées

- Plus besoin d'envoyer un message vide avant de fermer le canal d'ajout dans ImportedData (comme suggéré dans https://github.com/signaux-faibles/opensignauxfaibles/pull/266#discussion_r543672450)
- Suppression de la fonction `getBSON()` qui duplique partiellement la structure `Event` (cf PR #264)
- Suppression du type intermédiaire `engine.SocketMessage` et de ses méthodes => usage direct de `marshal.Event`
