### PR TITLE
feat(parsers): Les fichiers urssaf gzippés peuvent être décompressés à la volée

### DIFF
--- a/lib/base/main.go
+++ b/lib/base/main.go
@@ -7,16 +7,18 @@ import (
 
 // AdminBatch metadata Batch
 type AdminBatch struct {
-	ID            AdminID    `json:"id" bson:"_id"`
-	Files         BatchFiles `json:"files" bson:"files"`
-	Name          string     `json:"name" bson:"name"`
-	Readonly      bool       `json:"readonly" bson:"readonly"`
-	CompleteTypes []string   `json:"complete_types" bson:"complete_types"`
-	Params        struct {
-		DateDebut       time.Time `json:"date_debut" bson:"date_debut"`
-		DateFin         time.Time `json:"date_fin" bson:"date_fin"`
-		DateFinEffectif time.Time `json:"date_fin_effectif" bson:"date_fin_effectif"`
-	} `json:"params" bson:"param"`
+	ID            AdminID          `json:"id" bson:"_id"`
+	Files         BatchFiles       `json:"files" bson:"files"`
+	Name          string           `json:"name" bson:"name"`
+	Readonly      bool             `json:"readonly" bson:"readonly"`
+	CompleteTypes []string         `json:"complete_types" bson:"complete_types"`
+	Params        adminBatchParams `json:"params" bson:"param"`
+}
+
+type adminBatchParams struct {
+	DateDebut       time.Time `json:"date_debut" bson:"date_debut"`
+	DateFin         time.Time `json:"date_fin" bson:"date_fin"`
+	DateFinEffectif time.Time `json:"date_fin_effectif" bson:"date_fin_effectif"`
 }
 
 // New crée un nouveau batch
@@ -56,6 +58,10 @@ func MockBatch(filetype string, filepaths []string) AdminBatch {
 	fileMap := map[string][]string{filetype: filepaths}
 	batch := AdminBatch{
 		Files: BatchFiles(fileMap),
+		Params: adminBatchParams{
+			DateDebut: time.Date(2019, 0, 1, 0, 0, 0, 0, time.UTC), // January 1st, 2019
+			DateFin:   time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC), // February 1st, 2019
+		},
 	}
 	return batch
 }

--- a/lib/marshal/mapping.go
+++ b/lib/marshal/mapping.go
@@ -1,12 +1,11 @@
 package marshal
 
 import (
-	"bufio"
 	"encoding/csv"
 	"errors"
 	"io"
 	"log"
-	"os"
+	"path"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/base"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/sfregexp"
@@ -111,13 +110,13 @@ func OpenAndReadSiretMapping(
 	batch *base.AdminBatch,
 ) (Comptes, error) {
 
-	file, err := os.Open(basePath + endPath)
+	file, fileReader, err := OpenFileReader(path.Join(basePath, endPath))
 	if err != nil {
 		return nil, errors.New("Erreur à l'ouverture du fichier, " + err.Error())
 	}
 	defer file.Close()
 
-	addSiretMapping, err := readSiretMapping(bufio.NewReader(file), cache, batch)
+	addSiretMapping, err := readSiretMapping(fileReader, cache, batch)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/marshal/parsingHelpers.go
+++ b/lib/marshal/parsingHelpers.go
@@ -3,10 +3,23 @@ package marshal
 import (
 	"bufio"
 	"compress/gzip"
+	"encoding/csv"
 	"io"
 	"os"
 	"strings"
 )
+
+// OpenCsvReader ouvre un fichier CSV potentiellement gzippé et retourne un csv.Reader.
+func OpenCsvReader(filePath string, comma rune, lazyQuotes bool) (*os.File, *csv.Reader, error) {
+	file, fileReader, err := OpenFileReader(filePath)
+	if err != nil {
+		return file, nil, err
+	}
+	reader := csv.NewReader(fileReader)
+	reader.Comma = comma
+	reader.LazyQuotes = lazyQuotes
+	return file, reader, err
+}
 
 // OpenFileReader ouvre un fichier potentiellement gzippé et retourne un io.Reader.
 func OpenFileReader(filePath string) (*os.File, io.Reader, error) {

--- a/lib/marshal/parsingHelpers.go
+++ b/lib/marshal/parsingHelpers.go
@@ -1,0 +1,27 @@
+package marshal
+
+import (
+	"bufio"
+	"compress/gzip"
+	"io"
+	"os"
+	"strings"
+)
+
+// OpenFileReader ouvre un fichier potentiellement gzippé et retourne un io.Reader.
+func OpenFileReader(filePath string) (*os.File, io.Reader, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, nil, err
+	}
+	var fileReader io.Reader
+	if strings.HasSuffix(filePath, ".gz") {
+		fileReader, err = gzip.NewReader(file)
+		if err != nil {
+			return file, nil, err
+		}
+	} else {
+		fileReader = bufio.NewReader(file)
+	}
+	return file, fileReader, err
+}

--- a/lib/marshal/tracker.go
+++ b/lib/marshal/tracker.go
@@ -2,7 +2,6 @@ package marshal
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/globalsign/mgo/bson"
 )
@@ -40,7 +39,7 @@ func (tracker *ParsingTracker) AddFilterError(err error) {
 		tracker.nbSkippedLines++
 		tracker.lastSkippedLine = tracker.currentLine
 	}
-	fmt.Fprintf(os.Stderr, "Line %d: %v\n", tracker.currentLine, err.Error()) // on ne souhaite pas conserver ces erreurs dans le rapport
+	// fmt.Fprintf(os.Stderr, "Line %d: %v\n", tracker.currentLine, err.Error()) // on ne souhaite pas conserver ces erreurs dans le rapport
 }
 
 // AddParseError rapporte une erreur rencontrée sur la ligne en cours de parsing

