### PR TITLE
feat(reduce): time_til_outcome négatif

### DIFF
--- a/js/RawDataTypes.ts
+++ b/js/RawDataTypes.ts
@@ -21,7 +21,7 @@ import {
 
 // Types de données de base
 
-export type Periode = string // Date.getTime().toString()
+export type Periode = string // TODO: empêcher l'usage de valeurs non numériques, c.a.d. autres que Date.getTime().toString()
 export type Timestamp = number // Date.getTime()
 export type ParPériode<T> = Record<Periode, T>
 

--- a/js/reduce.algo2/cibleApprentissage.ts
+++ b/js/reduce.algo2/cibleApprentissage.ts
@@ -21,7 +21,7 @@ export type Variables = {
 
 export function cibleApprentissage(
   output_indexed: ParPériode<{ tag_failure?: boolean; tag_default?: boolean }>,
-  n_months: number
+  n_months: number /** nombre de mois avant/après l'évènement pendant lesquels outcome sera true */
 ): ParPériode<SortieCibleApprentissage> {
   "use strict"
 

--- a/js/reduce.algo2/cibleApprentissage.ts
+++ b/js/reduce.algo2/cibleApprentissage.ts
@@ -40,7 +40,28 @@ export function cibleApprentissage(
     }
   }
 
-  const output_outcome = f.lookAhead(merged_info, "outcome", n_months, true)
+  function objectMap<InputVal, OutputVal>(
+    obj: Record<string, InputVal>,
+    fct: (key: string, val: InputVal) => OutputVal
+  ): Record<string, OutputVal> {
+    const result: Record<string, OutputVal> = {}
+    Object.entries(obj).forEach(([key, val]) => {
+      result[key] = fct(key, val)
+    })
+    return result
+  }
+
+  const outputPastOutcome = objectMap(
+    f.lookAhead(merged_info, "outcome", n_months, false),
+    (_, val) => ({
+      ...val,
+      time_til_outcome: -val.time_til_outcome, // ex: -1 veut dire qu'il y a eu une défaillance il y a 1 mois
+    })
+  )
+  const output_outcome = {
+    ...outputPastOutcome,
+    ...f.lookAhead(merged_info, "outcome", n_months, true),
+  }
   const output_default = f.lookAhead(
     output_cotisation,
     "tag_default",

--- a/js/reduce.algo2/cibleApprentissage.ts
+++ b/js/reduce.algo2/cibleApprentissage.ts
@@ -1,5 +1,7 @@
 import { f } from "./functions"
 import { ParPériode } from "../RawDataTypes"
+import { SortieDefaillances } from "./defaillances"
+import { SortieCotisation } from "./cotisation"
 import { Outcome } from "./lookAhead"
 
 export type SortieCibleApprentissage = {
@@ -7,9 +9,9 @@ export type SortieCibleApprentissage = {
   /** Distance de l'évènement, exprimé en nombre de périodes. */
   time_til_outcome?: Outcome["time_til_outcome"]
   /** Distance de l'évènement basé sur le défaut de paiement des cotisations (cf tag_default), exprimé en nombre de périodes. */
-  time_til_default?: number
+  time_til_default?: Outcome["time_til_outcome"]
   /** Distance de l'évènement basé sur une défaillance (cf tag_failure des procédures collectives), exprimé en nombre de périodes. */
-  time_til_failure?: number
+  time_til_failure?: Outcome["time_til_outcome"]
 }
 
 // Variables est inspecté pour générer docs/variables.json (cf generate-docs.ts)
@@ -20,7 +22,10 @@ export type Variables = {
 }
 
 export function cibleApprentissage(
-  output_indexed: ParPériode<{ tag_failure?: boolean; tag_default?: boolean }>,
+  output_indexed: ParPériode<{
+    tag_failure?: SortieDefaillances["tag_failure"]
+    tag_default?: SortieCotisation["tag_default"]
+  }>,
   n_months: number /** nombre de mois avant/après l'évènement pendant lesquels outcome sera true */
 ): ParPériode<SortieCibleApprentissage> {
   "use strict"

--- a/js/reduce.algo2/cibleApprentissage_tests.ts
+++ b/js/reduce.algo2/cibleApprentissage_tests.ts
@@ -42,7 +42,7 @@ const testCases: TestCase[] = [
     expected: {
       "2015-01-01": {
         time_til_outcome: 2,
-        outcome: false,
+        outcome: false, // pas encore true car time_til_outcome > n_months
         time_til_default: 2,
       },
       "2015-02-01": { time_til_outcome: 1, outcome: true, time_til_default: 1 },

--- a/js/reduce.algo2/cibleApprentissage_tests.ts
+++ b/js/reduce.algo2/cibleApprentissage_tests.ts
@@ -47,7 +47,7 @@ const testCases: TestCase[] = [
       },
       "2015-02-01": { time_til_outcome: 1, outcome: true, time_til_default: 1 },
       "2015-03-01": { time_til_outcome: 0, outcome: true, time_til_default: 0 },
-      "2015-04-01": {},
+      "2015-04-01": { time_til_outcome: -1, outcome: true },
     },
   },
   {
@@ -66,7 +66,7 @@ const testCases: TestCase[] = [
       },
       "2015-02-01": { time_til_outcome: 1, outcome: true, time_til_failure: 1 },
       "2015-03-01": { time_til_outcome: 0, outcome: true, time_til_failure: 0 },
-      "2015-04-01": {},
+      "2015-04-01": { time_til_outcome: -1, outcome: true },
     },
   },
   {

--- a/js/reduce.algo2/defaillances.ts
+++ b/js/reduce.algo2/defaillances.ts
@@ -56,7 +56,7 @@ export function defaillances(
       )
     )
     const time_til_last = Object.keys(output_indexed).filter((val) => {
-      return val >= (periode_effet.toISOString().split("T")[0] as string)
+      return val >= (periode_effet.toISOString().split("T")[0] as string) // TODO: corriger cette comparaison
     })
 
     time_til_last.forEach((time) => {

--- a/js/reduce.algo2/defaillances_tests.ts
+++ b/js/reduce.algo2/defaillances_tests.ts
@@ -3,6 +3,8 @@ import { defaillances } from "./defaillances"
 import { EntréeDéfaillances } from "../GeneratedTypes"
 import { ParHash } from "../RawDataTypes"
 
+// TODO: modifier toutes les dates YYYY-MM-DD employées comme clés pour respecter le type ParPeriode<>
+
 test("Une ouverture de liquidation est prise en compte dans la période courante et les suivantes", (t) => {
   const output_indexed = {
     ["2018-01-01"]: {},

--- a/js/reduce.algo2/lookAhead.ts
+++ b/js/reduce.algo2/lookAhead.ts
@@ -20,8 +20,8 @@ export function lookAhead<
 >(
   data: ParPériode<T>,
   attr_name: K,
-  n_months: number,
-  past: boolean
+  n_months: number /** nombre de mois avant/après l'évènement pendant lesquels outcome sera true */,
+  past: boolean /** si true: on popule outcome pour les périodes passées, au lieu des périodes futures */
 ): ParPériode<Outcome> {
   "use strict"
   // Est-ce que l'évènement se répercute dans le passé (past = true on pourra se

--- a/lib/engine/jsFunctions.go
+++ b/lib/engine/jsFunctions.go
@@ -1025,7 +1025,15 @@ function sirene(sireneArray) {
             outcome: Boolean(((_a = output_procol[k]) === null || _a === void 0 ? void 0 : _a.tag_failure) || ((_b = output_cotisation[k]) === null || _b === void 0 ? void 0 : _b.tag_default)),
         };
     }
-    const output_outcome = f.lookAhead(merged_info, "outcome", n_months, true);
+    function objectMap(obj, fct) {
+        const result = {};
+        Object.entries(obj).forEach(([key, val]) => {
+            result[key] = fct(key, val);
+        });
+        return result;
+    }
+    const outputPastOutcome = objectMap(f.lookAhead(merged_info, "outcome", n_months, false), (_, val) => (Object.assign(Object.assign({}, val), { time_til_outcome: -val.time_til_outcome })));
+    const output_outcome = Object.assign(Object.assign({}, outputPastOutcome), f.lookAhead(merged_info, "outcome", n_months, true));
     const output_default = f.lookAhead(output_cotisation, "tag_default", n_months, true);
     const output_failure = f.lookAhead(output_procol, "tag_failure", n_months, true);
     const output_cible = all_keys.reduce(function (m, k) {


### PR DESCRIPTION
Fixes #307.

Comme suggéré par Pierre [ici](https://github.com/signaux-faibles/predictsignauxfaibles/pull/13#discussion_r566119438), `time_til_outcome` peut désormais prendre une valeur négative.

Exemple: `-3` indique que la défaillance a eu lieu il y a 3 mois.