### PR TITLE
fix(parsers): Validation et indexation automatique de colonnes csv

### DIFF
--- a/lib/apdemande/main.go
+++ b/lib/apdemande/main.go
@@ -92,12 +92,7 @@ func parseColMapping(reader *csv.Reader) (marshal.ColMapping, error) {
 	if err != nil {
 		return nil, err
 	}
-	var idx = marshal.GetFieldBindings(header)
-	requiredFields := marshal.ExtractColTags(APDemande{})
-	if _, err := idx.HasFields(requiredFields); err != nil {
-		return nil, err
-	}
-	return idx, nil
+	return marshal.ValidateAndIndexColumnsFromColTags(header, APDemande{})
 }
 
 func (parser *apdemandeParser) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {

--- a/lib/apdemande/main.go
+++ b/lib/apdemande/main.go
@@ -17,19 +17,19 @@ import (
 
 // APDemande Demande d'activité partielle
 type APDemande struct {
-	ID                 string       `json:"id_demande" bson:"id_demande"`
-	Siret              string       `json:"-" bson:"-"`
-	EffectifEntreprise *int         `json:"effectif_entreprise" bson:"effectif_entreprise"`
-	Effectif           *int         `json:"effectif" bson:"effectif"`
-	DateStatut         time.Time    `json:"date_statut" bson:"date_statut"`
-	Periode            misc.Periode `json:"periode" bson:"periode"`
-	HTA                *float64     `json:"hta" bson:"hta"`
+	ID                 string       `col:"ID_DA" json:"id_demande" bson:"id_demande"`
+	Siret              string       `col:"ETAB_SIRET" json:"-" bson:"-"`
+	EffectifEntreprise *int         `col:"EFF_ENT" json:"effectif_entreprise" bson:"effectif_entreprise"`
+	Effectif           *int         `col:"EFF_ETAB" json:"effectif" bson:"effectif"`
+	DateStatut         time.Time    `col:"DATE_STATUT" json:"date_statut" bson:"date_statut"`
+	Periode            misc.Periode `cols:"DATE_DEB,DATE_FIN" json:"periode" bson:"periode"`
+	HTA                *float64     `col:"HTA" json:"hta" bson:"hta"`
 	MTA                *float64     `json:"mta" bson:"mta"`
-	EffectifAutorise   *int         `json:"effectif_autorise" bson:"effectif_autorise"`
-	MotifRecoursSE     *int         `json:"motif_recours_se" bson:"motif_recours_se"`
-	HeureConsommee     *float64     `json:"heure_consommee" bson:"heure_consommee"`
+	EffectifAutorise   *int         `col:"EFF_AUTO" json:"effectif_autorise" bson:"effectif_autorise"`
+	MotifRecoursSE     *int         `col:"MOTIF_RECOURS_SE" json:"motif_recours_se" bson:"motif_recours_se"`
+	HeureConsommee     *float64     `col:"S_HEURE_CONSOM_TOT" json:"heure_consommee" bson:"heure_consommee"`
 	MontantConsomme    *float64     `json:"montant_consommee" bson:"montant_consommee"`
-	EffectifConsomme   *int         `json:"effectif_consomme" bson:"effectif_consomme"`
+	EffectifConsomme   *int         `col:"S_HEURE_CONSOM_TOT" json:"effectif_consomme" bson:"effectif_consomme"`
 }
 
 // Key id de l'objet
@@ -93,20 +93,7 @@ func parseColMapping(reader *csv.Reader) (marshal.ColMapping, error) {
 		return nil, err
 	}
 	var idx = marshal.GetFieldBindings(header)
-	requiredFields := []string{
-		"ID_DA",
-		"ETAB_SIRET",
-		"EFF_ENT",
-		"EFF_ETAB",
-		"DATE_STATUT",
-		"DATE_DEB",
-		"DATE_FIN",
-		"HTA",
-		"EFF_AUTO",
-		"MOTIF_RECOURS_SE",
-		"S_HEURE_CONSOM_TOT",
-		"S_EFF_CONSOM_TOT",
-	}
+	requiredFields := marshal.ExtractColTags(APDemande{})
 	if _, err := idx.HasFields(requiredFields); err != nil {
 		return nil, err
 	}

--- a/lib/apdemande/main.go
+++ b/lib/apdemande/main.go
@@ -22,7 +22,7 @@ type APDemande struct {
 	EffectifEntreprise *int         `col:"EFF_ENT" json:"effectif_entreprise" bson:"effectif_entreprise"`
 	Effectif           *int         `col:"EFF_ETAB" json:"effectif" bson:"effectif"`
 	DateStatut         time.Time    `col:"DATE_STATUT" json:"date_statut" bson:"date_statut"`
-	Periode            misc.Periode `cols:"DATE_DEB,DATE_FIN" json:"periode" bson:"periode"`
+	Periode            misc.Periode `col:"DATE_DEB,DATE_FIN" json:"periode" bson:"periode"`
 	HTA                *float64     `col:"HTA" json:"hta" bson:"hta"`
 	MTA                *float64     `json:"mta" bson:"mta"`
 	EffectifAutorise   *int         `col:"EFF_AUTO" json:"effectif_autorise" bson:"effectif_autorise"`

--- a/lib/apdemande/main_test.go
+++ b/lib/apdemande/main_test.go
@@ -20,19 +20,13 @@ func TestApdemande(t *testing.T) {
 	t.Run("should fail if one column misses", func(t *testing.T) {
 		output := marshal.RunParserInline(t, Parser, []string{"ID_DA,ETAB_SIRET"}) // EFF_ENT is missing (among others)
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
-		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
-		reportData, _ := output.Events[0].ParseReport()
-		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
-		assert.Contains(t, reportData["headFatal"], "Fatal: Colonne EFF_ENT non trouvée. Abandon.")
+		assert.Contains(t, marshal.GetFatalError(output), "Fatal: Colonne EFF_ENT non trouvée. Abandon.")
 	})
 
 	t.Run("should fail if a composite column misses", func(t *testing.T) {
 		headerRow := []string{"ID_DA,ETAB_SIRET,EFF_ENT,EFF_ETAB,DATE_STATUT,HTA,EFF_AUTO,MOTIF_RECOURS_SE,S_HEURE_CONSOM_TOT,S_HEURE_CONSOM_TOT,DATE_FIN"} // DATE_DEB is missing
 		output := marshal.RunParserInline(t, Parser, headerRow)
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
-		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
-		reportData, _ := output.Events[0].ParseReport()
-		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
-		assert.Contains(t, reportData["headFatal"], "Fatal: Colonne DATE_DEB non trouvée. Abandon.")
+		assert.Contains(t, marshal.GetFatalError(output), "Fatal: Colonne DATE_DEB non trouvée. Abandon.")
 	})
 }

--- a/lib/apdemande/main_test.go
+++ b/lib/apdemande/main_test.go
@@ -3,7 +3,6 @@ package apdemande
 import (
 	"flag"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,9 +18,7 @@ func TestApdemande(t *testing.T) {
 	marshal.TestParserOutput(t, Parser, marshal.NewCache(), testData, golden, *update)
 
 	t.Run("should fail if one column misses", func(t *testing.T) {
-		csvData := strings.Join([]string{"ID_DA,ETAB_SIRET"}, "\n") // EFF_ENT is missing (among others)
-		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
-		output := marshal.RunParser(Parser, marshal.NewCache(), csvFile.Name())
+		output := marshal.RunParserInline(t, Parser, []string{"ID_DA,ETAB_SIRET"}) // EFF_ENT is missing (among others)
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
 		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
 		reportData, _ := output.Events[0].ParseReport()
@@ -30,9 +27,8 @@ func TestApdemande(t *testing.T) {
 	})
 
 	t.Run("should fail if a composite column misses", func(t *testing.T) {
-		csvData := strings.Join([]string{"ID_DA,ETAB_SIRET,EFF_ENT,EFF_ETAB,DATE_STATUT,HTA,EFF_AUTO,MOTIF_RECOURS_SE,S_HEURE_CONSOM_TOT,S_HEURE_CONSOM_TOT,DATE_FIN"}, "\n") // DATE_DEB is missing
-		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
-		output := marshal.RunParser(Parser, marshal.NewCache(), csvFile.Name())
+		headerRow := []string{"ID_DA,ETAB_SIRET,EFF_ENT,EFF_ETAB,DATE_STATUT,HTA,EFF_AUTO,MOTIF_RECOURS_SE,S_HEURE_CONSOM_TOT,S_HEURE_CONSOM_TOT,DATE_FIN"} // DATE_DEB is missing
+		output := marshal.RunParserInline(t, Parser, headerRow)
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
 		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
 		reportData, _ := output.Events[0].ParseReport()

--- a/lib/apdemande/main_test.go
+++ b/lib/apdemande/main_test.go
@@ -28,4 +28,15 @@ func TestApdemande(t *testing.T) {
 		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
 		assert.Contains(t, reportData["headFatal"], "Fatal: Colonne EFF_ENT non trouvée. Abandon.")
 	})
+
+	t.Run("should fail if a composite column misses", func(t *testing.T) {
+		csvData := strings.Join([]string{"ID_DA,ETAB_SIRET,EFF_ENT,EFF_ETAB,DATE_STATUT,HTA,EFF_AUTO,MOTIF_RECOURS_SE,S_HEURE_CONSOM_TOT,S_HEURE_CONSOM_TOT,DATE_FIN"}, "\n") // DATE_DEB is missing
+		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
+		output := marshal.RunParser(Parser, marshal.NewCache(), csvFile.Name())
+		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
+		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
+		reportData, _ := output.Events[0].ParseReport()
+		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
+		assert.Contains(t, reportData["headFatal"], "Fatal: Colonne DATE_DEB non trouvée. Abandon.")
+	})
 }

--- a/lib/apdemande/main_test.go
+++ b/lib/apdemande/main_test.go
@@ -3,7 +3,10 @@ package apdemande
 import (
 	"flag"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/marshal"
 )
@@ -14,4 +17,15 @@ func TestApdemande(t *testing.T) {
 	var golden = filepath.Join("testData", "expectedApdemande.json")
 	var testData = filepath.Join("testData", "apdemandeTestData.csv")
 	marshal.TestParserOutput(t, Parser, marshal.NewCache(), testData, golden, *update)
+
+	t.Run("should fail if one column misses", func(t *testing.T) {
+		csvData := strings.Join([]string{"ID_DA,ETAB_SIRET"}, "\n") // EFF_ENT is missing (among others)
+		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
+		output := marshal.RunParser(Parser, marshal.NewCache(), csvFile.Name())
+		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
+		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
+		reportData, _ := output.Events[0].ParseReport()
+		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
+		assert.Contains(t, reportData["headFatal"], "Fatal: Colonne EFF_ENT non trouvée. Abandon.")
+	})
 }

--- a/lib/marshal/fields.go
+++ b/lib/marshal/fields.go
@@ -55,12 +55,13 @@ func LowercaseFields(headerFields []string) []string {
 
 // ExtractColTags extraie les noms de colonnes depuis les valeurs du tag "col"
 // de chaque propriété de l'objet fourni.
+// Il est possible d'associer plusieurs colonnes en séparant par des virgules.
 func ExtractColTags(object interface{}) (expectedFields []string) {
 	structure := reflect.TypeOf(object)
 	for i := 0; i < structure.NumField(); i++ {
 		tag := structure.Field(i).Tag.Get("col")
 		if tag != "" {
-			expectedFields = append(expectedFields, tag)
+			expectedFields = append(expectedFields, strings.Split(tag, ",")...)
 		}
 	}
 	return expectedFields

--- a/lib/marshal/fields.go
+++ b/lib/marshal/fields.go
@@ -16,7 +16,10 @@ func IndexFields(headerFields []string, expectedFields []string) ColMapping {
 	}
 	var colMapping = ColMapping{}
 	for _, name := range expectedFields {
-		colMapping[name] = misc.SliceIndex(len(headerFields), func(i int) bool { return normalizedHeaderFields[i] == name })
+		idx := misc.SliceIndex(len(headerFields), func(i int) bool { return normalizedHeaderFields[i] == name })
+		if idx != -1 {
+			colMapping[name] = idx
+		}
 	}
 	return colMapping
 }

--- a/lib/marshal/fields.go
+++ b/lib/marshal/fields.go
@@ -22,9 +22,9 @@ func IndexFields(headerFields []string, expectedFields []string) ColMapping {
 
 // GetFieldBindings indexe la position de chaque colonne par son nom,
 // à partir de la liste ordonnée des noms de colonne, telle que lue en en-tête.
-func GetFieldBindings(orderedFields []string) ColMapping {
+func GetFieldBindings(headerFields []string) ColMapping {
 	var colMapping = ColMapping{}
-	for idx, name := range orderedFields {
+	for idx, name := range headerFields {
 		colMapping[name] = idx
 	}
 	return colMapping

--- a/lib/marshal/fields.go
+++ b/lib/marshal/fields.go
@@ -13,14 +13,14 @@ import (
 // tag "col" annotant les propriétés du type de destination du parseur.
 func ValidateAndIndexColumnsFromColTags(headerRow []string, destObject interface{}) (ColMapping, error) {
 	requiredFields := extractColTags(destObject)
-	idx := GetFieldBindings(headerRow)
+	idx := indexFields(headerRow)
 	_, err := idx.HasFields(requiredFields)
 	return idx, err
 }
 
-// IndexFields indexe la position de chaque colonne par son nom,
-// à partir d'un en-tête ordonné et d'une liste de colonnes attendues.
-func IndexFields(headerFields []string, expectedFields []string) ColMapping {
+// IndexSpecificFields indexe la position des colonnes spécifiées,
+// à partir de la liste ordonnée des noms de colonne, telle que lue en en-tête.
+func IndexSpecificFields(headerFields []string, expectedFields []string) ColMapping {
 	var colMapping = ColMapping{}
 	for _, name := range expectedFields {
 		idx := misc.SliceIndex(len(headerFields), func(i int) bool { return headerFields[i] == name })
@@ -31,9 +31,9 @@ func IndexFields(headerFields []string, expectedFields []string) ColMapping {
 	return colMapping
 }
 
-// GetFieldBindings indexe la position de chaque colonne par son nom,
+// indexFields indexe la position de chaque colonne par son nom,
 // à partir de la liste ordonnée des noms de colonne, telle que lue en en-tête.
-func GetFieldBindings(headerFields []string) ColMapping {
+func indexFields(headerFields []string) ColMapping {
 	var colMapping = ColMapping{}
 	for idx, name := range headerFields {
 		colMapping[name] = idx

--- a/lib/marshal/fields.go
+++ b/lib/marshal/fields.go
@@ -1,0 +1,10 @@
+package marshal
+
+// GetFieldBindings indexe la position de chaque colonne par nom.
+func GetFieldBindings(fields []string) map[string]int {
+	var f = map[string]int{}
+	for i, k := range fields {
+		f[k] = i
+	}
+	return f
+}

--- a/lib/marshal/fields.go
+++ b/lib/marshal/fields.go
@@ -8,6 +8,16 @@ import (
 	"github.com/signaux-faibles/opensignauxfaibles/lib/misc"
 )
 
+// ValidateAndIndexColumnsFromColTags valide puis indexe les colonnes trouvées
+// en en-tête d'un fichier csv, à partir des noms de colonnes spécifiés dans le
+// tag "col" annotant les propriétés du type de destination du parseur.
+func ValidateAndIndexColumnsFromColTags(headerRow []string, destObject interface{}) (ColMapping, error) {
+	requiredFields := extractColTags(destObject)
+	idx := GetFieldBindings(headerRow)
+	_, err := idx.HasFields(requiredFields)
+	return idx, err
+}
+
 // IndexFields indexe la position de chaque colonne par son nom,
 // à partir d'un en-tête ordonné et d'une liste de colonnes attendues.
 func IndexFields(headerFields []string, expectedFields []string) ColMapping {
@@ -53,10 +63,10 @@ func LowercaseFields(headerFields []string) []string {
 	return normalizedHeaderFields
 }
 
-// ExtractColTags extraie les noms de colonnes depuis les valeurs du tag "col"
+// extractColTags extraie les noms de colonnes depuis les valeurs du tag "col"
 // de chaque propriété de l'objet fourni.
 // Il est possible d'associer plusieurs colonnes en séparant par des virgules.
-func ExtractColTags(object interface{}) (expectedFields []string) {
+func extractColTags(object interface{}) (expectedFields []string) {
 	structure := reflect.TypeOf(object)
 	for i := 0; i < structure.NumField(); i++ {
 		tag := structure.Field(i).Tag.Get("col")

--- a/lib/marshal/fields.go
+++ b/lib/marshal/fields.go
@@ -10,13 +10,9 @@ import (
 // IndexFields indexe la position de chaque colonne par son nom,
 // à partir d'un en-tête ordonné et d'une liste de colonnes attendues.
 func IndexFields(headerFields []string, expectedFields []string) ColMapping {
-	var normalizedHeaderFields = make([]string, len(headerFields))
-	for i, name := range headerFields {
-		normalizedHeaderFields[i] = strings.ToLower(name)
-	}
 	var colMapping = ColMapping{}
 	for _, name := range expectedFields {
-		idx := misc.SliceIndex(len(headerFields), func(i int) bool { return normalizedHeaderFields[i] == name })
+		idx := misc.SliceIndex(len(headerFields), func(i int) bool { return headerFields[i] == name })
 		if idx != -1 {
 			colMapping[name] = idx
 		}
@@ -45,4 +41,13 @@ func (colMapping ColMapping) HasFields(requiredFields []string) (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+// LowercaseFields normalise les noms de colonnes en minuscules.
+func LowercaseFields(headerFields []string) []string {
+	var normalizedHeaderFields = make([]string, len(headerFields))
+	for i, name := range headerFields {
+		normalizedHeaderFields[i] = strings.ToLower(name)
+	}
+	return normalizedHeaderFields
 }

--- a/lib/marshal/fields.go
+++ b/lib/marshal/fields.go
@@ -1,11 +1,26 @@
 package marshal
 
+import "errors"
+
 // GetFieldBindings indexe la position de chaque colonne par son nom,
 // à partir de la liste ordonnée des noms de colonne, telle que lue en en-tête.
-func GetFieldBindings(orderedFields []string) map[string]int {
-	var f = map[string]int{}
+func GetFieldBindings(orderedFields []string) ColMapping {
+	var f = ColMapping{}
 	for i, k := range orderedFields {
 		f[k] = i
 	}
 	return f
+}
+
+// ColMapping fournit l'indice de chaque colonne.
+type ColMapping map[string]int
+
+// HasFields vérifie la présence d'un ensemble de colonnes.
+func (colMapping ColMapping) HasFields(requiredFields []string) (bool, error) {
+	for _, field := range requiredFields {
+		if _, found := colMapping[field]; !found {
+			return false, errors.New("Colonne " + field + " non trouvée. Abandon.")
+		}
+	}
+	return true, nil
 }

--- a/lib/marshal/fields.go
+++ b/lib/marshal/fields.go
@@ -1,15 +1,34 @@
 package marshal
 
-import "errors"
+import (
+	"errors"
+	"strings"
+
+	"github.com/signaux-faibles/opensignauxfaibles/lib/misc"
+)
+
+// IndexFields indexe la position de chaque colonne par son nom,
+// à partir d'un en-tête ordonné et d'une liste de colonnes attendues.
+func IndexFields(headerFields []string, expectedFields []string) ColMapping {
+	var normalizedHeaderFields = make([]string, len(headerFields))
+	for i, name := range headerFields {
+		normalizedHeaderFields[i] = strings.ToLower(name)
+	}
+	var colMapping = ColMapping{}
+	for _, name := range expectedFields {
+		colMapping[name] = misc.SliceIndex(len(headerFields), func(i int) bool { return normalizedHeaderFields[i] == name })
+	}
+	return colMapping
+}
 
 // GetFieldBindings indexe la position de chaque colonne par son nom,
 // à partir de la liste ordonnée des noms de colonne, telle que lue en en-tête.
 func GetFieldBindings(orderedFields []string) ColMapping {
-	var f = ColMapping{}
-	for i, k := range orderedFields {
-		f[k] = i
+	var colMapping = ColMapping{}
+	for idx, name := range orderedFields {
+		colMapping[name] = idx
 	}
-	return f
+	return colMapping
 }
 
 // ColMapping fournit l'indice de chaque colonne.
@@ -17,9 +36,9 @@ type ColMapping map[string]int
 
 // HasFields vérifie la présence d'un ensemble de colonnes.
 func (colMapping ColMapping) HasFields(requiredFields []string) (bool, error) {
-	for _, field := range requiredFields {
-		if _, found := colMapping[field]; !found {
-			return false, errors.New("Colonne " + field + " non trouvée. Abandon.")
+	for _, name := range requiredFields {
+		if _, found := colMapping[name]; !found {
+			return false, errors.New("Colonne " + name + " non trouvée. Abandon.")
 		}
 	}
 	return true, nil

--- a/lib/marshal/fields.go
+++ b/lib/marshal/fields.go
@@ -1,9 +1,10 @@
 package marshal
 
-// GetFieldBindings indexe la position de chaque colonne par nom.
-func GetFieldBindings(fields []string) map[string]int {
+// GetFieldBindings indexe la position de chaque colonne par son nom,
+// à partir de la liste ordonnée des noms de colonne, telle que lue en en-tête.
+func GetFieldBindings(orderedFields []string) map[string]int {
 	var f = map[string]int{}
-	for i, k := range fields {
+	for i, k := range orderedFields {
 		f[k] = i
 	}
 	return f

--- a/lib/marshal/fields.go
+++ b/lib/marshal/fields.go
@@ -2,6 +2,7 @@ package marshal
 
 import (
 	"errors"
+	"reflect"
 	"strings"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/misc"
@@ -50,4 +51,17 @@ func LowercaseFields(headerFields []string) []string {
 		normalizedHeaderFields[i] = strings.ToLower(name)
 	}
 	return normalizedHeaderFields
+}
+
+// ExtractColTags extraie les noms de colonnes depuis les valeurs du tag "col"
+// de chaque propriété de l'objet fourni.
+func ExtractColTags(object interface{}) (expectedFields []string) {
+	structure := reflect.TypeOf(object)
+	for i := 0; i < structure.NumField(); i++ {
+		tag := structure.Field(i).Tag.Get("col")
+		if tag != "" {
+			expectedFields = append(expectedFields, tag)
+		}
+	}
+	return expectedFields
 }

--- a/lib/marshal/testing.go
+++ b/lib/marshal/testing.go
@@ -38,6 +38,17 @@ type tuplesAndEvents = struct {
 	Events []Event `json:"events"`
 }
 
+// GetFatalError retourne le message d'erreur fatale obtenu suite à une
+// opération de parsing.
+func GetFatalError(output tuplesAndEvents) string {
+	reportData, _ := output.Events[0].ParseReport()
+	headFatal, ok := reportData["headFatal"].([]interface{})
+	if ok != true || len(headFatal) != 1 {
+		return ""
+	}
+	return headFatal[0].(string)
+}
+
 // RunParserInline returns Tuples and Events resulting from the execution of a
 // Parser on a given list of rows, with an empty Cache.
 func RunParserInline(t *testing.T, parser Parser, rows []string) (output tuplesAndEvents) {

--- a/lib/marshal/testing.go
+++ b/lib/marshal/testing.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -35,6 +36,14 @@ func MockComptesMapping(mapping map[string]string) Comptes {
 type tuplesAndEvents = struct {
 	Tuples []Tuple `json:"tuples"`
 	Events []Event `json:"events"`
+}
+
+// RunParserInline returns Tuples and Events resulting from the execution of a
+// Parser on a given list of rows, with an empty Cache.
+func RunParserInline(t *testing.T, parser Parser, rows []string) (output tuplesAndEvents) {
+	csvData := strings.Join(rows, "\n")
+	csvFile := CreateTempFileWithContent(t, []byte(csvData)) // will clean up after the test
+	return RunParser(parser, NewCache(), csvFile.Name())
 }
 
 // RunParser returns Tuples and Events resulting from the execution of a

--- a/lib/marshal/testing.go
+++ b/lib/marshal/testing.go
@@ -39,12 +39,15 @@ type tuplesAndEvents = struct {
 }
 
 // GetFatalError retourne le message d'erreur fatale obtenu suite à une
-// opération de parsing.
+// opération de parsing, ou une chaine vide.
 func GetFatalError(output tuplesAndEvents) string {
 	reportData, _ := output.Events[0].ParseReport()
 	headFatal, ok := reportData["headFatal"].([]interface{})
-	if ok != true || len(headFatal) != 1 {
+	if ok != true || headFatal == nil || len(headFatal) < 1 {
 		return ""
+	}
+	if len(headFatal) > 1 {
+		log.Fatal("headFatal should never contain more than one item")
 	}
 	return headFatal[0].(string)
 }

--- a/lib/parsing/main.go
+++ b/lib/parsing/main.go
@@ -1,3 +1,6 @@
+// Ce paquet centralise les parseurs de fichiers pour les mettre à
+// disposition de `engine`.
+
 package parsing
 
 import (

--- a/lib/paydex/main.go
+++ b/lib/paydex/main.go
@@ -21,9 +21,9 @@ import (
 
 // Paydex décrit le format de chaque entrée de donnée résultant du parsing.
 type Paydex struct {
-	Siren      string    `json:"siren" bson:"siren"`
-	DateValeur time.Time `json:"date_valeur" bson:"date_valeur"`
-	NbJours    int       `json:"nb_jours" bson:"nb_jours"`
+	Siren      string    `col:"SIREN" json:"siren" bson:"siren"`
+	DateValeur time.Time `col:"DATE_VALEUR" json:"date_valeur" bson:"date_valeur"`
+	NbJours    int       `col:"NB_JOURS" json:"nb_jours" bson:"nb_jours"`
 }
 
 // Key _id de l'objet
@@ -69,9 +69,7 @@ func (parser *paydexParser) Open(filePath string) (err error) {
 	}
 	headerRow, err := parser.reader.Read()
 	if err == nil {
-		expectedFields := []string{"SIREN", "NB_JOURS", "DATE_VALEUR"}
-		parser.colIndex = marshal.IndexFields(headerRow, expectedFields)
-		_, err = parser.colIndex.HasFields(expectedFields)
+		parser.colIndex, err = marshal.ValidateAndIndexColumnsFromColTags(headerRow, Paydex{})
 	}
 	return err
 }

--- a/lib/paydex/main.go
+++ b/lib/paydex/main.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/base"
@@ -67,9 +66,11 @@ func (parser *paydexParser) Open(filePath string) (err error) {
 	if err != nil {
 		return err
 	}
-	row, err := parser.reader.Read() // parse header
-	if strings.Join(row, ";") != "SIREN;NB_JOURS;NB_JOURS_LIB;DATE_VALEUR" {
-		err = fmt.Errorf("unexpected header: %v", strings.Join(row, ";"))
+	headerRow, err := parser.reader.Read()
+	if err == nil {
+		expectedFields := []string{"SIREN", "NB_JOURS", "DATE_VALEUR"}
+		colIndex := marshal.IndexFields(headerRow, expectedFields)
+		_, err = colIndex.HasFields(expectedFields)
 	}
 	return err
 }

--- a/lib/paydex/main_test.go
+++ b/lib/paydex/main_test.go
@@ -41,9 +41,7 @@ func TestPaydex(t *testing.T) {
 	t.Run("should fail if one of the required columns is missing", func(t *testing.T) {
 		output := marshal.RunParserInline(t, ParserPaydex, []string{"SIREN;NB_JOURS_LIB;DATE_VALEUR"}) // NB_JOURS is missing
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
-		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
-		reportData, _ := output.Events[0].ParseReport()
-		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
+		assert.Contains(t, marshal.GetFatalError(output), "Fatal: Colonne NB_JOURS non trouvée. Abandon.")
 	})
 
 	t.Run("should adapt to different order of columns", func(t *testing.T) {

--- a/lib/paydex/main_test.go
+++ b/lib/paydex/main_test.go
@@ -49,6 +49,21 @@ func TestPaydex(t *testing.T) {
 		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
 	})
 
+	t.Run("should adapt to different order of columns", func(t *testing.T) {
+		csvData := strings.Join([]string{
+			"SIREN;DATE_VALEUR;NB_JOURS",
+			"000000001;15/12/2018;2",
+		}, "\n")
+		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
+		output := marshal.RunParser(ParserPaydex, marshal.NewCache(), csvFile.Name())
+		expected := Paydex{
+			Siren:      "000000001",
+			DateValeur: time.Date(2018, 12, 15, 00, 00, 00, 0, time.UTC),
+			NbJours:    2,
+		}
+		assert.EqualValues(t, []marshal.Tuple{&expected}, output.Tuples)
+	})
+
 	t.Run("should generate the right tuples and events from test file", func(t *testing.T) {
 		var golden = filepath.Join("testData", "expectedPaydex.json")
 		var testData = filepath.Join("testData", "paydexTestData.csv")

--- a/lib/paydex/main_test.go
+++ b/lib/paydex/main_test.go
@@ -3,7 +3,6 @@ package paydex
 import (
 	"flag"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -40,9 +39,7 @@ func TestParsePaydexLine(t *testing.T) {
 // integration tests
 func TestPaydex(t *testing.T) {
 	t.Run("should fail if one of the required columns is missing", func(t *testing.T) {
-		csvData := strings.Join([]string{"SIREN;NB_JOURS_LIB;DATE_VALEUR"}, "\n") // NB_JOURS is missing
-		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
-		output := marshal.RunParser(ParserPaydex, marshal.NewCache(), csvFile.Name())
+		output := marshal.RunParserInline(t, ParserPaydex, []string{"SIREN;NB_JOURS_LIB;DATE_VALEUR"}) // NB_JOURS is missing
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
 		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
 		reportData, _ := output.Events[0].ParseReport()
@@ -50,12 +47,11 @@ func TestPaydex(t *testing.T) {
 	})
 
 	t.Run("should adapt to different order of columns", func(t *testing.T) {
-		csvData := strings.Join([]string{
+		csvRows := []string{
 			"SIREN;DATE_VALEUR;NB_JOURS",
 			"000000001;15/12/2018;2",
-		}, "\n")
-		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
-		output := marshal.RunParser(ParserPaydex, marshal.NewCache(), csvFile.Name())
+		}
+		output := marshal.RunParserInline(t, ParserPaydex, csvRows)
 		expected := Paydex{
 			Siren:      "000000001",
 			DateValeur: time.Date(2018, 12, 15, 00, 00, 00, 0, time.UTC),

--- a/lib/paydex/main_test.go
+++ b/lib/paydex/main_test.go
@@ -46,6 +46,7 @@ func TestPaydex(t *testing.T) {
 		reportData, _ := output.Events[0].ParseReport()
 		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
 	})
+
 	t.Run("should generate the right tuples and events from test file", func(t *testing.T) {
 		var golden = filepath.Join("testData", "expectedPaydex.json")
 		var testData = filepath.Join("testData", "paydexTestData.csv")

--- a/lib/paydex/main_test.go
+++ b/lib/paydex/main_test.go
@@ -22,14 +22,16 @@ func TestParsePaydexLine(t *testing.T) {
 			DateValeur: time.Date(2018, 12, 15, 00, 00, 00, 0, time.UTC),
 			NbJours:    2,
 		}
-		actual, err := parsePaydexLine(row)
+		colIndex := marshal.ColMapping{"SIREN": 0, "NB_JOURS": 1, "DATE_VALEUR": 3}
+		actual, err := parsePaydexLine(colIndex, row)
 		assert.Equal(t, expected, *actual)
 		assert.Equal(t, nil, err)
 	})
 
 	t.Run("should report parse error on invalid date", func(t *testing.T) {
 		row := []string{"000000001", "2", "2 jours", "12/15/2018"} // "15" is in the "month" slot
-		actual, err := parsePaydexLine(row)
+		colIndex := marshal.ColMapping{"SIREN": 0, "NB_JOURS": 1, "DATE_VALEUR": 3}
+		actual, err := parsePaydexLine(colIndex, row)
 		assert.EqualError(t, err, "invalid date: 12/15/2018")
 		assert.Nil(t, actual)
 	})

--- a/lib/sirene/main.go
+++ b/lib/sirene/main.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -46,7 +45,7 @@ type Sirene struct {
 }
 
 // liste des colonnes attendues, dans l'ordre attendu
-var fields = []string{
+var expectedFields = []string{
 	"siren", // TODO: construire cette liste par reflection des champs de Sirene ? ou détecter les indices depuis l'en-tête ?
 	"nic",
 	"siret",
@@ -207,11 +206,10 @@ func (parser *sireneParser) Open(filePath string) (err error) {
 	headerRow, err := parser.reader.Read()
 	if err != nil {
 		return err // may be io.EOF
-	} else if !reflect.DeepEqual(headerRow, fields) {
-		return errors.New("sirene header does not match the parser's expectations")
 	}
 	parser.colIndex = marshal.GetFieldBindings(headerRow)
-	return nil
+	_, err = parser.colIndex.HasFields(expectedFields)
+	return err
 }
 
 func (parser *sireneParser) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {

--- a/lib/sirene/main.go
+++ b/lib/sirene/main.go
@@ -105,14 +105,6 @@ var fields = []string{
 	"geo_l5",
 }
 
-func getFieldBindings(fields []string) map[string]int {
-	var f = map[string]int{}
-	for i, k := range fields {
-		f[k] = i
-	}
-	return f
-}
-
 var typeVoie = map[string]string{
 	"ALL":  "ALLÉE",
 	"AV":   "AVENUE",
@@ -221,7 +213,7 @@ func (parser *sireneParser) Open(filePath string) (err error) {
 }
 
 func (parser *sireneParser) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {
-	f := getFieldBindings(fields)
+	f := marshal.GetFieldBindings(fields)
 	for {
 		parsedLine := marshal.ParsedLineResult{}
 		row, err := parser.reader.Read()

--- a/lib/sirene/main.go
+++ b/lib/sirene/main.go
@@ -18,91 +18,30 @@ import (
 
 // Sirene informations sur les entreprises
 type Sirene struct {
-	Siren                string     `json:"siren,omitempty" bson:"siren,omitempty"`
-	Nic                  string     `json:"nic,omitempty" bson:"nic,omitempty"`
-	Siege                bool       `json:"siege,omitempty" bson:"siege,omitempty"`
-	ComplementAdresse    string     `json:"complement_adresse,omitempty" bson:"complement_adresse,omitempty"`
-	NumVoie              string     `json:"numero_voie,omitempty" bson:"numero_voie,omitempty"`
-	IndRep               string     `json:"indrep,omitempty" bson:"indrep,omitempty"`
-	TypeVoie             string     `json:"type_voie,omitempty" bson:"type_voie,omitempty"`
-	Voie                 string     `json:"voie,omitempty" bson:"voie,omitempty"`
-	Commune              string     `json:"commune,omitempty" bson:"commune,omitempty"`
-	CommuneEtranger      string     `json:"commune_etranger,omitempty" bson:"commune_etranger,omitempty"`
-	DistributionSpeciale string     `json:"distribution_speciale,omitempty" bson:"distribution_speciale,omitempty"`
-	CodeCommune          string     `json:"code_commune,omitempty" bson:"code_commune,omitempty"`
-	CodeCedex            string     `json:"code_cedex,omitempty" bson:"code_cedex,omitempty"`
-	Cedex                string     `json:"cedex,omitempty" bson:"cedex,omitempty"`
-	CodePaysEtranger     string     `json:"code_pays_etranger,omitempty" bson:"code_pays_etranger,omitempty"`
-	PaysEtranger         string     `json:"pays_etranger,omitempty" bson:"pays_etranger,omitempty"`
-	CodePostal           string     `json:"code_postal,omitempty" bson:"code_postal,omitempty"`
+	Siren                string     `col:"siren" json:"siren,omitempty" bson:"siren,omitempty"`
+	Nic                  string     `col:"nic" json:"nic,omitempty" bson:"nic,omitempty"`
+	Siege                bool       `col:"etablissementSiege" json:"siege,omitempty" bson:"siege,omitempty"`
+	ComplementAdresse    string     `col:"complementAdresseEtablissement" json:"complement_adresse,omitempty" bson:"complement_adresse,omitempty"`
+	NumVoie              string     `col:"numeroVoieEtablissement" json:"numero_voie,omitempty" bson:"numero_voie,omitempty"`
+	IndRep               string     `col:"indiceRepetitionEtablissement" json:"indrep,omitempty" bson:"indrep,omitempty"`
+	TypeVoie             string     `col:"typeVoieEtablissement" json:"type_voie,omitempty" bson:"type_voie,omitempty"`
+	Voie                 string     `col:"libelleVoieEtablissement" json:"voie,omitempty" bson:"voie,omitempty"`
+	Commune              string     `col:"libelleCommuneEtablissement" json:"commune,omitempty" bson:"commune,omitempty"`
+	CommuneEtranger      string     `col:"libelleCommuneEtrangerEtablissement" json:"commune_etranger,omitempty" bson:"commune_etranger,omitempty"`
+	DistributionSpeciale string     `col:"distributionSpecialeEtablissement" json:"distribution_speciale,omitempty" bson:"distribution_speciale,omitempty"`
+	CodeCommune          string     `col:"codeCommuneEtablissement" json:"code_commune,omitempty" bson:"code_commune,omitempty"`
+	CodeCedex            string     `col:"codeCedexEtablissement" json:"code_cedex,omitempty" bson:"code_cedex,omitempty"`
+	Cedex                string     `col:"libelleCedexEtablissement" json:"cedex,omitempty" bson:"cedex,omitempty"`
+	CodePaysEtranger     string     `col:"codePaysEtrangerEtablissement" json:"code_pays_etranger,omitempty" bson:"code_pays_etranger,omitempty"`
+	PaysEtranger         string     `col:"libellePaysEtrangerEtablissement" json:"pays_etranger,omitempty" bson:"pays_etranger,omitempty"`
+	CodePostal           string     `col:"codePostalEtablissement" json:"code_postal,omitempty" bson:"code_postal,omitempty"`
 	Departement          string     `json:"departement,omitempty" bson:"departement,omitempty"`
 	APE                  string     `json:"ape,omitempty" bson:"ape,omitempty"`
-	CodeActivite         string     `json:"code_activite,omitempty" bson:"code_activite,omitempty"`
-	NomenActivite        string     `json:"nomen_activite,omitempty" bson:"nomen_activite,omitempty"`
-	Creation             *time.Time `json:"date_creation,omitempty" bson:"date_creation,omitempty"`
-	Longitude            float64    `json:"longitude,omitempty" bson:"longitude,omitempty"`
-	Latitude             float64    `json:"latitude,omitempty" bson:"latitude,omitempty"`
-}
-
-// liste des colonnes attendues, dans l'ordre attendu
-var expectedFields = []string{
-	"siren", // TODO: construire cette liste par reflection des champs de Sirene ? ou détecter les indices depuis l'en-tête ?
-	"nic",
-	"siret",
-	"statutDiffusionEtablissement",
-	"dateCreationEtablissement",
-	"trancheEffectifsEtablissement",
-	"anneeEffectifsEtablissement",
-	"activitePrincipaleRegistreMetiersEtablissement",
-	"dateDernierTraitementEtablissement",
-	"etablissementSiege",
-	"nombrePeriodesEtablissement",
-	"complementAdresseEtablissement",
-	"numeroVoieEtablissement",
-	"indiceRepetitionEtablissement",
-	"typeVoieEtablissement",
-	"libelleVoieEtablissement",
-	"codePostalEtablissement",
-	"libelleCommuneEtablissement",
-	"libelleCommuneEtrangerEtablissement",
-	"distributionSpecialeEtablissement",
-	"codeCommuneEtablissement",
-	"codeCedexEtablissement",
-	"libelleCedexEtablissement",
-	"codePaysEtrangerEtablissement",
-	"libellePaysEtrangerEtablissement",
-	"complementAdresse2Etablissement",
-	"numeroVoie2Etablissement",
-	"indiceRepetition2Etablissement",
-	"typeVoie2Etablissement",
-	"libelleVoie2Etablissement",
-	"codePostal2Etablissement",
-	"libelleCommune2Etablissement",
-	"libelleCommuneEtranger2Etablissement",
-	"distributionSpeciale2Etablissement",
-	"codeCommune2Etablissement",
-	"codeCedex2Etablissement",
-	"libelleCedex2Etablissement",
-	"codePaysEtranger2Etablissement",
-	"libellePaysEtranger2Etablissement",
-	"dateDebut",
-	"etatAdministratifEtablissement",
-	"enseigne1Etablissement",
-	"enseigne2Etablissement",
-	"enseigne3Etablissement",
-	"denominationUsuelleEtablissement",
-	"activitePrincipaleEtablissement",
-	"nomenclatureActivitePrincipaleEtablissement",
-	"caractereEmployeurEtablissement",
-	"longitude",
-	"latitude",
-	"geo_score",
-	"geo_type",
-	"geo_adresse",
-	"geo_id",
-	"geo_ligne",
-	"geo_l4",
-	"geo_l5",
+	CodeActivite         string     `col:"activitePrincipaleEtablissement" json:"code_activite,omitempty" bson:"code_activite,omitempty"`
+	NomenActivite        string     `col:"nomenclatureActivitePrincipaleEtablissement" json:"nomen_activite,omitempty" bson:"nomen_activite,omitempty"`
+	Creation             *time.Time `col:"dateCreationEtablissement" json:"date_creation,omitempty" bson:"date_creation,omitempty"`
+	Longitude            float64    `col:"longitude" json:"longitude,omitempty" bson:"longitude,omitempty"`
+	Latitude             float64    `col:"latitude" json:"latitude,omitempty" bson:"latitude,omitempty"`
 }
 
 var typeVoie = map[string]string{
@@ -208,6 +147,7 @@ func (parser *sireneParser) Open(filePath string) (err error) {
 		return err // may be io.EOF
 	}
 	parser.colIndex = marshal.GetFieldBindings(headerRow)
+	expectedFields := marshal.ExtractColTags(Sirene{})
 	_, err = parser.colIndex.HasFields(expectedFields)
 	return err
 }

--- a/lib/sirene/main.go
+++ b/lib/sirene/main.go
@@ -146,9 +146,7 @@ func (parser *sireneParser) Open(filePath string) (err error) {
 	if err != nil {
 		return err // may be io.EOF
 	}
-	parser.colIndex = marshal.GetFieldBindings(headerRow)
-	expectedFields := marshal.ExtractColTags(Sirene{})
-	_, err = parser.colIndex.HasFields(expectedFields)
+	parser.colIndex, err = marshal.ValidateAndIndexColumnsFromColTags(headerRow, Sirene{})
 	return err
 }
 

--- a/lib/sirene/main.go
+++ b/lib/sirene/main.go
@@ -45,8 +45,9 @@ type Sirene struct {
 	Latitude             float64    `json:"latitude,omitempty" bson:"latitude,omitempty"`
 }
 
+// liste des colonnes attendues, dans l'ordre attendu
 var fields = []string{
-	"siren",
+	"siren", // TODO: construire cette liste par reflection des champs de Sirene ? ou détecter les indices depuis l'en-tête ?
 	"nic",
 	"siret",
 	"statutDiffusionEtablissement",

--- a/lib/sirene/main_test.go
+++ b/lib/sirene/main_test.go
@@ -21,9 +21,6 @@ func TestSirene(t *testing.T) {
 	t.Run("should fail if a required column is missing", func(t *testing.T) {
 		output := marshal.RunParserInline(t, Parser, []string{"siren"}) // many columns are missing
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
-		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
-		reportData, _ := output.Events[0].ParseReport()
-		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
-		assert.Regexp(t, regexp.MustCompile("Colonne [^ ]+ non trouvée"), reportData["headFatal"])
+		assert.Regexp(t, regexp.MustCompile("Colonne [^ ]+ non trouvée"), marshal.GetFatalError(output))
 	})
 }

--- a/lib/sirene/main_test.go
+++ b/lib/sirene/main_test.go
@@ -3,9 +3,12 @@ package sirene
 import (
 	"flag"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/marshal"
+	"github.com/stretchr/testify/assert"
 )
 
 var update = flag.Bool("update", false, "Update the expected test values in golden file")
@@ -15,4 +18,15 @@ var testData = filepath.Join("testData", "sireneTestData.csv")
 
 func TestSirene(t *testing.T) {
 	marshal.TestParserOutput(t, Parser, marshal.NewCache(), testData, golden, *update)
+
+	t.Run("should fail if a required column is missing", func(t *testing.T) {
+		csvData := strings.Join([]string{"siren"}, "\n") // many columns are missing
+		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
+		output := marshal.RunParser(Parser, marshal.NewCache(), csvFile.Name())
+		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
+		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
+		reportData, _ := output.Events[0].ParseReport()
+		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
+		assert.Regexp(t, regexp.MustCompile("Colonne [^ ]+ non trouvée"), reportData["headFatal"])
+	})
 }

--- a/lib/sirene/main_test.go
+++ b/lib/sirene/main_test.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/marshal"
@@ -20,9 +19,7 @@ func TestSirene(t *testing.T) {
 	marshal.TestParserOutput(t, Parser, marshal.NewCache(), testData, golden, *update)
 
 	t.Run("should fail if a required column is missing", func(t *testing.T) {
-		csvData := strings.Join([]string{"siren"}, "\n") // many columns are missing
-		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
-		output := marshal.RunParser(Parser, marshal.NewCache(), csvFile.Name())
+		output := marshal.RunParserInline(t, Parser, []string{"siren"}) // many columns are missing
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
 		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
 		reportData, _ := output.Events[0].ParseReport()

--- a/lib/sirene_ul/main_test.go
+++ b/lib/sirene_ul/main_test.go
@@ -23,17 +23,13 @@ func TestSireneUlHeader(t *testing.T) {
 		csvRows := []string{"siren,statutDiffusionUniteLegale,unitePurgeeUniteLegale,dateCreationUniteLegale,sigleUniteLegale,sexeUniteLegale,prenom1UniteLegale,prenom2UniteLegale,prenom3UniteLegale,prenom4UniteLegale,prenomUsuelUniteLegale,pseudonymeUniteLegale,identifiantAssociationUniteLegale,trancheEffectifsUniteLegale,anneeEffectifsUniteLegale,dateDernierTraitementUniteLegale,nombrePeriodesUniteLegale,categorieEntreprise,anneeCategorieEntreprise,dateDebut,etatAdministratifUniteLegale,nomUniteLegale,nomUsageUniteLegale,denominationUniteLegale,denominationUsuelle1UniteLegale,denominationUsuelle2UniteLegale,denominationUsuelle3UniteLegale,categorieJuridiqueUniteLegale,activitePrincipaleUniteLegale,nomenclatureActivitePrincipaleUniteLegale,nicSiegeUniteLegale,economieSocialeSolidaireUniteLegale,caractereEmployeurUniteLegale"}
 		output := marshal.RunParserInline(t, Parser, csvRows)
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
-		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
-		reportData, _ := output.Events[0].ParseReport()
-		assert.Equal(t, false, reportData["isFatal"], "should not report a fatal error")
+		assert.Equal(t, "", marshal.GetFatalError(output), "should not report a fatal error")
 	})
 
 	t.Run("reports a fatal error in case of unexpected csv header", func(t *testing.T) {
 		csvRows := []string{"sirenXYZ,statutDiffusionUniteLegale,unitePurgeeUniteLegale,dateCreationUniteLegale,sigleUniteLegale,sexeUniteLegale,prenom1UniteLegale,prenom2UniteLegale,prenom3UniteLegale,prenom4UniteLegale,prenomUsuelUniteLegale,pseudonymeUniteLegale,identifiantAssociationUniteLegale,trancheEffectifsUniteLegale,anneeEffectifsUniteLegale,dateDernierTraitementUniteLegale,nombrePeriodesUniteLegale,categorieEntreprise,anneeCategorieEntreprise,dateDebut,etatAdministratifUniteLegale,nomUniteLegale,nomUsageUniteLegale,denominationUniteLegale,denominationUsuelle1UniteLegale,denominationUsuelle2UniteLegale,denominationUsuelle3UniteLegale,categorieJuridiqueUniteLegale,activitePrincipaleUniteLegale,nomenclatureActivitePrincipaleUniteLegale,nicSiegeUniteLegale,economieSocialeSolidaireUniteLegale,caractereEmployeurUniteLegale"}
 		output := marshal.RunParserInline(t, Parser, csvRows)
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
-		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
-		reportData, _ := output.Events[0].ParseReport()
-		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
+		assert.Equal(t, "Fatal: sirene_ul header does not match the parser's expectations", marshal.GetFatalError(output))
 	})
 }

--- a/lib/sirene_ul/main_test.go
+++ b/lib/sirene_ul/main_test.go
@@ -3,7 +3,6 @@ package sireneul
 import (
 	"flag"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/marshal"
@@ -21,11 +20,8 @@ func TestSireneUl(t *testing.T) {
 
 func TestSireneUlHeader(t *testing.T) {
 	t.Run("can parse file that just contains a header", func(t *testing.T) {
-		csvData := strings.Join([]string{
-			"siren,statutDiffusionUniteLegale,unitePurgeeUniteLegale,dateCreationUniteLegale,sigleUniteLegale,sexeUniteLegale,prenom1UniteLegale,prenom2UniteLegale,prenom3UniteLegale,prenom4UniteLegale,prenomUsuelUniteLegale,pseudonymeUniteLegale,identifiantAssociationUniteLegale,trancheEffectifsUniteLegale,anneeEffectifsUniteLegale,dateDernierTraitementUniteLegale,nombrePeriodesUniteLegale,categorieEntreprise,anneeCategorieEntreprise,dateDebut,etatAdministratifUniteLegale,nomUniteLegale,nomUsageUniteLegale,denominationUniteLegale,denominationUsuelle1UniteLegale,denominationUsuelle2UniteLegale,denominationUsuelle3UniteLegale,categorieJuridiqueUniteLegale,activitePrincipaleUniteLegale,nomenclatureActivitePrincipaleUniteLegale,nicSiegeUniteLegale,economieSocialeSolidaireUniteLegale,caractereEmployeurUniteLegale",
-		}, "\n")
-		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
-		output := marshal.RunParser(Parser, marshal.NewCache(), csvFile.Name())
+		csvRows := []string{"siren,statutDiffusionUniteLegale,unitePurgeeUniteLegale,dateCreationUniteLegale,sigleUniteLegale,sexeUniteLegale,prenom1UniteLegale,prenom2UniteLegale,prenom3UniteLegale,prenom4UniteLegale,prenomUsuelUniteLegale,pseudonymeUniteLegale,identifiantAssociationUniteLegale,trancheEffectifsUniteLegale,anneeEffectifsUniteLegale,dateDernierTraitementUniteLegale,nombrePeriodesUniteLegale,categorieEntreprise,anneeCategorieEntreprise,dateDebut,etatAdministratifUniteLegale,nomUniteLegale,nomUsageUniteLegale,denominationUniteLegale,denominationUsuelle1UniteLegale,denominationUsuelle2UniteLegale,denominationUsuelle3UniteLegale,categorieJuridiqueUniteLegale,activitePrincipaleUniteLegale,nomenclatureActivitePrincipaleUniteLegale,nicSiegeUniteLegale,economieSocialeSolidaireUniteLegale,caractereEmployeurUniteLegale"}
+		output := marshal.RunParserInline(t, Parser, csvRows)
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
 		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
 		reportData, _ := output.Events[0].ParseReport()
@@ -33,11 +29,8 @@ func TestSireneUlHeader(t *testing.T) {
 	})
 
 	t.Run("reports a fatal error in case of unexpected csv header", func(t *testing.T) {
-		csvData := strings.Join([]string{
-			"sirenXYZ,statutDiffusionUniteLegale,unitePurgeeUniteLegale,dateCreationUniteLegale,sigleUniteLegale,sexeUniteLegale,prenom1UniteLegale,prenom2UniteLegale,prenom3UniteLegale,prenom4UniteLegale,prenomUsuelUniteLegale,pseudonymeUniteLegale,identifiantAssociationUniteLegale,trancheEffectifsUniteLegale,anneeEffectifsUniteLegale,dateDernierTraitementUniteLegale,nombrePeriodesUniteLegale,categorieEntreprise,anneeCategorieEntreprise,dateDebut,etatAdministratifUniteLegale,nomUniteLegale,nomUsageUniteLegale,denominationUniteLegale,denominationUsuelle1UniteLegale,denominationUsuelle2UniteLegale,denominationUsuelle3UniteLegale,categorieJuridiqueUniteLegale,activitePrincipaleUniteLegale,nomenclatureActivitePrincipaleUniteLegale,nicSiegeUniteLegale,economieSocialeSolidaireUniteLegale,caractereEmployeurUniteLegale",
-		}, "\n")
-		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
-		output := marshal.RunParser(Parser, marshal.NewCache(), csvFile.Name())
+		csvRows := []string{"sirenXYZ,statutDiffusionUniteLegale,unitePurgeeUniteLegale,dateCreationUniteLegale,sigleUniteLegale,sexeUniteLegale,prenom1UniteLegale,prenom2UniteLegale,prenom3UniteLegale,prenom4UniteLegale,prenomUsuelUniteLegale,pseudonymeUniteLegale,identifiantAssociationUniteLegale,trancheEffectifsUniteLegale,anneeEffectifsUniteLegale,dateDernierTraitementUniteLegale,nombrePeriodesUniteLegale,categorieEntreprise,anneeCategorieEntreprise,dateDebut,etatAdministratifUniteLegale,nomUniteLegale,nomUsageUniteLegale,denominationUniteLegale,denominationUsuelle1UniteLegale,denominationUsuelle2UniteLegale,denominationUsuelle3UniteLegale,categorieJuridiqueUniteLegale,activitePrincipaleUniteLegale,nomenclatureActivitePrincipaleUniteLegale,nicSiegeUniteLegale,economieSocialeSolidaireUniteLegale,caractereEmployeurUniteLegale"}
+		output := marshal.RunParserInline(t, Parser, csvRows)
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
 		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
 		reportData, _ := output.Events[0].ParseReport()

--- a/lib/urssaf/effectif.go
+++ b/lib/urssaf/effectif.go
@@ -83,7 +83,7 @@ func parseEffectifColMapping(reader *csv.Reader) (marshal.ColMapping, []periodCo
 	}
 
 	expectedFields := []string{"siret", "compte"}
-	var idx = marshal.IndexFields(marshal.LowercaseFields(fields), expectedFields)
+	var idx = marshal.IndexSpecificFields(marshal.LowercaseFields(fields), expectedFields)
 	if _, err = idx.HasFields(expectedFields); err != nil {
 		return nil, nil, err
 	}

--- a/lib/urssaf/effectif.go
+++ b/lib/urssaf/effectif.go
@@ -3,7 +3,6 @@ package urssaf
 import (
 	"bufio"
 	"encoding/csv"
-	"errors"
 	"io"
 	"os"
 	"strconv"
@@ -11,7 +10,6 @@ import (
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/base"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/marshal"
-	"github.com/signaux-faibles/opensignauxfaibles/lib/misc"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/sfregexp"
 )
 
@@ -86,12 +84,8 @@ func parseEffectifColMapping(reader *csv.Reader) (marshal.ColMapping, []periodCo
 
 	expectedFields := []string{"siret", "compte"}
 	var idx = marshal.IndexFields(fields, expectedFields)
-
-	if misc.SliceMin(idx["siret"], idx["compte"]) == -1 {
-		return nil, nil, errors.New("erreur à l'analyse du fichier, abandon, l'un " +
-			"des champs obligatoires n'a pu etre trouve:" +
-			" siretIndex = " + strconv.Itoa(idx["siret"]) +
-			", compteIndex = " + strconv.Itoa(idx["compte"]))
+	if _, err = idx.HasFields(expectedFields); err != nil {
+		return nil, nil, err
 	}
 
 	// Dans quels champs lire l'effectif

--- a/lib/urssaf/effectif.go
+++ b/lib/urssaf/effectif.go
@@ -83,7 +83,7 @@ func parseEffectifColMapping(reader *csv.Reader) (marshal.ColMapping, []periodCo
 	}
 
 	expectedFields := []string{"siret", "compte"}
-	var idx = marshal.IndexFields(fields, expectedFields)
+	var idx = marshal.IndexFields(marshal.LowercaseFields(fields), expectedFields)
 	if _, err = idx.HasFields(expectedFields); err != nil {
 		return nil, nil, err
 	}

--- a/lib/urssaf/effectif_ent.go
+++ b/lib/urssaf/effectif_ent.go
@@ -92,7 +92,7 @@ func parseEffectifEntColMapping(reader *csv.Reader) (marshal.ColMapping, []perio
 		return nil, nil, err
 	}
 	expectedFields := []string{"siren"}
-	var idx = marshal.IndexFields(fields, expectedFields)
+	var idx = marshal.IndexFields(marshal.LowercaseFields(fields), expectedFields)
 	// Dans quels champs lire l'effectifEnt
 	periods := parseEffectifPeriod(fields)
 	return idx, periods, nil

--- a/lib/urssaf/effectif_ent.go
+++ b/lib/urssaf/effectif_ent.go
@@ -92,7 +92,7 @@ func parseEffectifEntColMapping(reader *csv.Reader) (marshal.ColMapping, []perio
 		return nil, nil, err
 	}
 	expectedFields := []string{"siren"}
-	var idx = marshal.IndexFields(marshal.LowercaseFields(fields), expectedFields)
+	var idx = marshal.IndexSpecificFields(marshal.LowercaseFields(fields), expectedFields)
 	// Dans quels champs lire l'effectifEnt
 	periods := parseEffectifPeriod(fields)
 	return idx, periods, nil

--- a/lib/urssaf/effectif_ent.go
+++ b/lib/urssaf/effectif_ent.go
@@ -7,12 +7,10 @@ import (
 	"os"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/base"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/marshal"
-	"github.com/signaux-faibles/opensignauxfaibles/lib/misc"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/sfregexp"
 )
 
@@ -45,7 +43,7 @@ type effectifEntParser struct {
 	file    *os.File
 	reader  *csv.Reader
 	periods []periodCol
-	idx     colMapping
+	idx     marshal.ColMapping
 }
 
 func (parser *effectifEntParser) GetFileType() string {
@@ -88,14 +86,13 @@ func (parser *effectifEntParser) ParseLines(parsedLineChan chan marshal.ParsedLi
 	}
 }
 
-func parseEffectifEntColMapping(reader *csv.Reader) (colMapping, []periodCol, error) {
+func parseEffectifEntColMapping(reader *csv.Reader) (marshal.ColMapping, []periodCol, error) {
 	fields, err := reader.Read()
 	if err != nil {
 		return nil, nil, err
 	}
-	var idx = colMapping{
-		"siren": misc.SliceIndex(len(fields), func(i int) bool { return strings.ToLower(fields[i]) == "siren" }),
-	}
+	expectedFields := []string{"siren"}
+	var idx = marshal.IndexFields(fields, expectedFields)
 	// Dans quels champs lire l'effectifEnt
 	periods := parseEffectifPeriod(fields)
 	return idx, periods, nil
@@ -119,7 +116,7 @@ func parseEffectifPeriod(fields []string) []periodCol {
 	return periods
 }
 
-func parseEffectifEntLine(row []string, idx colMapping, periods *[]periodCol, parsedLine *marshal.ParsedLineResult) {
+func parseEffectifEntLine(row []string, idx marshal.ColMapping, periods *[]periodCol, parsedLine *marshal.ParsedLineResult) {
 	for _, period := range *periods {
 		value := row[period.colIndex]
 		if value != "" {

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/marshal"
@@ -135,9 +134,7 @@ func TestEffectif(t *testing.T) {
 	})
 
 	t.Run("Effectif ne peut pas être importé s'il manque une colonne", func(t *testing.T) {
-		csvData := strings.Join([]string{"siret"}, "\n") // "compte" column is missing
-		csvFile := marshal.CreateTempFileWithContent(t, []byte(csvData))
-		output := marshal.RunParser(ParserEffectif, marshal.NewCache(), csvFile.Name())
+		output := marshal.RunParserInline(t, ParserEffectif, []string{"siret"}) // "compte" column is missing
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
 		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
 		reportData, _ := output.Events[0].ParseReport()

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -2,7 +2,6 @@ package urssaf
 
 import (
 	"flag"
-	"log"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -143,8 +142,7 @@ func TestEffectif(t *testing.T) {
 		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
 		reportData, _ := output.Events[0].ParseReport()
 		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
-		log.Println(reportData["headFatal"])
-		assert.Regexp(t, regexp.MustCompile("champs obligatoires n'a pu etre trouve"), reportData["headFatal"])
+		assert.Regexp(t, regexp.MustCompile("Colonne compte non trouvée"), reportData["headFatal"])
 	})
 }
 

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -137,9 +137,7 @@ func TestEffectif(t *testing.T) {
 		output := marshal.RunParserInline(t, ParserEffectif, []string{"siret"}) // "compte" column is missing
 		assert.Equal(t, []marshal.Tuple(nil), output.Tuples, "should return no tuples")
 		assert.Equal(t, 1, len(output.Events), "should return a parsing report")
-		reportData, _ := output.Events[0].ParseReport()
-		assert.Equal(t, true, reportData["isFatal"], "should report a fatal error")
-		assert.Regexp(t, regexp.MustCompile("Colonne compte non trouvée"), reportData["headFatal"])
+		assert.Regexp(t, regexp.MustCompile("Colonne compte non trouvée"), marshal.GetFatalError(output))
 	})
 }
 


### PR DESCRIPTION
## Objectifs

- Dé-duplication: définir une fonction partagée pour indexer la position des colonnes de fichiers csv parsés
- Concision et documentation: spécifier les colonnes obligatoires sous forme d'annotations des champs du type de destination
- Robustesse: permettre aux parseurs de s'adapter si l'ordre des colonnes change, tout en vérifiant que les colonnes obligatoires sont bien présentes

## Mise en oeuvre

1. J'ai repéré 3 parseurs ayant des manières différentes (mais représentatives) d'indexer et valider les colonnes attendues: `apdemande`, `sirene` / `sirene_ul`, `effectif` / `effectif_ent` et `paydex`
2. Ajouté des tests pour prévenir les regressions sur la validation de colonnes
3. Progressivement mis en places des fonctions communes pour valider et indexer les colonnes dans ces parseurs, notamment `ValidateAndIndexColumnsFromColTags ()`
4. Refactorisé les tests pour réduire leur redondance

## Prochaines étapes proposées

- Généraliser l'usage de `ValidateAndIndexColumnsFromColTags ()` dans les parseurs restants.