### PR TITLE
build.sh est plus poli et utilise le bon nom de binaire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ tests/input-data/RawData.sample.json
 tests/output-snapshots/reduce-Features.golden.json
 tests/output-snapshots/reduce-map-output.golden.json
 tests/output-snapshots/test-compact.golden.json
+dist.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -3,15 +3,29 @@
 # ce script ne se charge pas d'installer les éléments nécessaires à la compilation.
 mkdir -p dist/static
 
+if ! [ -f config.toml ]; then
+  echo config.toml non trouvé, abandon
+  exit 1
+fi
+
 # compilation et recopie des éléments nécessaires
-go build -ldflags="-s -w"
-upx sfdata
+go build -ldflags="-s -w" -o sfdata
+if command -v upx &> /dev/null
+then
+    upx sfdata
+else
+    echo "upx n'a pas été trouvé, le binaire ne sera pas compressé"
+fi
+
+
 cp sfdata ../dist
 cp config.toml ../dist
 
 # création de l'archive
-tar cvJf dist.tar.xz dist/
+tar cvzf dist.tar.gz dist/ &> /dev/null
 
 # cleanup
 rm sfdata
 rm -r dist/
+
+echo dist.tar.gz généré


### PR DESCRIPTION
Tout est dans le titre.