### PR TITLE
feat(paydex): Intégrer données Paydex dans Public

### DIFF
--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -21,13 +21,13 @@ export type ParHash<T> = Record<DataHash, T>
 type EntrepriseDataValues = {
   key: Siren
   scope: "entreprise"
-  batch: Record<BatchKey, Partial<EntrepriseBatchProps>>
+  batch: Record<BatchKey, Partial<BatchValueProps>> // TODO: remplacer par `Partial<EntrepriseBatchProps>>`, une fois que tous les champs auront été séparés
 }
 
 type EtablissementDataValues = {
   key: Siret
   scope: "etablissement"
-  batch: Record<BatchKey, Partial<BatchValueProps>> // TODO: remplacer par Partial<EtablissementBatchProps>
+  batch: Record<BatchKey, Partial<BatchValueProps>> // TODO: remplacer par Partial<EtablissementBatchProps>, une fois que tous les champs auront été séparés
 }
 
 export type Scope = (EntrepriseDataValues | EtablissementDataValues)["scope"]
@@ -46,11 +46,11 @@ export type IndexFlags = {
 
 export type BatchKey = string
 
-export type BatchValues = Record<BatchKey, BatchValue>
+export type BatchValues = Record<BatchKey, BatchValue> // TODO: supprimer ce type, pour faire la distinction entre Entreprise et Etablissement
 
 export type DataType = keyof BatchValueProps // => 'reporder' | 'effectif' | 'apconso' | ...
 
-export type BatchValue = Partial<BatchValueProps>
+export type BatchValue = Partial<BatchValueProps> // TODO: supprimer ce type, pour faire la distinction entre Entreprise et Etablissement
 
 type CommonBatchProps = {
   reporder: ParPériode<EntréeRepOrder> // RepOrder est généré par "compact", et non importé => Usage de Periode en guise de hash d'indexation

--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -60,25 +60,30 @@ export type EntrepriseBatchProps = CommonBatchProps & {
   paydex: ParHash<EntréePaydex>
 }
 
-// TODO: continuer d'extraire les propriétés vers EntrepriseBatchProps et EtablissementBatchProps
-export type BatchValueProps = EntrepriseBatchProps & {
-  effectif: ParHash<EntréeEffectif>
+export type EtablissementBatchProps = CommonBatchProps & {
   apconso: ParHash<EntréeApConso>
-  apdemande: ParHash<EntréeApDemande>
-  compte: ParHash<EntréeCompte>
-  interim: ParHash<EntréeInterim>
-  delai: ParHash<EntréeDelai>
-  procol: ParHash<EntréeDéfaillances>
-  cotisation: ParHash<EntréeCotisation>
-  debit: ParHash<EntréeDebit>
-  ccsf: ParHash<{ date_traitement: Date }>
-  sirene: ParHash<EntréeSirene>
-  sirene_ul: ParHash<EntréeSireneEntreprise>
-  effectif_ent: ParHash<EntréeEffectif>
-  bdf: ParHash<EntréeBdf>
-  diane: ParHash<EntréeDiane>
-  ellisphere: ParHash<EntréeEllisphere>
 }
+
+// TODO: continuer d'extraire les propriétés vers EntrepriseBatchProps et EtablissementBatchProps
+export type BatchValueProps = CommonBatchProps &
+  EntrepriseBatchProps &
+  EtablissementBatchProps & {
+    effectif: ParHash<EntréeEffectif>
+    apdemande: ParHash<EntréeApDemande>
+    compte: ParHash<EntréeCompte>
+    interim: ParHash<EntréeInterim>
+    delai: ParHash<EntréeDelai>
+    procol: ParHash<EntréeDéfaillances>
+    cotisation: ParHash<EntréeCotisation>
+    debit: ParHash<EntréeDebit>
+    ccsf: ParHash<{ date_traitement: Date }>
+    sirene: ParHash<EntréeSirene>
+    sirene_ul: ParHash<EntréeSireneEntreprise>
+    effectif_ent: ParHash<EntréeEffectif>
+    bdf: ParHash<EntréeBdf>
+    diane: ParHash<EntréeDiane>
+    ellisphere: ParHash<EntréeEllisphere>
+  }
 
 // Détail des types de données
 

--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -10,7 +10,7 @@ export type Departement = string
 
 export type Siren = string
 export type Siret = string
-export type SiretOrSiren = Siret | Siren
+export type SiretOrSiren = Siret | Siren // TODO: supprimer ce type, une fois que tous les champs auront été séparés
 export type CodeAPE = string
 
 export type DataHash = string
@@ -46,11 +46,11 @@ export type IndexFlags = {
 
 export type BatchKey = string
 
-export type BatchValues = Record<BatchKey, BatchValue> // TODO: supprimer ce type, pour faire la distinction entre Entreprise et Etablissement
+export type BatchValues = Record<BatchKey, BatchValue>
 
 export type DataType = keyof BatchValueProps // => 'reporder' | 'effectif' | 'apconso' | ...
 
-export type BatchValue = Partial<BatchValueProps> // TODO: supprimer ce type, pour faire la distinction entre Entreprise et Etablissement
+export type BatchValue = Partial<BatchValueProps>
 
 type CommonBatchProps = {
   reporder: ParPériode<EntréeRepOrder> // RepOrder est généré par "compact", et non importé => Usage de Periode en guise de hash d'indexation
@@ -64,7 +64,7 @@ export type EtablissementBatchProps = CommonBatchProps & {
   apconso: ParHash<EntréeApConso>
 }
 
-// TODO: continuer d'extraire les propriétés vers EntrepriseBatchProps et EtablissementBatchProps
+// TODO: continuer d'extraire les propriétés vers EntrepriseBatchProps et EtablissementBatchProps, puis supprimer BatchValueProps et les types qui en dépendent
 export type BatchValueProps = CommonBatchProps &
   EntrepriseBatchProps &
   EtablissementBatchProps & {

--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -51,13 +51,17 @@ export type BatchValues = Record<BatchKey, BatchValue>
 export type DataType = keyof BatchValueProps // => 'reporder' | 'effectif' | 'apconso' | ...
 
 export type BatchValue = Partial<BatchValueProps>
-export type EntrepriseBatchProps = {
+
+type CommonBatchProps = {
+  reporder: ParPériode<EntréeRepOrder> // RepOrder est généré par "compact", et non importé => Usage de Periode en guise de hash d'indexation
+}
+
+export type EntrepriseBatchProps = CommonBatchProps & {
   paydex: ParHash<EntréePaydex>
 }
 
 // TODO: continuer d'extraire les propriétés vers EntrepriseBatchProps et EtablissementBatchProps
 export type BatchValueProps = EntrepriseBatchProps & {
-  reporder: ParPériode<EntréeRepOrder> // RepOrder est généré par "compact", et non importé => Usage de Periode en guise de hash d'indexation
   effectif: ParHash<EntréeEffectif>
   apconso: ParHash<EntréeApConso>
   apdemande: ParHash<EntréeApDemande>

--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -18,13 +18,13 @@ export type ParHash<T> = Record<DataHash, T>
 
 // Données importées pour une entreprise ou établissement
 
-type EntrepriseDataValues = {
+export type EntrepriseDataValues = {
   key: Siren
   scope: "entreprise"
   batch: Record<BatchKey, Partial<BatchValueProps>> // TODO: remplacer par `Partial<EntrepriseBatchProps>>`, une fois que tous les champs auront été séparés
 }
 
-type EtablissementDataValues = {
+export type EtablissementDataValues = {
   key: Siret
   scope: "etablissement"
   batch: Record<BatchKey, Partial<BatchValueProps>> // TODO: remplacer par Partial<EtablissementBatchProps>, une fois que tous les champs auront été séparés

--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -8,8 +8,9 @@ export type ParPériode<T> = Record<Periode, T>
 
 export type Departement = string
 
+export type Siren = string
 export type Siret = string
-export type SiretOrSiren = Siret | string
+export type SiretOrSiren = Siret | Siren
 export type CodeAPE = string
 
 export type DataHash = string
@@ -17,13 +18,21 @@ export type ParHash<T> = Record<DataHash, T>
 
 // Données importées pour une entreprise ou établissement
 
-export type Scope = "etablissement" | "entreprise"
-
-export type CompanyDataValues = {
-  key: SiretOrSiren
-  scope: Scope
-  batch: BatchValues
+type EntrepriseDataValues = {
+  key: Siren
+  scope: "entreprise"
+  batch: Record<BatchKey, Partial<EntrepriseBatchProps>>
 }
+
+type EtablissementDataValues = {
+  key: Siret
+  scope: "etablissement"
+  batch: Record<BatchKey, Partial<BatchValueProps>> // TODO: remplacer par Partial<EtablissementBatchProps>
+}
+
+export type Scope = (EntrepriseDataValues | EtablissementDataValues)["scope"]
+
+export type CompanyDataValues = EntrepriseDataValues | EtablissementDataValues
 
 export type CompanyDataValuesWithFlags = CompanyDataValues & IndexFlags
 
@@ -42,8 +51,12 @@ export type BatchValues = Record<BatchKey, BatchValue>
 export type DataType = keyof BatchValueProps // => 'reporder' | 'effectif' | 'apconso' | ...
 
 export type BatchValue = Partial<BatchValueProps>
+export type EntrepriseBatchProps = {
+  paydex: ParHash<EntréePaydex>
+}
 
-export type BatchValueProps = {
+// TODO: continuer d'extraire les propriétés vers EntrepriseBatchProps et EtablissementBatchProps
+export type BatchValueProps = EntrepriseBatchProps & {
   reporder: ParPériode<EntréeRepOrder> // RepOrder est généré par "compact", et non importé => Usage de Periode en guise de hash d'indexation
   effectif: ParHash<EntréeEffectif>
   apconso: ParHash<EntréeApConso>
@@ -61,7 +74,6 @@ export type BatchValueProps = {
   bdf: ParHash<EntréeBdf>
   diane: ParHash<EntréeDiane>
   ellisphere: ParHash<EntréeEllisphere>
-  paydex: ParHash<EntréePaydex>
 }
 
 // Détail des types de données

--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -61,6 +61,7 @@ export type BatchValueProps = {
   bdf: ParHash<EntréeBdf>
   diane: ParHash<EntréeDiane>
   ellisphere: ParHash<EntréeEllisphere>
+  paydex: ParHash<EntréePaydex>
 }
 
 // Détail des types de données
@@ -223,4 +224,9 @@ export type EntréeEllisphere = {
   code_filiere: string
   refid_filiere: string
   personne_pou_m_filiere: string
+}
+
+export type EntréePaydex = {
+  date_valeur: Date
+  nb_jours: number
 }

--- a/js/public/ava_tests.ts
+++ b/js/public/ava_tests.ts
@@ -1,8 +1,10 @@
-// Objectif de cette suite de tests d'intégration:
-// Vérifier la compatibilité des types et mesurer la couverture lors du passage
-// de données entre les fonctions map(), reduce() et finalize(), en s'appuyant
-// sur le jeu de données minimal utilisé dans notre suite de bout en bout
-// définie dans test.sh.
+// Ces tests visent à couvrir toutes les fonctions invoquées par map(), en lui
+// fournissant un jeu de données minimal mais incluant tous les types d'entrée
+// inclus dans RawData.
+//
+// => Penser à ajouter les nouveaux types dans rawEtabData et rawEntrData.
+//
+// TODO: renommer ce fichier --> `map_tests.ts`.
 
 import test, { ExecutionContext } from "ava"
 import { map } from "./map"

--- a/js/public/ava_tests.ts
+++ b/js/public/ava_tests.ts
@@ -14,7 +14,7 @@ import { runMongoMap } from "../test/helpers/mongodb"
 import { setGlobals } from "../test/helpers/setGlobals"
 import {
   EtablissementBatchProps,
-  CompanyDataValuesWithFlags,
+  EtablissementDataValues,
   Siret,
 } from "../RawDataTypes"
 
@@ -37,12 +37,11 @@ const rawEtabData: EtablissementBatchProps = {
   },
 }
 
-const rawData: CompanyDataValuesWithFlags = {
+const rawData: EtablissementDataValues = {
   batch: {
     [batchKey]: rawEtabData,
   },
   scope: "etablissement",
-  index: { algo2: false }, // car il n'y a pas de données justifiant que l'établissement compte 10 employés ou pas
   key: siret,
 }
 

--- a/js/public/map.ts
+++ b/js/public/map.ts
@@ -9,6 +9,7 @@ import {
   EntréeDiane,
   EntréeEllisphere,
   EntréeSireneEntreprise,
+  EntréePaydex,
 } from "../RawDataTypes"
 import { SortieDebit } from "./debits"
 import { Bdf } from "./bdf"
@@ -40,6 +41,7 @@ type SortieMapEntreprise = SortieMapCommon & {
   bdf: Bdf[]
   sirene_ul: EntréeSireneEntreprise
   ellisphere: EntréeEllisphere
+  paydex: EntréePaydex[]
 }
 
 export type SortieMap = SortieMapEtablissement | SortieMapEntreprise
@@ -84,6 +86,7 @@ export function map(this: Input): void {
     const bdf = f.bdf(value.bdf)
     const sirene_ul = Object.values(value.sirene_ul ?? {})[0] ?? null
     const ellisphere = Object.values(value.ellisphere ?? {})[0] ?? null
+
     if (sirene_ul) {
       sirene_ul.raison_sociale = f.raison_sociale(
         sirene_ul.raison_sociale,
@@ -110,6 +113,13 @@ export function map(this: Input): void {
     if (ellisphere) {
       v.ellisphere = ellisphere
     }
+
+    if (value.paydex) {
+      v.paydex = Object.values(value.paydex).sort(
+        (p1, p2) => p1.date_valeur.getTime() - p2.date_valeur.getTime()
+      )
+    }
+
     if (Object.keys(v) !== []) {
       emit("entreprise_" + this.value.key, v)
     }

--- a/js/public/public_tests.ts
+++ b/js/public/public_tests.ts
@@ -1,8 +1,7 @@
-// Version TypeScript / AVA de public/_test.js, précedemment exécuté par jsc,
-// lors de l'appel à `go test`, via js/test/test_public.sh.
+// Tests des fonctions map(), reduce() et finalize() de Public,
+// en les faisant tourner sur les données de test/data/objects.js.
 //
-// Usage: $ npx ava public/public_tests.ts
-//     ou $ npm test
+// Important: ce jeu de données ne couvre pas tous les types d'entrées.
 
 import { generatePeriodSerie } from "../common/generatePeriodSerie"
 import { map, Input, OutKey, OutValue } from "./map"

--- a/lib/engine/jsFunctions.go
+++ b/lib/engine/jsFunctions.go
@@ -845,6 +845,9 @@ db.getCollection("Features").createIndex({
         if (ellisphere) {
             v.ellisphere = ellisphere;
         }
+        if (value.paydex) {
+            v.paydex = Object.values(value.paydex).sort((p1, p2) => p1.date_valeur.getTime() - p2.date_valeur.getTime());
+        }
         if (Object.keys(v) !== []) {
             emit("entreprise_" + this.value.key, v);
         }

--- a/lib/parsing/main.go
+++ b/lib/parsing/main.go
@@ -16,6 +16,8 @@ import (
 )
 
 // RegisteredParsers liste des parsers disponibles
+// Note: penser à tenir à jour la table des formats, dans la documentation:
+// https://github.com/signaux-faibles/documentation/blob/master/processus-traitement-donnees.md#sp%C3%A9cificit%C3%A9s-de-limport
 var registeredParsers = map[string]marshal.Parser{
 	"debit":        urssaf.ParserDebit,
 	"ccsf":         urssaf.ParserCCSF,

--- a/lib/paydex/main.go
+++ b/lib/paydex/main.go
@@ -22,7 +22,7 @@ import (
 
 // Paydex décrit le format de chaque entrée de donnée résultant du parsing.
 type Paydex struct {
-	Siren      string    `json:"siren" bson:"siren"`
+	Siren      string    `json:"-" bson:"-"`
 	DateValeur time.Time `json:"date_valeur" bson:"date_valeur"`
 	NbJours    int       `json:"nb_jours" bson:"nb_jours"`
 }

--- a/lib/paydex/testData/expectedPaydex.json
+++ b/lib/paydex/testData/expectedPaydex.json
@@ -1,27 +1,22 @@
 {
   "tuples": [
     {
-      "siren": "000000001",
       "date_valeur": "2018-12-15T00:00:00Z",
       "nb_jours": 2
     },
     {
-      "siren": "000000001",
       "date_valeur": "2018-01-15T00:00:00Z",
       "nb_jours": 1
     },
     {
-      "siren": "000000001",
       "date_valeur": "2019-01-15T00:00:00Z",
       "nb_jours": 3
     },
     {
-      "siren": "000000002",
       "date_valeur": "2018-12-15T00:00:00Z",
       "nb_jours": 4
     },
     {
-      "siren": "000000002",
       "date_valeur": "2019-01-15T00:00:00Z",
       "nb_jours": 5
     }

--- a/tests/output-snapshots/test-import.golden.txt
+++ b/tests/output-snapshots/test-import.golden.txt
@@ -79,17 +79,14 @@
 				"1910" : {
 					"paydex" : {
 						"08d189057ad993550d687c012c38deba" : {
-							"siren" : "000000001",
 							"date_valeur" : ISODate("2018-12-15T00:00:00Z"),
 							"nb_jours" : 2
 						},
 						"14e0ccedefff3afa3b6fcf0d529d0f6b" : {
-							"siren" : "000000001",
 							"date_valeur" : ISODate("2019-01-15T00:00:00Z"),
 							"nb_jours" : 3
 						},
 						"e1f1f42c498b07f1267ed0f03b5d2cbf" : {
-							"siren" : "000000001",
 							"date_valeur" : ISODate("2018-01-15T00:00:00Z"),
 							"nb_jours" : 1
 						}
@@ -107,12 +104,10 @@
 				"1910" : {
 					"paydex" : {
 						"262fb3db3a0e98195003a8d78d82f3b9" : {
-							"siren" : "000000002",
 							"date_valeur" : ISODate("2018-12-15T00:00:00Z"),
 							"nb_jours" : 4
 						},
 						"8e8223443c1df0dcb532eaa834886638" : {
-							"siren" : "000000002",
 							"date_valeur" : ISODate("2019-01-15T00:00:00Z"),
 							"nb_jours" : 5
 						}


### PR DESCRIPTION
Suite de #277.

## Objectif

Cette PR permet d'exporter dans la collection `Public` les données parsées depuis le fichier Paydex.

## Modifications annexes

Pour que le code de cette intégration soit couvert par nos tests automatisés, et pour ne pas oublier de couvrir les entrées de données qu'on ajouterait à l'avenir, j'ai:

- introduit un type `EntrepriseBatchProps` qui – à terme – définira de manière exhaustive les entrées de données supportées par les documents de type `entreprise` stockés dans `RawData` (+ `EtablissementBatchProps` pour les `etablissement`s)
- écrit un test unitaire pour la fonction `map()` de `Public` qui créée un document `RawData` d'`entreprise` remplissant toutes les entrées supportées par ce type (défini seulement par `paydex`, pour l'instant) puis vérifie que toutes données de ces entrées se retrouvent bien en sortie du `map()`.

Enfin, j'ai:
- retiré la propriété `siren` des tuples stockés dans `RawData`, tel que discuté ce matin.
- mis à jour la documentation d'en-tête des tests de Public.