### PR TITLE
fix(CI): Suivre aussi la couverture de tests du code Go sur Codacy

### DIFF
--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Go test
         run: |
           go test -coverprofile=go-coverage.out ./...
-          go run github.com/axw/gocov/gocov convert go-coverage.out | go run github.com/AlekSi/gocov-xml > go-coverage.xml
+          go run github.com/axw/gocov/gocov convert go-coverage.out > go-coverage.json
+          go run github.com/AlekSi/gocov-xml -source $PWD/go-coverage.json > go-coverage.xml
 
       - name: Use cache for Node/npm dependencies
         uses: actions/cache@v1

--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -29,7 +29,13 @@ jobs:
         run: go build -o "sfdata" -v .
 
       - name: Go test
-        run: go test -coverprofile=go-coverage.out ./...
+        run: |
+          go test -coverprofile=go-coverage.out ./...
+          # Prerequisites
+          go get github.com/axw/gocov/gocov
+          go get github.com/AlekSi/gocov-xml
+          # Coverage
+          gocov convert go-coverage.out | gocov-xml > go-coverage.xml
 
       - name: Use cache for Node/npm dependencies
         uses: actions/cache@v1
@@ -77,4 +83,4 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_REPOSITORY_TOKEN_FOR_COVERAGE }}
-          coverage-reports: go-coverage.out,js/coverage/lcov.info
+          coverage-reports: go-coverage.xml,js/coverage/lcov.info

--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -36,7 +36,9 @@ jobs:
           # echo "go run github.com/AlekSi/gocov-xml -source $PWD/go-coverage.json"
           # go run github.com/AlekSi/gocov-xml -source "$PWD/go-coverage.json" > go-coverage.xml
           # cat go-coverage.xml
-          go run github.com/t-yuki/gocover-cobertura < go-coverage.out > go-coverage.xml,
+          go run github.com/t-yuki/gocover-cobertura < go-coverage.out > go-coverage.xml
+          cat go-coverage.xml
+          echo "$PWD/go-coverage.xml"
 
       - name: Use cache for Node/npm dependencies
         uses: actions/cache@v1

--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           go test -coverprofile=go-coverage.out ./...
           # Prerequisites
-          go get github.com/axw/gocov/gocov
-          go get github.com/AlekSi/gocov-xml
+          go install github.com/axw/gocov/gocov
+          go install github.com/AlekSi/gocov-xml
           # Coverage
           gocov convert go-coverage.out | gocov-xml > go-coverage.xml
 

--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Go build
-        run: go build -o "sfdata" -v .
-
       - name: Go test (with coverage)
         run: |
           go test -coverprofile=go-coverage.out -covermode count ./...

--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -31,11 +31,12 @@ jobs:
       - name: Go test
         run: |
           go test -coverprofile=go-coverage.out ./...
-          go run github.com/axw/gocov/gocov convert go-coverage.out > go-coverage.json
-          cat go-coverage.json
-          echo "go run github.com/AlekSi/gocov-xml -source $PWD/go-coverage.json"
-          go run github.com/AlekSi/gocov-xml -source "$PWD/go-coverage.json" > go-coverage.xml
-          cat go-coverage.xml
+          # go run github.com/axw/gocov/gocov convert go-coverage.out > go-coverage.json
+          # cat go-coverage.json
+          # echo "go run github.com/AlekSi/gocov-xml -source $PWD/go-coverage.json"
+          # go run github.com/AlekSi/gocov-xml -source "$PWD/go-coverage.json" > go-coverage.xml
+          # cat go-coverage.xml
+          go run github.com/t-yuki/gocover-cobertura < go-coverage.out > go-coverage.xml,
 
       - name: Use cache for Node/npm dependencies
         uses: actions/cache@v1

--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      - name: Go build
+        run: go build -o "sfdata" -v .
+
+      - name: Go test
+        run: go test -coverprofile=go-coverage.out ./...
+
       - name: Use cache for Node/npm dependencies
         uses: actions/cache@v1
         with:
