### PR TITLE
fix(CI): Correction du calcul de couverture par fichier Go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Show coverage
         run: go tool cover -func=go-coverage.out
       - name: Generate coverage report
-        run: go run github.com/t-yuki/gocover-cobertura < go-coverage.out > go-coverage.xml
+        run: go run github.com/richardlt/gocover-cobertura < go-coverage.out > go-coverage.xml
       - uses: actions/upload-artifact@v2
         with:
           name: go-coverage-report


### PR DESCRIPTION
## Problème

Suite à la fusion de PR #286 (sensée augmenter le score de couverture des fichiers Go), le score de couverture rapporté par Codacy a baissé de 29 points. (cf https://github.com/signaux-faibles/opensignauxfaibles/pull/286#issuecomment-757772441)

## Analyse

En réexécutant en local la chaine de mesure employé en CI, je me suis rendu compte que nos fichiers Go les plus couverts montraient un score très bas sur codacy (ex: [`apconso.go`](https://app.codacy.com/gh/signaux-faibles/opensignauxfaibles/file/51943291072/coverage?bid=18037842&fileBranchId=18037842) avec un score de 6%) alors que la couverture retourné par `go test` est élevée. (66%, toujours sur `apconso.go`)

Il s'avère que cette erreur de calcul est causée par l'outil `github.com/t-yuki/gocover-cobertura` employé pour générer un rapport XML requis par Codacy, à partir des résultats fournis par `go test`. Cette erreur a été corrigée dans une PR non fusionnée ([Update find file func according to latest go/cover code](https://github.com/t-yuki/gocover-cobertura/pull/23)).

## Résolution

- remplacer l'outil `github.com/t-yuki/gocover-cobertura` par le fork `github.com/richardlt/gocover-cobertura` (créé par l'auteur de la PR corrige mentionnée ci-dessus)

## Résultats

Rapport XML avant cette PR:

```xml
				<class name="APConso" filename="github.com/signaux-faibles/opensignauxfaibles/lib/apconso/main.go" line-rate="0.04761905" branch-rate="0" complexity="0">
					<methods>
						<method name="Key" signature="" line-rate="0.071428575" branch-rate="0" complexity="0">
							<lines>
								<line number="26" hits="0"></line>
								<line number="27" hits="0"></line>
								<line number="28" hits="0"></line>
								<line number="26" hits="0"></line>
								<line number="27" hits="0"></line>
								<line number="28" hits="0"></line>
								<line number="26" hits="0"></line>
								<line number="27" hits="0"></line>
								<!-- plusieurs fois chaque numéro de ligne, avec un hits à 0 dans la plupart des cas -->
```

Après cette PR:

```xml
				<class name="APConso" filename="github.com/signaux-faibles/opensignauxfaibles/lib/apconso/main.go" line-rate="0.6666667" branch-rate="0" complexity="0">
					<methods>
						<method name="Key" signature="" line-rate="1" branch-rate="0" complexity="0">
							<lines>
								<line number="26" hits="6"></line>
								<line number="27" hits="6"></line>
								<line number="28" hits="6"></line>
							</lines>
						</method>
						<method name="Type" signature="" line-rate="0" branch-rate="0" complexity="0">
							<lines>
								<line number="31" hits="0"></line>
								<line number="32" hits="0"></line>
								<line number="33" hits="0"></line>
							</lines>
						</method>
```

Augmentation du [score de couverture rapporté par Codacy](https://app.codacy.com/gh/signaux-faibles/opensignauxfaibles/pullRequest?prid=6777846):

![image](https://user-images.githubusercontent.com/531781/104167726-22c37c00-53fd-11eb-9a4e-3910d96c803f.png)
