### PR TITLE
fix(CI): Validation du titre des PRs

### DIFF
--- a/.github/semantic-pr-title.yml
+++ b/.github/semantic-pr-title.yml
@@ -1,0 +1,1 @@
+REGEX: "(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9\\s]+\\))?(:\\s)([a-z0-9\\s]+)"

--- a/.github/semantic-pr-title.yml
+++ b/.github/semantic-pr-title.yml
@@ -1,1 +1,0 @@
-REGEX: "(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([a-z0-9\\s]+\\))?(:\\s)([a-z0-9\\s]+)"

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# "Semantic Pull Request" to just check the PR title, and ignore the commits messages
+titleOnly: true


### PR DESCRIPTION
## Problème

Vu qu'on _squash_ les commits lorsqu'on fusionne une PR dans la branche principale du dépôt, le titre de la PR devient le message de commit qui sera intégré dans cette branche.

Sachant que la normalisation des messages de commits permet une meilleure lisibilité de la nature des changements apportés et un comptage automatique des numéros de versions, il serait pratique que GitHub nous prévienne lorsqu'un titre de PR n'est pas normalisé au format Conventional Commit.

## Solution proposée

Installation de ~~[coleHafner/semantic-pr-title: GitHub app to enforce Angular commit conventions for PR title](https://github.com/coleHafner/semantic-pr-title)~~ [GitHub Apps - Semantic Pull Requests](https://github.com/apps/semantic-pull-requests). (comme dans `prepare-import`)

<img width="834" alt="Capture d’écran 2021-03-18 à 17 50 27" src="https://user-images.githubusercontent.com/531781/111664792-6d54e080-8812-11eb-8318-12a124e0e5fa.png">