@@ -71,4 +77,4 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_REPOSITORY_TOKEN_FOR_COVERAGE }}
-          coverage-reports: js/coverage/lcov.info
+          coverage-reports: go-coverage.out,js/coverage/lcov.info

--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -31,11 +31,7 @@ jobs:
       - name: Go test
         run: |
           go test -coverprofile=go-coverage.out ./...
-          # Prerequisites
-          go install github.com/axw/gocov/gocov
-          go install github.com/AlekSi/gocov-xml
-          # Coverage
-          gocov convert go-coverage.out | gocov-xml > go-coverage.xml
+          go run github.com/axw/gocov/gocov convert go-coverage.out | go run github.com/AlekSi/gocov-xml > go-coverage.xml
 
       - name: Use cache for Node/npm dependencies
         uses: actions/cache@v1

--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -28,17 +28,10 @@ jobs:
       - name: Go build
         run: go build -o "sfdata" -v .
 
-      - name: Go test
+      - name: Go test (with coverage)
         run: |
           go test -coverprofile=go-coverage.out -covermode count ./...
-          # go run github.com/axw/gocov/gocov convert go-coverage.out > go-coverage.json
-          # cat go-coverage.json
-          # echo "go run github.com/AlekSi/gocov-xml -source $PWD/go-coverage.json"
-          # go run github.com/AlekSi/gocov-xml -source "$PWD/go-coverage.json" > go-coverage.xml
-          # cat go-coverage.xml
           go run github.com/t-yuki/gocover-cobertura < go-coverage.out > go-coverage.xml
-          cat go-coverage.xml
-          echo "$PWD/go-coverage.xml"
 
       - name: Use cache for Node/npm dependencies
         uses: actions/cache@v1

--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -32,7 +32,10 @@ jobs:
         run: |
           go test -coverprofile=go-coverage.out ./...
           go run github.com/axw/gocov/gocov convert go-coverage.out > go-coverage.json
-          go run github.com/AlekSi/gocov-xml -source $PWD/go-coverage.json > go-coverage.xml
+          cat go-coverage.json
+          echo "go run github.com/AlekSi/gocov-xml -source $PWD/go-coverage.json"
+          go run github.com/AlekSi/gocov-xml -source "$PWD/go-coverage.json" > go-coverage.xml
+          cat go-coverage.xml
 
       - name: Use cache for Node/npm dependencies
         uses: actions/cache@v1

--- a/.github/workflows/js-functions.yml
+++ b/.github/workflows/js-functions.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Go test
         run: |
-          go test -coverprofile=go-coverage.out ./...
+          go test -coverprofile=go-coverage.out -covermode count ./...
           # go run github.com/axw/gocov/gocov convert go-coverage.out > go-coverage.json
           # cat go-coverage.json
           # echo "go run github.com/AlekSi/gocov-xml -source $PWD/go-coverage.json"


### PR DESCRIPTION
## Bonne nouvelle

Ça marche ! 🥳

## Moins bonne nouvelle

![image](https://user-images.githubusercontent.com/531781/103023007-625d1d80-454d-11eb-80f8-c7c983caebad.png)

... la couverture du code Golang fait baisser notre score sur Codacy 😅 – pour l'instant, en tout cas !

## Prochaines étapes

1. fusionner cette PR avant les autres, pour qu'on voie leur impact sur le score de couverture
2. vérifier dans [la liste des fichiers de Codacy](https://app.codacy.com/gh/signaux-faibles/opensignauxfaibles/files?bid=18037842 ) que nos fichiers Go ont désormais bien un score de couverture 
3. faire le ménage dans les workflows de CI, pour éviter d'exécuter 2 fois les tests Go.
4. augmenter la couverture, en ajoutant des tests, mais aussi en intégrant la couverture lors de l'exécution des tests de bout en bout (si possible)