### PR TITLE
fix(tests): Figer l'ordre des rapports de `sfdata check`

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	flag "github.com/cosiner/flag"
@@ -172,6 +173,7 @@ func (params checkBatchHandler) Run() error {
 		return errors.New("Erreurs détectées: " + err.Error())
 	}
 
+	sort.Strings(reports) // to make sure that parsed files are always listed in the same order
 	printJSON(bson.M{"reports": reports})
 	return nil
 }

--- a/tests/output-snapshots/test-check.golden.txt
+++ b/tests/output-snapshots/test-check.golden.txt
@@ -3,22 +3,6 @@
 	{
 		"event" : {
 			"headRejected" : [
-				"Line 2: record on line 3: wrong number of fields",
-				"Line 4: parse error on line 5, column 1: bare \" in non-quoted-field"
-			],
-			"headFatal" : [ ],
-			"linesSkipped" : 0,
-			"summary" : "/../lib/urssaf/testData/debitCorrompuTestData.csv: intégration terminée, 5 lignes traitées, 0 erreurs fatales, 2 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
-			"batchKey" : "1910"
-		},
-		"reportType" : "CheckBatch",
-		"parserCode" : "debit",
-		"hasDate" : true,
-		"hasStartDate" : true
-	},
-	{
-		"event" : {
-			"headRejected" : [
 				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2011-08-01 00:00:00 +0000 UTC",
 				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2011-09-01 00:00:00 +0000 UTC",
 				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2011-10-01 00:00:00 +0000 UTC",
@@ -117,6 +101,22 @@
 		},
 		"reportType" : "CheckBatch",
 		"parserCode" : "admin_urssaf",
+		"hasDate" : true,
+		"hasStartDate" : true
+	},
+	{
+		"event" : {
+			"headRejected" : [
+				"Line 2: record on line 3: wrong number of fields",
+				"Line 4: parse error on line 5, column 1: bare \" in non-quoted-field"
+			],
+			"headFatal" : [ ],
+			"linesSkipped" : 0,
+			"summary" : "/../lib/urssaf/testData/debitCorrompuTestData.csv: intégration terminée, 5 lignes traitées, 0 erreurs fatales, 2 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
+			"batchKey" : "1910"
+		},
+		"reportType" : "CheckBatch",
+		"parserCode" : "debit",
 		"hasDate" : true,
 		"hasStartDate" : true
 	},

--- a/tests/test-check.sh
+++ b/tests/test-check.sh
@@ -59,7 +59,7 @@ echo "- sfdata check (with 2 files to parse) 👉 ${RESULT2}"
   > "${OUTPUT_FILE}" \
 ) << CONTENT
 print("// Documents from db.Journal:");
-printjson(db.Journal.find().toArray().map(doc => ({
+printjson(db.Journal.find().sort({ reportType: -1, parserCode: 1 }).toArray().map(doc => ({
   // note: we use map() to force the order of properties at every run of this test
   event: {
     headRejected: doc.event.headRejected,


### PR DESCRIPTION
## Problème

En travaillant sur la PR #335, l'ordre des rapports générés par `sfdata check` a encore changé, comme dans la [PR #334](https://github.com/signaux-faibles/opensignauxfaibles/pull/334/files#diff-fc9abfbc3f2c2438ac1e157c22e8e449925c2f81b6459f4171775581cb59be45). Ces changements impliquent le besoin de mettre à jour le golden file de `test-check.sh` alors qu'en réalité `sfdata` se comporte comme d'habitude.

## Solution proposée

Figer l'ordre des rapports une fois pour toute, en utilisant un tri par nom de fichier.