--- a/lib/marshal/tracker.go
+++ b/lib/marshal/tracker.go
@@ -39,7 +39,6 @@ func (tracker *ParsingTracker) AddFilterError(err error) {
 		tracker.nbSkippedLines++
 		tracker.lastSkippedLine = tracker.currentLine
 	}
-	// fmt.Fprintf(os.Stderr, "Line %d: %v\n", tracker.currentLine, err.Error()) // on ne souhaite pas conserver ces erreurs dans le rapport
 }
 
 // AddParseError rapporte une erreur rencontrée sur la ligne en cours de parsing

--- a/lib/urssaf/ccsf.go
+++ b/lib/urssaf/ccsf.go
@@ -59,14 +59,10 @@ func (parser *ccsfParser) Close() error {
 }
 
 func (parser *ccsfParser) Open(filePath string) (err error) {
-	var fileReader io.Reader
-	parser.file, fileReader, err = marshal.OpenFileReader(filePath)
-	if err != nil {
-		return err
+	parser.file, parser.reader, err = marshal.OpenCsvReader(filePath, ';', false)
+	if err == nil {
+		parser.idx, err = marshal.IndexColumnsFromCsvHeader(parser.reader, CCSF{})
 	}
-	parser.reader = csv.NewReader(fileReader)
-	parser.reader.Comma = ';'
-	parser.idx, err = marshal.IndexColumnsFromCsvHeader(parser.reader, CCSF{})
 	return err
 }
 

--- a/lib/urssaf/ccsf.go
+++ b/lib/urssaf/ccsf.go
@@ -1,7 +1,6 @@
 package urssaf
 
 import (
-	"bufio"
 	"encoding/csv"
 	"errors"
 	"io"
@@ -60,11 +59,12 @@ func (parser *ccsfParser) Close() error {
 }
 
 func (parser *ccsfParser) Open(filePath string) (err error) {
-	parser.file, err = os.Open(filePath)
+	var fileReader io.Reader
+	parser.file, fileReader, err = marshal.OpenFileReader(filePath)
 	if err != nil {
 		return err
 	}
-	parser.reader = csv.NewReader(bufio.NewReader(parser.file))
+	parser.reader = csv.NewReader(fileReader)
 	parser.reader.Comma = ';'
 	parser.idx, err = marshal.IndexColumnsFromCsvHeader(parser.reader, CCSF{})
 	return err

--- a/lib/urssaf/debit.go
+++ b/lib/urssaf/debit.go
@@ -76,16 +76,16 @@ func (parser *debitParser) Open(filePath string) (err error) {
 	if err != nil {
 		return err
 	}
-	// var reader *io.Reader
+	var fileReader io.Reader
 	if strings.HasSuffix(filePath, ".gz") {
-		zr, err := gzip.NewReader(parser.file)
+		fileReader, err = gzip.NewReader(parser.file)
 		if err != nil {
 			return err
 		}
-		parser.reader = openDebitFile(zr)
 	} else {
-		parser.reader = openDebitFile(bufio.NewReader(parser.file))
+		fileReader = bufio.NewReader(parser.file)
 	}
+	parser.reader = openDebitFile(fileReader)
 	parser.idx, err = marshal.IndexColumnsFromCsvHeader(parser.reader, Debit{})
 	return err
 }

--- a/lib/urssaf/debit.go
+++ b/lib/urssaf/debit.go
@@ -1,12 +1,9 @@
 package urssaf
 
 import (
-	"bufio"
-	"compress/gzip"
 	"encoding/csv"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/base"
@@ -80,18 +77,9 @@ func (parser *debitParser) Open(filePath string) (err error) {
 }
 
 func openDebitFile(filePath string) (*os.File, *csv.Reader, error) {
-	file, err := os.Open(filePath)
+	file, fileReader, err := marshal.OpenFileReader(filePath)
 	if err != nil {
 		return file, nil, err
-	}
-	var fileReader io.Reader
-	if strings.HasSuffix(filePath, ".gz") {
-		fileReader, err = gzip.NewReader(file)
-		if err != nil {
-			return file, nil, err
-		}
-	} else {
-		fileReader = bufio.NewReader(file)
 	}
 	csvReader := csv.NewReader(fileReader)
 	csvReader.Comma = ';'

--- a/lib/urssaf/debit.go
+++ b/lib/urssaf/debit.go
@@ -69,21 +69,11 @@ func (parser *debitParser) Init(cache *marshal.Cache, batch *base.AdminBatch) (e
 }
 
 func (parser *debitParser) Open(filePath string) (err error) {
-	parser.file, parser.reader, err = openDebitFile(filePath)
+	parser.file, parser.reader, err = marshal.OpenCsvReader(filePath, ';', false)
 	if err == nil {
 		parser.idx, err = marshal.IndexColumnsFromCsvHeader(parser.reader, Debit{})
 	}
 	return err
-}
-
-func openDebitFile(filePath string) (*os.File, *csv.Reader, error) {
-	file, fileReader, err := marshal.OpenFileReader(filePath)
-	if err != nil {
-		return file, nil, err
-	}
-	csvReader := csv.NewReader(fileReader)
-	csvReader.Comma = ';'
-	return file, csvReader, nil
 }
 
 func (parser *debitParser) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {

--- a/lib/urssaf/delai.go
+++ b/lib/urssaf/delai.go
@@ -67,21 +67,11 @@ func (parser *delaiParser) Init(cache *marshal.Cache, batch *base.AdminBatch) (e
 }
 
 func (parser *delaiParser) Open(filePath string) (err error) {
-	parser.file, parser.reader, err = openDelaiFile(filePath)
+	parser.file, parser.reader, err = marshal.OpenCsvReader(filePath, ';', false)
 	if err == nil {
 		parser.idx, err = marshal.IndexColumnsFromCsvHeader(parser.reader, Delai{})
 	}
 	return err
-}
-
-func openDelaiFile(filePath string) (*os.File, *csv.Reader, error) {
-	file, fileReader, err := marshal.OpenFileReader(filePath)
-	if err != nil {
-		return file, nil, err
-	}
-	csvReader := csv.NewReader(fileReader)
-	csvReader.Comma = ';'
-	return file, csvReader, nil
 }
 
 func (parser *delaiParser) ParseLines(parsedLineChan chan marshal.ParsedLineResult) {

--- a/lib/urssaf/delai.go
+++ b/lib/urssaf/delai.go
@@ -1,10 +1,7 @@
 package urssaf
 
 import (
-	"bufio"
-	"compress/gzip"
 	"encoding/csv"
-	"strings"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/base"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/marshal"
@@ -78,18 +75,9 @@ func (parser *delaiParser) Open(filePath string) (err error) {
 }
 
 func openDelaiFile(filePath string) (*os.File, *csv.Reader, error) {
-	file, err := os.Open(filePath)
+	file, fileReader, err := marshal.OpenFileReader(filePath)
 	if err != nil {
 		return file, nil, err
-	}
-	var fileReader io.Reader
-	if strings.HasSuffix(filePath, ".gz") {
-		fileReader, err = gzip.NewReader(file)
-		if err != nil {
-			return file, nil, err
-		}
-	} else {
-		fileReader = bufio.NewReader(file)
 	}
 	csvReader := csv.NewReader(fileReader)
 	csvReader.Comma = ';'

--- a/lib/urssaf/effectif.go
+++ b/lib/urssaf/effectif.go
@@ -58,21 +58,11 @@ func (parser *effectifParser) Close() error {
 }
 
 func (parser *effectifParser) Open(filePath string) (err error) {
-	parser.file, parser.reader, err = openEffectifFile(filePath)
+	parser.file, parser.reader, err = marshal.OpenCsvReader(filePath, ';', false)
 	if err == nil {
 		parser.idx, parser.periods, err = parseEffectifColMapping(parser.reader)
 	}
 	return err
-}
-
-func openEffectifFile(filePath string) (*os.File, *csv.Reader, error) {
-	file, fileReader, err := marshal.OpenFileReader(filePath)
-	if err != nil {
-		return file, nil, err
-	}
-	reader := csv.NewReader(fileReader)
-	reader.Comma = ';'
-	return file, reader, err
 }
 
 func parseEffectifColMapping(reader *csv.Reader) (marshal.ColMapping, []periodCol, error) {

--- a/lib/urssaf/effectif.go
+++ b/lib/urssaf/effectif.go
@@ -1,7 +1,6 @@
 package urssaf
 
 import (
-	"bufio"
 	"encoding/csv"
 	"io"
 	"os"
@@ -67,11 +66,12 @@ func (parser *effectifParser) Open(filePath string) (err error) {
 }
 
 func openEffectifFile(filePath string) (*os.File, *csv.Reader, error) {
-	file, err := os.Open(filePath)
+	var fileReader io.Reader
+	file, fileReader, err := marshal.OpenFileReader(filePath)
 	if err != nil {
 		return file, nil, err
 	}
-	reader := csv.NewReader(bufio.NewReader(file))
+	reader := csv.NewReader(fileReader)
 	reader.Comma = ';'
 	return file, reader, err
 }

--- a/lib/urssaf/effectif.go
+++ b/lib/urssaf/effectif.go
@@ -66,7 +66,6 @@ func (parser *effectifParser) Open(filePath string) (err error) {
 }
 
 func openEffectifFile(filePath string) (*os.File, *csv.Reader, error) {
-	var fileReader io.Reader
 	file, fileReader, err := marshal.OpenFileReader(filePath)
 	if err != nil {
 		return file, nil, err

--- a/lib/urssaf/effectif_ent.go
+++ b/lib/urssaf/effectif_ent.go
@@ -58,15 +58,7 @@ func (parser *effectifEntParser) Init(cache *marshal.Cache, batch *base.AdminBat
 }
 
 func (parser *effectifEntParser) Open(filePath string) (err error) {
-	var fileReader io.Reader
-	parser.file, fileReader, err = marshal.OpenFileReader(filePath)
-	if err != nil {
-		return err
-	}
-	if err == nil {
-		parser.reader = csv.NewReader(fileReader)
-		parser.reader.Comma = ';'
-	}
+	parser.file, parser.reader, err = marshal.OpenCsvReader(filePath, ';', false)
 	if err == nil {
 		parser.idx, parser.periods, err = parseEffectifEntColMapping(parser.reader)
 	}

--- a/lib/urssaf/effectif_ent.go
+++ b/lib/urssaf/effectif_ent.go
@@ -1,7 +1,6 @@
 package urssaf
 
 import (
-	"bufio"
 	"encoding/csv"
 	"io"
 	"os"
@@ -59,9 +58,13 @@ func (parser *effectifEntParser) Init(cache *marshal.Cache, batch *base.AdminBat
 }
 
 func (parser *effectifEntParser) Open(filePath string) (err error) {
-	parser.file, err = os.Open(filePath)
+	var fileReader io.Reader
+	parser.file, fileReader, err = marshal.OpenFileReader(filePath)
+	if err != nil {
+		return err
+	}
 	if err == nil {
-		parser.reader = csv.NewReader(bufio.NewReader(parser.file))
+		parser.reader = csv.NewReader(fileReader)
 		parser.reader.Comma = ';'
 	}
 	if err == nil {

--- a/lib/urssaf/procol.go
+++ b/lib/urssaf/procol.go
@@ -1,7 +1,6 @@
 package urssaf
 
 import (
-	"bufio"
 	"encoding/csv"
 	"io"
 	"os"
@@ -66,11 +65,11 @@ func (parser *procolParser) Open(filePath string) (err error) {
 }
 
 func openProcolFile(filePath string) (*os.File, *csv.Reader, error) {
-	file, err := os.Open(filePath)
+	file, fileReader, err := marshal.OpenFileReader(filePath)
 	if err != nil {
 		return file, nil, err
 	}
-	reader := csv.NewReader(bufio.NewReader(file))
+	reader := csv.NewReader(fileReader)
 	reader.Comma = ';'
 	reader.LazyQuotes = true
 	return file, reader, err

--- a/lib/urssaf/procol.go
+++ b/lib/urssaf/procol.go
@@ -57,22 +57,11 @@ func (parser *procolParser) Close() error {
 }
 
 func (parser *procolParser) Open(filePath string) (err error) {
-	parser.file, parser.reader, err = openProcolFile(filePath)
+	parser.file, parser.reader, err = marshal.OpenCsvReader(filePath, ';', true)
 	if err == nil {
 		parser.idx, err = parseProcolColMapping(parser.reader)
 	}
 	return err
-}
-
-func openProcolFile(filePath string) (*os.File, *csv.Reader, error) {
-	file, fileReader, err := marshal.OpenFileReader(filePath)
-	if err != nil {
-		return file, nil, err
-	}
-	reader := csv.NewReader(fileReader)
-	reader.Comma = ';'
-	reader.LazyQuotes = true
-	return file, reader, err
 }
 
 func parseProcolColMapping(reader *csv.Reader) (marshal.ColMapping, error) {

--- a/lib/urssaf/testData/expectedComptes.json
+++ b/lib/urssaf/testData/expectedComptes.json
@@ -6,11 +6,6 @@
       "periode": "2018-12-01T00:00:00Z"
     },
     {
-      "siret": "22222222222222",
-      "numero_compte": "450359886246036238",
-      "periode": "2018-12-01T00:00:00Z"
-    },
-    {
       "siret": "11111111111111",
       "numero_compte": "636043216536562844",
       "periode": "2018-12-01T00:00:00Z"
@@ -23,13 +18,15 @@
       "event": {
         "batchKey": "",
         "headFatal": [],
-        "headRejected": [],
+        "headRejected": [
+          "Line 2: Pas de siret associé au compte 450359886246036238 à la période 2018-12-01 00:00:00 +0000 UTC"
+        ],
         "isFatal": false,
         "linesParsed": 3,
-        "linesRejected": 0,
+        "linesRejected": 1,
         "linesSkipped": 0,
-        "linesValid": 3,
-        "summary": "testData/comptesTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides"
+        "linesValid": 2,
+        "summary": "testData/comptesTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 1 lignes rejetées, 0 lignes filtrées, 2 lignes valides"
       },
       "priority": "info",
       "parserCode": "admin_urssaf",

--- a/lib/urssaf/testData/expectedComptes.json
+++ b/lib/urssaf/testData/expectedComptes.json
@@ -6,6 +6,11 @@
       "periode": "2018-12-01T00:00:00Z"
     },
     {
+      "siret": "22222222222222",
+      "numero_compte": "450359886246036238",
+      "periode": "2018-12-01T00:00:00Z"
+    },
+    {
       "siret": "11111111111111",
       "numero_compte": "636043216536562844",
       "periode": "2018-12-01T00:00:00Z"
@@ -18,15 +23,13 @@
       "event": {
         "batchKey": "",
         "headFatal": [],
-        "headRejected": [
-          "Line 2: Pas de siret associé au compte 450359886246036238 à la période 2018-12-01 00:00:00 +0000 UTC"
-        ],
+        "headRejected": [],
         "isFatal": false,
         "linesParsed": 3,
-        "linesRejected": 1,
+        "linesRejected": 0,
         "linesSkipped": 0,
-        "linesValid": 2,
-        "summary": "testData/comptesTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 1 lignes rejetées, 0 lignes filtrées, 2 lignes valides"
+        "linesValid": 3,
+        "summary": "testData/comptesTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides"
       },
       "priority": "info",
       "parserCode": "admin_urssaf",

--- a/lib/urssaf/testData/expectedComptes.json
+++ b/lib/urssaf/testData/expectedComptes.json
@@ -1,0 +1,36 @@
+{
+  "tuples": [
+    {
+      "siret": "00000000000000",
+      "numero_compte": "111982477292496174",
+      "periode": "2018-12-01T00:00:00Z"
+    },
+    {
+      "siret": "11111111111111",
+      "numero_compte": "636043216536562844",
+      "periode": "2018-12-01T00:00:00Z"
+    }
+  ],
+  "events": [
+    {
+      "date": "0001-01-01T00:00:00Z",
+      "startDate": "0001-01-01T00:00:00Z",
+      "event": {
+        "batchKey": "",
+        "headFatal": [],
+        "headRejected": [
+          "Line 2: Pas de siret associé au compte 450359886246036238 à la période 2018-12-01 00:00:00 +0000 UTC"
+        ],
+        "isFatal": false,
+        "linesParsed": 3,
+        "linesRejected": 1,
+        "linesSkipped": 0,
+        "linesValid": 2,
+        "summary": "testData/comptesTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 1 lignes rejetées, 0 lignes filtrées, 2 lignes valides"
+      },
+      "priority": "info",
+      "parserCode": "admin_urssaf",
+      "report_type": ""
+    }
+  ]
+}

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -59,9 +59,9 @@ func TestUrssaf(t *testing.T) {
 }
 
 func TestComptes(t *testing.T) {
-	var cache = makeCacheWithComptesMapping()
 
 	t.Run("Le fichier de test Comptes est parsé comme d'habitude", func(t *testing.T) {
+		cache := marshal.NewCache()
 		var golden = filepath.Join("testData", "expectedComptes.json")
 		var testData = filepath.Join("testData", "comptesTestData.csv")
 		marshal.TestParserOutput(t, ParserCompte, cache, testData, golden, *update)

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -61,10 +61,9 @@ func TestUrssaf(t *testing.T) {
 func TestComptes(t *testing.T) {
 
 	t.Run("Le fichier de test Comptes est parsé comme d'habitude", func(t *testing.T) {
-		cache := marshal.NewCache()
 		var golden = filepath.Join("testData", "expectedComptes.json")
 		var testData = filepath.Join("testData", "comptesTestData.csv")
-		marshal.TestParserOutput(t, ParserCompte, cache, testData, golden, *update)
+		marshal.TestParserOutput(t, ParserCompte, makeCacheWithComptesMapping(), testData, golden, *update)
 	})
 }
 

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -38,6 +38,7 @@ func TestUrssaf(t *testing.T) {
 			{ParserDebit, "debitTestData.csv", "expectedDebit.json"},
 			{ParserDelai, "delaiTestData.csv", "expectedDelai.json"},
 			{ParserCCSF, "ccsfTestData.csv", "expectedCcsf.json"},
+			{ParserCompte, "comptesTestData.csv", "expectedComptes.json"},
 			// TODO: appliquer à tous les fichiers
 		}
 		for _, testCase := range urssafFiles {

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -40,17 +40,19 @@ func TestUrssaf(t *testing.T) {
 			// TODO: appliquer à tous les fichiers
 		}
 		for _, testCase := range urssafFiles {
-			// Compression du fichier de données
-			err := exec.Command("gzip", "--keep", filepath.Join("testData", testCase.InputFile)).Run() // créée une version gzippée du fichier
-			assert.NoError(t, err)
-			compressedFilePath := filepath.Join("testData", testCase.InputFile+".gz")
-			t.Cleanup(func() { os.Remove(compressedFilePath) })
-			// Création d'un fichier Golden temporaire mentionnant le nom du fichier compressé
-			initialGoldenContent, err := ioutil.ReadFile(filepath.Join("testData", testCase.GoldenFile))
-			assert.NoError(t, err)
-			goldenContent := bytes.ReplaceAll(initialGoldenContent, []byte(testCase.InputFile), []byte(testCase.InputFile+".gz"))
-			tmpGoldenFile := marshal.CreateTempFileWithContent(t, goldenContent)
-			marshal.TestParserOutput(t, testCase.Parser, makeCacheWithComptesMapping(), compressedFilePath, tmpGoldenFile.Name(), false)
+			t.Run(testCase.Parser.GetFileType(), func(t *testing.T) {
+				// Compression du fichier de données
+				err := exec.Command("gzip", "--keep", filepath.Join("testData", testCase.InputFile)).Run() // créée une version gzippée du fichier
+				assert.NoError(t, err)
+				compressedFilePath := filepath.Join("testData", testCase.InputFile+".gz")
+				t.Cleanup(func() { os.Remove(compressedFilePath) })
+				// Création d'un fichier Golden temporaire mentionnant le nom du fichier compressé
+				initialGoldenContent, err := ioutil.ReadFile(filepath.Join("testData", testCase.GoldenFile))
+				assert.NoError(t, err)
+				goldenContent := bytes.ReplaceAll(initialGoldenContent, []byte(testCase.InputFile), []byte(testCase.InputFile+".gz"))
+				tmpGoldenFile := marshal.CreateTempFileWithContent(t, goldenContent)
+				marshal.TestParserOutput(t, testCase.Parser, makeCacheWithComptesMapping(), compressedFilePath, tmpGoldenFile.Name(), false)
+			})
 		}
 	})
 }

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -33,12 +33,13 @@ func TestUrssaf(t *testing.T) {
 			Parser     marshal.Parser
 			InputFile  string
 			GoldenFile string
+			Cache      marshal.Cache
 		}
 		urssafFiles := []TestCase{
-			{ParserDebit, "debitTestData.csv", "expectedDebit.json"},
-			{ParserDelai, "delaiTestData.csv", "expectedDelai.json"},
-			{ParserCCSF, "ccsfTestData.csv", "expectedCcsf.json"},
-			{ParserCompte, "comptesTestData.csv", "expectedComptes.json"},
+			{ParserDebit, "debitTestData.csv", "expectedDebit.json", makeCacheWithComptesMapping()},
+			{ParserDelai, "delaiTestData.csv", "expectedDelai.json", makeCacheWithComptesMapping()},
+			{ParserCCSF, "ccsfTestData.csv", "expectedCcsf.json", makeCacheWithComptesMapping()},
+			{ParserCompte, "comptesTestData.csv", "expectedComptes.json", marshal.NewCache()},
 			// TODO: appliquer à tous les fichiers
 		}
 		for _, testCase := range urssafFiles {
@@ -53,7 +54,7 @@ func TestUrssaf(t *testing.T) {
 				assert.NoError(t, err)
 				goldenContent := bytes.ReplaceAll(initialGoldenContent, []byte(testCase.InputFile), []byte(testCase.InputFile+".gz"))
 				tmpGoldenFile := marshal.CreateTempFileWithContent(t, goldenContent)
-				marshal.TestParserOutput(t, testCase.Parser, makeCacheWithComptesMapping(), compressedFilePath, tmpGoldenFile.Name(), false)
+				marshal.TestParserOutput(t, testCase.Parser, testCase.Cache, compressedFilePath, tmpGoldenFile.Name(), false)
 			})
 		}
 	})
@@ -64,7 +65,7 @@ func TestComptes(t *testing.T) {
 	t.Run("Le fichier de test Comptes est parsé comme d'habitude", func(t *testing.T) {
 		var golden = filepath.Join("testData", "expectedComptes.json")
 		var testData = filepath.Join("testData", "comptesTestData.csv")
-		marshal.TestParserOutput(t, ParserCompte, makeCacheWithComptesMapping(), testData, golden, *update)
+		marshal.TestParserOutput(t, ParserCompte, marshal.NewCache(), testData, golden, *update)
 	})
 }
 

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -29,22 +29,28 @@ func makeCacheWithComptesMapping() marshal.Cache {
 
 func TestUrssaf(t *testing.T) {
 	t.Run("Les fichiers urssaf gzippés peuvent être décompressés à la volée", func(t *testing.T) {
-		urssafFiles := map[string]string{
-			"debitTestData.csv": "expectedDebit.json",
+		type TestCase struct {
+			Parser     marshal.Parser
+			InputFile  string
+			GoldenFile string
+		}
+		urssafFiles := []TestCase{
+			{ParserDebit, "debitTestData.csv", "expectedDebit.json"},
+			{ParserDelai, "delaiTestData.csv", "expectedDelai.json"},
 			// TODO: appliquer à tous les fichiers
 		}
-		for inputFile, goldenFile := range urssafFiles {
+		for _, testCase := range urssafFiles {
 			// Compression du fichier de données
-			err := exec.Command("gzip", "--keep", filepath.Join("testData", inputFile)).Run() // créée une version gzippée du fichier
+			err := exec.Command("gzip", "--keep", filepath.Join("testData", testCase.InputFile)).Run() // créée une version gzippée du fichier
 			assert.NoError(t, err)
-			compressedFilePath := filepath.Join("testData", inputFile+".gz")
+			compressedFilePath := filepath.Join("testData", testCase.InputFile+".gz")
 			t.Cleanup(func() { os.Remove(compressedFilePath) })
 			// Création d'un fichier Golden temporaire mentionnant le nom du fichier compressé
-			initialGoldenContent, err := ioutil.ReadFile(filepath.Join("testData", goldenFile))
+			initialGoldenContent, err := ioutil.ReadFile(filepath.Join("testData", testCase.GoldenFile))
 			assert.NoError(t, err)
-			goldenContent := bytes.ReplaceAll(initialGoldenContent, []byte(inputFile), []byte(inputFile+".gz"))
+			goldenContent := bytes.ReplaceAll(initialGoldenContent, []byte(testCase.InputFile), []byte(testCase.InputFile+".gz"))
 			tmpGoldenFile := marshal.CreateTempFileWithContent(t, goldenContent)
-			marshal.TestParserOutput(t, ParserDebit, makeCacheWithComptesMapping(), compressedFilePath, tmpGoldenFile.Name(), false)
+			marshal.TestParserOutput(t, testCase.Parser, makeCacheWithComptesMapping(), compressedFilePath, tmpGoldenFile.Name(), false)
 		}
 	})
 }

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -42,7 +42,7 @@ func TestUrssaf(t *testing.T) {
 			{ParserDelai, "delaiTestData.csv", "expectedDelai.json", makeCacheWithComptesMapping()},
 			{ParserEffectifEnt, "effectifEntTestData.csv", "expectedEffectifEnt.json", makeCacheWithComptesMapping()},
 			{ParserEffectif, "effectifTestData.csv", "expectedEffectif.json", makeCacheWithComptesMapping()},
-			// TODO: appliquer à tous les fichiers
+			{ParserProcol, "procolTestData.csv", "expectedProcol.json", makeCacheWithComptesMapping()},
 		}
 		for _, testCase := range urssafFiles {
 			t.Run(testCase.Parser.GetFileType(), func(t *testing.T) {

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -41,6 +41,7 @@ func TestUrssaf(t *testing.T) {
 			{ParserDebit, "debitTestData.csv", "expectedDebit.json", makeCacheWithComptesMapping()},
 			{ParserDelai, "delaiTestData.csv", "expectedDelai.json", makeCacheWithComptesMapping()},
 			{ParserEffectifEnt, "effectifEntTestData.csv", "expectedEffectifEnt.json", makeCacheWithComptesMapping()},
+			{ParserEffectif, "effectifTestData.csv", "expectedEffectif.json", makeCacheWithComptesMapping()},
 			// TODO: appliquer à tous les fichiers
 		}
 		for _, testCase := range urssafFiles {

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -37,6 +37,7 @@ func TestUrssaf(t *testing.T) {
 		urssafFiles := []TestCase{
 			{ParserDebit, "debitTestData.csv", "expectedDebit.json"},
 			{ParserDelai, "delaiTestData.csv", "expectedDelai.json"},
+			{ParserCCSF, "ccsfTestData.csv", "expectedCcsf.json"},
 			// TODO: appliquer à tous les fichiers
 		}
 		for _, testCase := range urssafFiles {

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -58,6 +58,16 @@ func TestUrssaf(t *testing.T) {
 	})
 }
 
+func TestComptes(t *testing.T) {
+	var cache = makeCacheWithComptesMapping()
+
+	t.Run("Le fichier de test Comptes est parsé comme d'habitude", func(t *testing.T) {
+		var golden = filepath.Join("testData", "expectedComptes.json")
+		var testData = filepath.Join("testData", "comptesTestData.csv")
+		marshal.TestParserOutput(t, ParserCompte, cache, testData, golden, *update)
+	})
+}
+
 func TestDebit(t *testing.T) {
 	var golden = filepath.Join("testData", "expectedDebit.json")
 	var testData = filepath.Join("testData", "debitTestData.csv")

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -36,10 +36,11 @@ func TestUrssaf(t *testing.T) {
 			Cache      marshal.Cache
 		}
 		urssafFiles := []TestCase{
-			{ParserDebit, "debitTestData.csv", "expectedDebit.json", makeCacheWithComptesMapping()},
-			{ParserDelai, "delaiTestData.csv", "expectedDelai.json", makeCacheWithComptesMapping()},
 			{ParserCCSF, "ccsfTestData.csv", "expectedCcsf.json", makeCacheWithComptesMapping()},
 			{ParserCompte, "comptesTestData.csv", "expectedComptes.json", marshal.NewCache()},
+			{ParserDebit, "debitTestData.csv", "expectedDebit.json", makeCacheWithComptesMapping()},
+			{ParserDelai, "delaiTestData.csv", "expectedDelai.json", makeCacheWithComptesMapping()},
+			{ParserEffectifEnt, "effectifEntTestData.csv", "expectedEffectifEnt.json", makeCacheWithComptesMapping()},
 			// TODO: appliquer à tous les fichiers
 		}
 		for _, testCase := range urssafFiles {


### PR DESCRIPTION
## Objectif

Si un fichier urssaf est fourni avec l'extension `.gz`, `sfdata` décompressera les données à la volée, au moment de les importer.

## Changements apportés

- Ajout d'un test unitaire pour le parseur `Compte` (code: `admin_urssaf`), comme pour les autres => spécification de date de début et date de fin dans `MockBatch()`, pour que des tuples soient générés lors de l'exécution des tests => extraction de la sous-structure `adminBatchParams`
- Ajout de tests qui compressent chaque fichier de test urssaf, execute son parseur, et vérifie que la sortie correspond à celle de la version non compressée
- Ajout des helpers `OpenCsvReader()` et `OpenFileReader()` appelés dans tous les parseurs pouvant accepter des fichiers compressés avec `gzip` => déduplication du code sous-jacent.
- Tant qu'on y est: suppression des entrées "(filtered)" qui polluent la sortie standard, et sont de toute façon comptées dans le rapport de parsing stocké dans Journal.

## Étapes suivantes

- [x] modifier `prepare-import` pour supporter ces fichiers `.gz` => https://github.com/signaux-faibles/prepare-import/pull/57
- [x] mentionner le support des fichiers `.gz` dans la documentation => https://github.com/signaux-faibles/documentation/pull/36