### PR TITLE
feat(types): Alignement des types entre Go et TypeScript – partie 2

### DIFF
--- a/js/GeneratedTypes.d.ts
+++ b/js/GeneratedTypes.d.ts
@@ -19,6 +19,32 @@ export interface EntréeApConso {
   periode: Date
 }
 /**
+ * Champs importés par le parseur lib/apdemande/main.go de sfdata.
+ */
+export interface EntréeApDemande {
+  id_demande: string
+  periode: {
+    start: Date
+    end: Date
+  }
+  /**
+   * Nombre total d'heures autorisées
+   */
+  hta: number
+  /**
+   * Cause d'activité partielle
+   */
+  motif_recours_se: number
+  effectif_entreprise?: number
+  effectif?: number
+  date_statut?: Date
+  mta?: number
+  effectif_autorise?: number
+  heure_consomme?: number
+  montant_consomme?: number
+  effectif_consomme?: number
+}
+/**
  * Note: CE SCHEMA EST INCOMPLET POUR L'INSTANT. Cf https://github.com/signaux-faibles/opensignauxfaibles/pull/143
  */
 export interface EntréeBdf {

--- a/js/GeneratedTypes.d.ts
+++ b/js/GeneratedTypes.d.ts
@@ -22,7 +22,13 @@ export interface EntréeCcsf {
    * Date de début de la procédure CCSF
    */
   date_traitement: Date
+  /**
+   * TODO: choisir un type plus précis
+   */
   stade: string
+  /**
+   * TODO: choisir un type plus précis
+   */
   action: string
 }
 /**

--- a/js/GeneratedTypes.d.ts
+++ b/js/GeneratedTypes.d.ts
@@ -9,6 +9,16 @@
  */
 
 /**
+ * Champs importés par le parseur lib/apconso/main.go de sfdata.
+ */
+export interface EntréeApConso {
+  id_conso: string
+  heure_consomme: number
+  montant: number
+  effectif: number
+  periode: Date
+}
+/**
  * Note: CE SCHEMA EST INCOMPLET POUR L'INSTANT. Cf https://github.com/signaux-faibles/opensignauxfaibles/pull/143
  */
 export interface EntréeBdf {

--- a/js/GeneratedTypes.d.ts
+++ b/js/GeneratedTypes.d.ts
@@ -15,6 +15,17 @@ export interface EntréeBdf {
   siren: string
 }
 /**
+ * Champs importés par le parseur lib/urssaf/ccsf.go de sfdata.
+ */
+export interface EntréeCcsf {
+  /**
+   * Date de début de la procédure CCSF
+   */
+  date_traitement: Date
+  stade: string
+  action: string
+}
+/**
  * Champs importés par le parseur lib/urssaf/delai.go de sfdata.
  */
 export interface EntréeDelai {

--- a/js/GeneratedTypes.d.ts
+++ b/js/GeneratedTypes.d.ts
@@ -40,7 +40,7 @@ export interface EntréeApDemande {
   date_statut?: Date
   mta?: number
   effectif_autorise?: number
-  heure_consomme?: number
+  heure_consommee?: number
   montant_consomme?: number
   effectif_consomme?: number
 }

--- a/js/GeneratedTypes.d.ts
+++ b/js/GeneratedTypes.d.ts
@@ -74,3 +74,27 @@ export interface EntréeDelai {
    */
   action: string
 }
+/**
+ * Champs importés par le parseur lib/urssaf/procol.go de sfdata.
+ */
+export interface EntréeDéfaillances {
+  /**
+   * Nature de la procédure de défaillance.
+   */
+  action_procol: "liquidation" | "redressement" | "sauvegarde"
+  /**
+   * Evénement survenu dans le cadre de cette procédure.
+   */
+  stade_procol:
+    | "abandon_procedure"
+    | "solde_procedure"
+    | "fin_procedure"
+    | "plan_continuation"
+    | "ouverture"
+    | "inclusion_autre_procedure"
+    | "cloture_insuffisance_actif"
+  /**
+   * Date effet de la procédure collective.
+   */
+  date_effet: Date
+}

--- a/js/GeneratedTypes.d.ts
+++ b/js/GeneratedTypes.d.ts
@@ -41,7 +41,7 @@ export interface EntréeApDemande {
   mta?: number
   effectif_autorise?: number
   heure_consommee?: number
-  montant_consomme?: number
+  montant_consommee?: number
   effectif_consomme?: number
 }
 /**

--- a/js/GeneratedTypes.d.ts
+++ b/js/GeneratedTypes.d.ts
@@ -14,8 +14,8 @@
 export interface EntréeApConso {
   id_conso: string
   heure_consomme: number
-  montant: number
-  effectif: number
+  montant?: number
+  effectif?: number
   periode: Date
 }
 /**

--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -1,6 +1,11 @@
 /* eslint-disable no-use-before-define */
 
-import { EntréeDelai, EntréeCcsf, EntréeDéfaillances } from "./GeneratedTypes"
+import {
+  EntréeApConso,
+  EntréeDelai,
+  EntréeCcsf,
+  EntréeDéfaillances,
+} from "./GeneratedTypes"
 
 // Types de données de base
 
@@ -87,12 +92,6 @@ export type BatchValueProps = CommonBatchProps &
   }
 
 // Détail des types de données
-
-export type EntréeApConso = {
-  id_conso: string
-  periode: Date
-  heure_consomme: number
-}
 
 export type EntréeApDemande = {
   id_demande: string

--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 
-import { EntréeDelai } from "./GeneratedTypes"
+import { EntréeDelai, EntréeCcsf } from "./GeneratedTypes"
 
 // Types de données de base
 
@@ -87,13 +87,6 @@ export type BatchValueProps = CommonBatchProps &
   }
 
 // Détail des types de données
-
-export type EntréeCcsf = {
-  /** Date de début de la procédure CCSF */
-  date_traitement: Date
-  stade: string // TODO: choisir un type plus précis
-  action: string // TODO: choisir un type plus précis
-}
 
 export type EntréeDéfaillances = {
   /** Nature de la procédure de défaillance. */

--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -2,6 +2,7 @@
 
 import {
   EntréeApConso,
+  EntréeApDemande,
   EntréeDelai,
   EntréeCcsf,
   EntréeDéfaillances,
@@ -92,21 +93,6 @@ export type BatchValueProps = CommonBatchProps &
   }
 
 // Détail des types de données
-
-export type EntréeApDemande = {
-  id_demande: string
-  periode: { start: Date; end: Date }
-  hta: number /* Nombre total d'heures autorisées */
-  motif_recours_se: number /* Cause d'activité partielle */
-  effectif_entreprise?: number
-  effectif?: number
-  date_statut?: Date
-  mta?: number
-  effectif_autorise?: number
-  heure_consomme?: number
-  montant_consomme?: number
-  effectif_consomme?: number
-}
 
 export type EntréeCompte = {
   /** Date à laquelle cet établissement est associé à ce numéro de compte URSSAF. */

--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 
-import { EntréeDelai, EntréeCcsf } from "./GeneratedTypes"
+import { EntréeDelai, EntréeCcsf, EntréeDéfaillances } from "./GeneratedTypes"
 
 // Types de données de base
 
@@ -87,22 +87,6 @@ export type BatchValueProps = CommonBatchProps &
   }
 
 // Détail des types de données
-
-export type EntréeDéfaillances = {
-  /** Nature de la procédure de défaillance. */
-  action_procol: "liquidation" | "redressement" | "sauvegarde"
-  /** Evénement survenu dans le cadre de cette procédure. */
-  stade_procol:
-    | "abandon_procedure"
-    | "solde_procedure"
-    | "fin_procedure"
-    | "plan_continuation"
-    | "ouverture"
-    | "inclusion_autre_procedure"
-    | "cloture_insuffisance_actif"
-  /** Date effet de la procédure collective. */
-  date_effet: Date
-}
 
 export type EntréeApConso = {
   id_conso: string

--- a/js/common/procolToHuman.ts
+++ b/js/common/procolToHuman.ts
@@ -1,4 +1,4 @@
-import { EntréeDéfaillances } from "../RawDataTypes"
+import { EntréeDéfaillances } from "../GeneratedTypes"
 
 export type ProcolToHumanRes =
   | "liquidation"

--- a/js/compact/currentState_tests.ts
+++ b/js/compact/currentState_tests.ts
@@ -1,7 +1,6 @@
 import test, { ExecutionContext } from "ava"
 import { currentState } from "./currentState"
-import { EntréeApConso } from "../GeneratedTypes"
-import { EntréeApDemande } from "../RawDataTypes"
+import { EntréeApConso, EntréeApDemande } from "../GeneratedTypes"
 
 const makeApDemande = (): EntréeApDemande => ({
   id_demande: "",

--- a/js/compact/currentState_tests.ts
+++ b/js/compact/currentState_tests.ts
@@ -1,6 +1,7 @@
 import test, { ExecutionContext } from "ava"
 import { currentState } from "./currentState"
-import { EntréeApDemande, EntréeApConso } from "../RawDataTypes"
+import { EntréeApConso } from "../GeneratedTypes"
+import { EntréeApDemande } from "../RawDataTypes"
 
 const makeApDemande = (): EntréeApDemande => ({
   id_demande: "",

--- a/js/public/apconso.ts
+++ b/js/public/apconso.ts
@@ -1,4 +1,5 @@
-import { EntréeApConso, ParHash } from "../RawDataTypes"
+import { EntréeApConso } from "../GeneratedTypes"
+import { ParHash } from "../RawDataTypes"
 
 export function apconso(apconso?: ParHash<EntréeApConso>): EntréeApConso[] {
   return Object.values(apconso ?? {}).sort((p1, p2) =>

--- a/js/public/apdemande.ts
+++ b/js/public/apdemande.ts
@@ -1,4 +1,5 @@
-import { EntréeApDemande, ParHash } from "../RawDataTypes"
+import { EntréeApDemande } from "../GeneratedTypes"
+import { ParHash } from "../RawDataTypes"
 
 export function apdemande(
   apdemande?: ParHash<EntréeApDemande>

--- a/js/public/map.ts
+++ b/js/public/map.ts
@@ -1,12 +1,11 @@
 import { f } from "./functions"
-import { EntréeDelai } from "../GeneratedTypes"
+import { EntréeDelai, EntréeDéfaillances } from "../GeneratedTypes"
 import {
   CompanyDataValues,
   BatchKey,
   EntréeApConso,
   EntréeApDemande,
   EntréeCompte,
-  EntréeDéfaillances,
   EntréeDiane,
   EntréeEllisphere,
   EntréeSirene,

--- a/js/public/map.ts
+++ b/js/public/map.ts
@@ -1,13 +1,13 @@
 import { f } from "./functions"
 import {
   EntréeApConso,
+  EntréeApDemande,
   EntréeDelai,
   EntréeDéfaillances,
 } from "../GeneratedTypes"
 import {
   CompanyDataValues,
   BatchKey,
-  EntréeApDemande,
   EntréeCompte,
   EntréeDiane,
   EntréeEllisphere,

--- a/js/public/map.ts
+++ b/js/public/map.ts
@@ -1,9 +1,12 @@
 import { f } from "./functions"
-import { EntréeDelai, EntréeDéfaillances } from "../GeneratedTypes"
+import {
+  EntréeApConso,
+  EntréeDelai,
+  EntréeDéfaillances,
+} from "../GeneratedTypes"
 import {
   CompanyDataValues,
   BatchKey,
-  EntréeApConso,
   EntréeApDemande,
   EntréeCompte,
   EntréeDiane,

--- a/js/reduce.algo2/apart.ts
+++ b/js/reduce.algo2/apart.ts
@@ -1,6 +1,6 @@
 import { f } from "./functions"
-import { EntréeApConso } from "../GeneratedTypes"
-import { EntréeApDemande, ParPériode } from "../RawDataTypes"
+import { EntréeApConso, EntréeApDemande } from "../GeneratedTypes"
+import { ParPériode } from "../RawDataTypes"
 
 type ApConsoHash = string
 

--- a/js/reduce.algo2/apart.ts
+++ b/js/reduce.algo2/apart.ts
@@ -1,5 +1,6 @@
 import { f } from "./functions"
-import { EntréeApDemande, EntréeApConso, ParPériode } from "../RawDataTypes"
+import { EntréeApConso } from "../GeneratedTypes"
+import { EntréeApDemande, ParPériode } from "../RawDataTypes"
 
 type ApConsoHash = string
 

--- a/js/reduce.algo2/ccsf.ts
+++ b/js/reduce.algo2/ccsf.ts
@@ -1,4 +1,5 @@
-import { EntréeCcsf, ParHash } from "../RawDataTypes"
+import { EntréeCcsf } from "../GeneratedTypes"
+import { ParHash } from "../RawDataTypes"
 
 type Input = {
   periode: Date

--- a/js/reduce.algo2/defaillances.ts
+++ b/js/reduce.algo2/defaillances.ts
@@ -1,6 +1,7 @@
 import { f } from "./functions"
 import { ProcolToHumanRes } from "../common/procolToHuman"
-import { EntréeDéfaillances, ParPériode, ParHash } from "../RawDataTypes"
+import { EntréeDéfaillances } from "../GeneratedTypes"
+import { ParPériode, ParHash } from "../RawDataTypes"
 
 export type SortieDefaillances = {
   /** État de la procédure collective. */

--- a/js/reduce.algo2/defaillances_tests.ts
+++ b/js/reduce.algo2/defaillances_tests.ts
@@ -1,6 +1,7 @@
 import test from "ava"
 import { defaillances } from "./defaillances"
-import { ParHash, EntréeDéfaillances } from "../RawDataTypes"
+import { EntréeDéfaillances } from "../GeneratedTypes"
+import { ParHash } from "../RawDataTypes"
 
 test("Une ouverture de liquidation est prise en compte dans la période courante et les suivantes", (t) => {
   const output_indexed = {

--- a/lib/engine/data.go
+++ b/lib/engine/data.go
@@ -416,6 +416,9 @@ func ValidateDataEntries(jsonSchema map[string]bson.M, collection string) error 
 
 func iterateToChannel(channel chan interface{}, iterator *mgo.Iter) error {
 	var item interface{}
+	if err := iterator.Err(); err != nil {
+		return err // e.g. "Erreur: Unknown $jsonSchema keyword: _TODO"
+	}
 	for iterator.Next(&item) {
 		if err := iterator.Err(); err != nil {
 			return err

--- a/lib/engine/data.go
+++ b/lib/engine/data.go
@@ -384,14 +384,14 @@ func ValidateDataEntries(jsonSchema map[string]bson.M, collection string) error 
 	startDate := time.Now()
 
 	w := sync.WaitGroup{}
-	gzipWriter := getItemChannelToStdout(&w)
+	writer := getItemChannelToStdout(&w)
 
 	// lister les entrées de données non définies (type: undefined au lieu de object)
 	pipeline, err := GetUndefinedDataValidationPipeline()
 	if err != nil {
 		return err
 	}
-	err = iterateToChannel(gzipWriter, Db.DB.C(collection).Pipe(pipeline).AllowDiskUse().Iter())
+	err = iterateToChannel(writer, Db.DB.C(collection).Pipe(pipeline).AllowDiskUse().Iter())
 	if err != nil {
 		return err
 	}
@@ -401,12 +401,12 @@ func ValidateDataEntries(jsonSchema map[string]bson.M, collection string) error 
 	if err != nil {
 		return err
 	}
-	err = iterateToChannel(gzipWriter, Db.DB.C(collection).Pipe(pipeline).AllowDiskUse().Iter())
+	err = iterateToChannel(writer, Db.DB.C(collection).Pipe(pipeline).AllowDiskUse().Iter())
 	if err != nil {
 		return err
 	}
 
-	close(gzipWriter)
+	close(writer)
 	w.Wait()
 
 	LogOperationEvent("ValidateDataEntries", startDate)

--- a/lib/engine/data_validation.go
+++ b/lib/engine/data_validation.go
@@ -57,7 +57,7 @@ func GetDataValidationPipeline(jsonSchema map[string]bson.M) (pipeline []bson.M,
 	for dataType, schema := range jsonSchema {
 		matchers = append(matchers, bson.M{
 			"dataType": dataType,
-			"$nor": []bson.M{
+			"$nor": []bson.M{ // "To find documents in the collection that do not satisfy the specified schema, use the $jsonSchema expression in a $nor expression" (https://docs.mongodb.com/manual/reference/operator/query/jsonSchema/#query-conditions)
 				{
 					"$jsonSchema": bson.M{
 						"bsonType": "object",

--- a/lib/engine/validationSchemas.go
+++ b/lib/engine/validationSchemas.go
@@ -17,6 +17,28 @@ var validationSchemas = map[string]string{
   "additionalProperties": false
 }
 `,
+"ccsf.schema.json": `{
+  "title": "EntréeCcsf",
+  "description": "Champs importés par le parseur lib/urssaf/ccsf.go de sfdata.",
+  "bsonType": "object",
+  "required": ["date_traitement", "stade", "action"],
+  "properties": {
+    "date_traitement": {
+      "bsonType": "date",
+      "description": "Date de début de la procédure CCSF"
+    },
+    "stade": {
+      "bsonType": "string",
+      "_TODO": "choisir un type plus précis"
+    },
+    "action": {
+      "bsonType": "string",
+      "_TODO": "choisir un type plus précis"
+    }
+  },
+  "additionalProperties": false
+}
+`,
 "delai.schema.json": `{
   "title": "EntréeDelai",
   "description": "Champs importés par le parseur lib/urssaf/delai.go de sfdata.",

--- a/lib/engine/validationSchemas.go
+++ b/lib/engine/validationSchemas.go
@@ -29,11 +29,11 @@ var validationSchemas = map[string]string{
     },
     "stade": {
       "bsonType": "string",
-      "_TODO": "choisir un type plus précis"
+      "description": "TODO: choisir un type plus précis"
     },
     "action": {
       "bsonType": "string",
-      "_TODO": "choisir un type plus précis"
+      "description": "TODO: choisir un type plus précis"
     }
   },
   "additionalProperties": false

--- a/lib/engine/validationSchemas.go
+++ b/lib/engine/validationSchemas.go
@@ -3,6 +3,31 @@
 package engine
 
 var validationSchemas = map[string]string{
+"apconso.schema.json": `{
+  "title": "EntréeApConso",
+  "description": "Champs importés par le parseur lib/apconso/main.go de sfdata.",
+  "bsonType": "object",
+  "required": ["id_conso", "heure_consomme", "montant", "effectif", "periode"],
+  "properties": {
+    "id_conso": {
+      "bsonType": "string"
+    },
+    "heure_consomme": {
+      "bsonType": "number"
+    },
+    "montant": {
+      "bsonType": "number"
+    },
+    "effectif": {
+      "bsonType": "number"
+    },
+    "periode": {
+      "bsonType": "date"
+    }
+  },
+  "additionalProperties": false
+}
+`,
 "bdf.schema.json": `{
   "title": "EntréeBdf",
   "description": "Note: CE SCHEMA EST INCOMPLET POUR L'INSTANT. Cf https://github.com/signaux-faibles/opensignauxfaibles/pull/143",

--- a/lib/engine/validationSchemas.go
+++ b/lib/engine/validationSchemas.go
@@ -7,7 +7,7 @@ var validationSchemas = map[string]string{
   "title": "EntréeApConso",
   "description": "Champs importés par le parseur lib/apconso/main.go de sfdata.",
   "bsonType": "object",
-  "required": ["id_conso", "heure_consomme", "montant", "effectif", "periode"],
+  "required": ["id_conso", "periode", "heure_consomme"],
   "properties": {
     "id_conso": {
       "bsonType": "string"

--- a/lib/engine/validationSchemas.go
+++ b/lib/engine/validationSchemas.go
@@ -72,7 +72,7 @@ var validationSchemas = map[string]string{
     "heure_consommee": {
       "bsonType": "number"
     },
-    "montant_consomme": {
+    "montant_consommee": {
       "bsonType": "number"
     },
     "effectif_consomme": {

--- a/lib/engine/validationSchemas.go
+++ b/lib/engine/validationSchemas.go
@@ -28,6 +28,60 @@ var validationSchemas = map[string]string{
   "additionalProperties": false
 }
 `,
+"apdemande.schema.json": `{
+  "title": "EntréeApDemande",
+  "description": "Champs importés par le parseur lib/apdemande/main.go de sfdata.",
+  "bsonType": "object",
+  "required": ["id_demande", "periode", "hta", "motif_recours_se"],
+  "properties": {
+    "id_demande": {
+      "bsonType": "string"
+    },
+    "periode": {
+      "bsonType": "object",
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "bsonType": "date" },
+        "end": { "bsonType": "date" }
+      },
+      "additionalProperties": false
+    },
+    "hta": {
+      "description": "Nombre total d'heures autorisées",
+      "bsonType": "number"
+    },
+    "motif_recours_se": {
+      "description": "Cause d'activité partielle",
+      "bsonType": "number"
+    },
+    "effectif_entreprise": {
+      "bsonType": "number"
+    },
+    "effectif": {
+      "bsonType": "number"
+    },
+    "date_statut": {
+      "bsonType": "date"
+    },
+    "mta": {
+      "bsonType": "number"
+    },
+    "effectif_autorise": {
+      "bsonType": "number"
+    },
+    "heure_consomme": {
+      "bsonType": "number"
+    },
+    "montant_consomme": {
+      "bsonType": "number"
+    },
+    "effectif_consomme": {
+      "bsonType": "number"
+    }
+  },
+  "additionalProperties": false
+}
+`,
 "bdf.schema.json": `{
   "title": "EntréeBdf",
   "description": "Note: CE SCHEMA EST INCOMPLET POUR L'INSTANT. Cf https://github.com/signaux-faibles/opensignauxfaibles/pull/143",

--- a/lib/engine/validationSchemas.go
+++ b/lib/engine/validationSchemas.go
@@ -69,7 +69,7 @@ var validationSchemas = map[string]string{
     "effectif_autorise": {
       "bsonType": "number"
     },
-    "heure_consomme": {
+    "heure_consommee": {
       "bsonType": "number"
     },
     "montant_consomme": {

--- a/lib/engine/validationSchemas.go
+++ b/lib/engine/validationSchemas.go
@@ -166,4 +166,36 @@ var validationSchemas = map[string]string{
   }
 ]
 `,
+"procol.schema.json": `{
+  "title": "EntréeDéfaillances",
+  "description": "Champs importés par le parseur lib/urssaf/procol.go de sfdata.",
+  "bsonType": "object",
+  "required": ["action_procol", "stade_procol", "date_effet"],
+  "properties": {
+    "action_procol": {
+      "description": "Nature de la procédure de défaillance.",
+      "bsonType": "string",
+      "enum": ["liquidation", "redressement", "sauvegarde"]
+    },
+    "stade_procol": {
+      "description": "Evénement survenu dans le cadre de cette procédure.",
+      "bsonType": "string",
+      "enum": [
+        "abandon_procedure",
+        "solde_procedure",
+        "fin_procedure",
+        "plan_continuation",
+        "ouverture",
+        "inclusion_autre_procedure",
+        "cloture_insuffisance_actif"
+      ]
+    },
+    "date_effet": {
+      "bsonType": "date",
+      "description": "Date effet de la procédure collective."
+    }
+  },
+  "additionalProperties": false
+}
+`,
 }

--- a/validation/apconso.schema.json
+++ b/validation/apconso.schema.json
@@ -2,7 +2,7 @@
   "title": "EntréeApConso",
   "description": "Champs importés par le parseur lib/apconso/main.go de sfdata.",
   "bsonType": "object",
-  "required": ["id_conso", "heure_consomme", "montant", "effectif", "periode"],
+  "required": ["id_conso", "periode", "heure_consomme"],
   "properties": {
     "id_conso": {
       "bsonType": "string"

--- a/validation/apconso.schema.json
+++ b/validation/apconso.schema.json
@@ -1,0 +1,24 @@
+{
+  "title": "EntréeApConso",
+  "description": "Champs importés par le parseur lib/apconso/main.go de sfdata.",
+  "bsonType": "object",
+  "required": ["id_conso", "heure_consomme", "montant", "effectif", "periode"],
+  "properties": {
+    "id_conso": {
+      "bsonType": "string"
+    },
+    "heure_consomme": {
+      "bsonType": "number"
+    },
+    "montant": {
+      "bsonType": "number"
+    },
+    "effectif": {
+      "bsonType": "number"
+    },
+    "periode": {
+      "bsonType": "date"
+    }
+  },
+  "additionalProperties": false
+}

--- a/validation/apdemande.schema.json
+++ b/validation/apdemande.schema.json
@@ -1,0 +1,53 @@
+{
+  "title": "EntréeApDemande",
+  "description": "Champs importés par le parseur lib/apdemande/main.go de sfdata.",
+  "bsonType": "object",
+  "required": ["id_demande", "periode", "hta", "motif_recours_se"],
+  "properties": {
+    "id_demande": {
+      "bsonType": "string"
+    },
+    "periode": {
+      "bsonType": "object",
+      "required": ["start", "end"],
+      "properties": {
+        "start": { "bsonType": "date" },
+        "end": { "bsonType": "date" }
+      },
+      "additionalProperties": false
+    },
+    "hta": {
+      "description": "Nombre total d'heures autorisées",
+      "bsonType": "number"
+    },
+    "motif_recours_se": {
+      "description": "Cause d'activité partielle",
+      "bsonType": "number"
+    },
+    "effectif_entreprise": {
+      "bsonType": "number"
+    },
+    "effectif": {
+      "bsonType": "number"
+    },
+    "date_statut": {
+      "bsonType": "date"
+    },
+    "mta": {
+      "bsonType": "number"
+    },
+    "effectif_autorise": {
+      "bsonType": "number"
+    },
+    "heure_consomme": {
+      "bsonType": "number"
+    },
+    "montant_consomme": {
+      "bsonType": "number"
+    },
+    "effectif_consomme": {
+      "bsonType": "number"
+    }
+  },
+  "additionalProperties": false
+}

--- a/validation/apdemande.schema.json
+++ b/validation/apdemande.schema.json
@@ -42,7 +42,7 @@
     "heure_consommee": {
       "bsonType": "number"
     },
-    "montant_consomme": {
+    "montant_consommee": {
       "bsonType": "number"
     },
     "effectif_consomme": {

--- a/validation/apdemande.schema.json
+++ b/validation/apdemande.schema.json
@@ -39,7 +39,7 @@
     "effectif_autorise": {
       "bsonType": "number"
     },
-    "heure_consomme": {
+    "heure_consommee": {
       "bsonType": "number"
     },
     "montant_consomme": {

--- a/validation/ccsf.schema.json
+++ b/validation/ccsf.schema.json
@@ -1,0 +1,8 @@
+{
+  "title": "EntréeCcsf",
+  "description": "Champs importés par le parseur lib/urssaf/ccsf.go de sfdata.",
+  "bsonType": "object",
+  "required": [],
+  "properties": {},
+  "additionalProperties": false
+}

--- a/validation/ccsf.schema.json
+++ b/validation/ccsf.schema.json
@@ -2,7 +2,20 @@
   "title": "EntréeCcsf",
   "description": "Champs importés par le parseur lib/urssaf/ccsf.go de sfdata.",
   "bsonType": "object",
-  "required": [],
-  "properties": {},
+  "required": ["date_traitement", "stade", "action"],
+  "properties": {
+    "date_traitement": {
+      "bsonType": "date",
+      "description": "Date de début de la procédure CCSF"
+    },
+    "stade": {
+      "bsonType": "string",
+      "_TODO": "choisir un type plus précis"
+    },
+    "action": {
+      "bsonType": "string",
+      "_TODO": "choisir un type plus précis"
+    }
+  },
   "additionalProperties": false
 }

--- a/validation/ccsf.schema.json
+++ b/validation/ccsf.schema.json
@@ -10,11 +10,11 @@
     },
     "stade": {
       "bsonType": "string",
-      "_TODO": "choisir un type plus précis"
+      "description": "TODO: choisir un type plus précis"
     },
     "action": {
       "bsonType": "string",
-      "_TODO": "choisir un type plus précis"
+      "description": "TODO: choisir un type plus précis"
     }
   },
   "additionalProperties": false

--- a/validation/procol.schema.json
+++ b/validation/procol.schema.json
@@ -1,0 +1,31 @@
+{
+  "title": "EntréeDéfaillances",
+  "description": "Champs importés par le parseur lib/urssaf/procol.go de sfdata.",
+  "bsonType": "object",
+  "required": ["action_procol", "stade_procol", "date_effet"],
+  "properties": {
+    "action_procol": {
+      "description": "Nature de la procédure de défaillance.",
+      "bsonType": "string",
+      "enum": ["liquidation", "redressement", "sauvegarde"]
+    },
+    "stade_procol": {
+      "description": "Evénement survenu dans le cadre de cette procédure.",
+      "bsonType": "string",
+      "enum": [
+        "abandon_procedure",
+        "solde_procedure",
+        "fin_procedure",
+        "plan_continuation",
+        "ouverture",
+        "inclusion_autre_procedure",
+        "cloture_insuffisance_actif"
+      ]
+    },
+    "date_effet": {
+      "bsonType": "date",
+      "description": "Date effet de la procédure collective."
+    }
+  },
+  "additionalProperties": false
+}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -37,7 +37,7 @@ func diffMaps(schemaProps map[string]propertySchema, structProps map[string]prop
 	}
 	for _, k := range commonKeys {
 		if !reflect.DeepEqual(structProps[k], schemaProps[k]) {
-			errors = append(errors, fmt.Errorf("property types of \"%v\" don't match: %v <> %v", k, schemaProps[k].BsonType, structProps[k].BsonType))
+			errors = append(errors, fmt.Errorf("property types of \"%v\" don't match: %v <> %v", k, schemaProps[k], structProps[k]))
 		}
 	}
 	return errors

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -46,7 +46,7 @@ func reflectPropsFromStruct(structInstance interface{}) map[string]propertySchem
 	for i := 0; i < fields.NumField(); i++ {
 		field := fields.Field(i)
 		fieldName := field.Tag.Get("json")
-		if fieldName != "" {
+		if fieldName != "" && fieldName != "-" {
 			fieldType := field.Type.Name()
 			// support pointer types
 			if fieldType == "" {

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -36,7 +36,7 @@ func TestDiffMaps(t *testing.T) {
 		schemaProps := map[string]propertySchema{"a": {BsonType: "number"}}
 		structProps := map[string]propertySchema{"a": {BsonType: "string"}}
 		assert.ElementsMatch(t, diffMaps(schemaProps, structProps), []error{
-			errors.New("property types of \"a\" don't match: number <> string"),
+			errors.New("property types of \"a\" don't match: {number map[] [] false} <> {string map[] [] false}"),
 		})
 	})
 }

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -69,8 +69,9 @@ func TestTypeAlignment(t *testing.T) {
 	}
 
 	typesToCompare := map[string]TypeToCompare{
-		"ccsf.schema.json":  {urssaf.CCSF{}, []error{}},
-		"delai.schema.json": {urssaf.Delai{}, []error{}}, // delai.schema.json est aligné avec le type urssaf.Delai 👌
+		"ccsf.schema.json":   {urssaf.CCSF{}, []error{}},
+		"procol.schema.json": {urssaf.Procol{}, []error{}},
+		"delai.schema.json":  {urssaf.Delai{}, []error{}}, // delai.schema.json est aligné avec le type urssaf.Delai 👌
 		"bdf.schema.json": {bdf.BDF{}, []error{ // bdf.schema.json n'est pas encore complet => la vérification va retourner les erreurs suivantes:
 			errors.New("property not found in JSON Schema: delai_fournisseur"),
 			errors.New("property not found in JSON Schema: dette_fiscale"),

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -33,10 +33,10 @@ func TestDiffMaps(t *testing.T) {
 		})
 	})
 	t.Run("doit détecter une entrée dont le type ne correspond pas", func(t *testing.T) {
-		schemaProps := map[string]propertySchema{"a": {"number"}}
-		structProps := map[string]propertySchema{"a": {"string"}}
+		schemaProps := map[string]propertySchema{"a": {BsonType: "number"}}
+		structProps := map[string]propertySchema{"a": {BsonType: "string"}}
 		assert.ElementsMatch(t, diffMaps(schemaProps, structProps), []error{
-			errors.New("property types of \"a\" don't match: {number} <> {string}"),
+			errors.New("property types of \"a\" don't match: number <> string"),
 		})
 	})
 }
@@ -46,20 +46,20 @@ func TestReflectPropsFromStruct(t *testing.T) {
 		type MyType struct {
 			MyField string `json:"myField"`
 		}
-		assert.Equal(t, map[string]propertySchema{"myField": {"string"}}, reflectPropsFromStruct(MyType{}))
+		assert.Equal(t, map[string]propertySchema{"myField": {BsonType: "string"}}, reflectPropsFromStruct(MyType{}))
 	})
 	t.Run("doit interpréter les types float64 et int comme number", func(t *testing.T) {
 		type MyType struct {
 			MyField1 int     `json:"f1"`
 			MyField2 float64 `json:"f2"`
 		}
-		assert.Equal(t, map[string]propertySchema{"f1": {"number"}, "f2": {"number"}}, reflectPropsFromStruct(MyType{}))
+		assert.Equal(t, map[string]propertySchema{"f1": {BsonType: "number"}, "f2": {BsonType: "number"}}, reflectPropsFromStruct(MyType{}))
 	})
 	t.Run("doit reconnaitre le type des pointeurs", func(t *testing.T) {
 		type MyType struct {
 			MyField1 *int `json:"f1"`
 		}
-		assert.Equal(t, map[string]propertySchema{"f1": {"number"}}, reflectPropsFromStruct(MyType{}))
+		assert.Equal(t, map[string]propertySchema{"f1": {BsonType: "number"}}, reflectPropsFromStruct(MyType{}))
 	})
 }
 

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/apconso"
+	"github.com/signaux-faibles/opensignauxfaibles/lib/apdemande"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/bdf"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/urssaf"
 	"github.com/stretchr/testify/assert"
@@ -70,10 +71,11 @@ func TestTypeAlignment(t *testing.T) {
 	}
 
 	typesToCompare := map[string]TypeToCompare{
-		"apconso.schema.json": {apconso.APConso{}, []error{}},
-		"ccsf.schema.json":    {urssaf.CCSF{}, []error{}},
-		"delai.schema.json":   {urssaf.Delai{}, []error{}},
-		"procol.schema.json":  {urssaf.Procol{}, []error{}},
+		"apconso.schema.json":   {apconso.APConso{}, []error{}},
+		"apdemande.schema.json": {apdemande.APDemande{}, []error{}},
+		"ccsf.schema.json":      {urssaf.CCSF{}, []error{}},
+		"delai.schema.json":     {urssaf.Delai{}, []error{}},
+		"procol.schema.json":    {urssaf.Procol{}, []error{}},
 		"bdf.schema.json": {bdf.BDF{}, []error{ // bdf.schema.json n'est pas encore complet => la vérification va retourner les erreurs suivantes:
 			errors.New("property not found in JSON Schema: delai_fournisseur"),
 			errors.New("property not found in JSON Schema: dette_fiscale"),

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/signaux-faibles/opensignauxfaibles/lib/apconso"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/bdf"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/urssaf"
 	"github.com/stretchr/testify/assert"
@@ -69,9 +70,10 @@ func TestTypeAlignment(t *testing.T) {
 	}
 
 	typesToCompare := map[string]TypeToCompare{
-		"ccsf.schema.json":   {urssaf.CCSF{}, []error{}},
-		"procol.schema.json": {urssaf.Procol{}, []error{}},
-		"delai.schema.json":  {urssaf.Delai{}, []error{}}, // delai.schema.json est aligné avec le type urssaf.Delai 👌
+		"apconso.schema.json": {apconso.APConso{}, []error{}},
+		"ccsf.schema.json":    {urssaf.CCSF{}, []error{}},
+		"delai.schema.json":   {urssaf.Delai{}, []error{}},
+		"procol.schema.json":  {urssaf.Procol{}, []error{}},
 		"bdf.schema.json": {bdf.BDF{}, []error{ // bdf.schema.json n'est pas encore complet => la vérification va retourner les erreurs suivantes:
 			errors.New("property not found in JSON Schema: delai_fournisseur"),
 			errors.New("property not found in JSON Schema: dette_fiscale"),

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -69,6 +69,7 @@ func TestTypeAlignment(t *testing.T) {
 	}
 
 	typesToCompare := map[string]TypeToCompare{
+		"ccsf.schema.json":  {urssaf.CCSF{}, []error{}},
 		"delai.schema.json": {urssaf.Delai{}, []error{}}, // delai.schema.json est aligné avec le type urssaf.Delai 👌
 		"bdf.schema.json": {bdf.BDF{}, []error{ // bdf.schema.json n'est pas encore complet => la vérification va retourner les erreurs suivantes:
 			errors.New("property not found in JSON Schema: delai_fournisseur"),


### PR DESCRIPTION
Suite de PR #309.

## Apports

- ajout de JSON Schemas pour les types `APConso`, `APDemande`, `CCSF`, `Delai` et `Procol`

## Étapes suivies pour chaque type

1. création d'un nouveau JSON Schema (vierge) dans le répertoire `validation/` => erreur de `go test` (fichier non référencé)
2. référencement du JSON Schema dans `validation/validation_test.go` => erreurs de `go test` (propriétés manquantes)
3. complétion du JSON Schema en s'appuyant sur le type Go en sortie du parseur => plus d'erreurs de `go test` ✅
4. dans la codebase TS: chargement du type depuis `GeneratedTypes.ts` au lieu de le définir dans `RawDataTypes.ts` => `go generate` passe sans erreurs ✅
5. si le JSON Schema est valide et que les types sont bien alignés, aucune erreur de validation ne sera listée par `test-import.sh` ✅

## Prochaines étapes

- Couvrir les types restants
- Généraliser la reflexion de types employée dans le test d'alignement (cf TODO dans `validation/validation.go`)