### PR TITLE
fix: Dé-duplication & découpage du pilotage de parseurs

### DIFF
--- a/lib/marshal/parser.go
+++ b/lib/marshal/parser.go
@@ -83,7 +83,11 @@ func ParseFile(path base.BatchFile, parser Parser, batch *base.AdminBatch, cache
 		tracker.AddFatalError(err)
 	}
 	if len(tracker.fatalErrors) == 0 {
-		runParserWithSirenFilter(parser, &filter, filePath, &tracker, outputChannel)
+		parsedLineChan := make(chan ParsedLineResult)
+		go parser.ParseLines(parsedLineChan)
+		for lineResult := range parsedLineChan {
+			parseTuplesFromLine(lineResult, &filter, &tracker, outputChannel)
+		}
 		if err := parser.Close(); err != nil {
 			tracker.AddFatalError(err)
 		}
@@ -91,36 +95,31 @@ func ParseFile(path base.BatchFile, parser Parser, batch *base.AdminBatch, cache
 	return CreateReportEvent(fileType, tracker.Report(batch.ID.Key, path.FilePath())) // abstract
 }
 
-func runParserWithSirenFilter(parser Parser, filter *SirenFilter, filePath string, tracker *ParsingTracker, outputChannel chan Tuple) {
-	// Note: on ne passe plus le tracker aux parseurs afin de garder ici le controle de la numérotation des lignes où les erreurs sont trouvées
-	parsedLineChan := make(chan ParsedLineResult)
-	go parser.ParseLines(parsedLineChan)
-	for lineResult := range parsedLineChan {
-		filterError := lineResult.FilterError
-		if filterError != nil {
-			tracker.AddFilterError(filterError) // on rapporte le filtrage même si aucun tuple n'est transmis par le parseur
-		}
-		for _, err := range lineResult.Errors {
-			tracker.AddParseError(err)
-		}
-		for _, tuple := range lineResult.Tuples {
-			if filterError != nil {
-				continue // l'erreur de filtrage a déjà été rapportée => on se contente de passer au tuple suivant
-			} else if _, err := isValid(tuple); err != nil {
-				// Si le siret/siren est invalide, on jette le tuple,
-				// et on rapporte une erreur seulement si aucune n'a été
-				// rapportée par le parseur.
-				if len(lineResult.Errors) == 0 {
-					tracker.AddParseError(err)
-				}
-			} else if filter.Skips(tuple.Key()) {
-				tracker.AddFilterError(errors.New("(filtered)"))
-			} else {
-				outputChannel <- tuple
-			}
-		}
-		tracker.Next()
+func parseTuplesFromLine(lineResult ParsedLineResult, filter *SirenFilter, tracker *ParsingTracker, outputChannel chan Tuple) {
+	filterError := lineResult.FilterError
+	if filterError != nil {
+		tracker.AddFilterError(filterError) // on rapporte le filtrage même si aucun tuple n'est transmis par le parseur
 	}
+	for _, err := range lineResult.Errors {
+		tracker.AddParseError(err)
+	}
+	for _, tuple := range lineResult.Tuples {
+		if filterError != nil {
+			continue // l'erreur de filtrage a déjà été rapportée => on se contente de passer au tuple suivant
+		} else if _, err := isValid(tuple); err != nil {
+			// Si le siret/siren est invalide, on jette le tuple,
+			// et on rapporte une erreur seulement si aucune n'a été
+			// rapportée par le parseur.
+			if len(lineResult.Errors) == 0 {
+				tracker.AddParseError(err)
+			}
+		} else if filter.Skips(tuple.Key()) {
+			tracker.AddFilterError(errors.New("(filtered)"))
+		} else {
+			outputChannel <- tuple
+		}
+	}
+	tracker.Next()
 }
 
 // GetJSON sérialise un tuple au format JSON.

--- a/lib/marshal/parser.go
+++ b/lib/marshal/parser.go
@@ -96,6 +96,7 @@ func runParserOnFile(filePath string, parser Parser, batch *base.AdminBatch, cac
 	go parser.ParseLines(parsedLineChan)
 	for lineResult := range parsedLineChan {
 		parseTuplesFromLine(lineResult, &filter, tracker, outputChannel)
+		tracker.Next()
 	}
 	return parser.Close()
 }
@@ -124,7 +125,6 @@ func parseTuplesFromLine(lineResult ParsedLineResult, filter *SirenFilter, track
 			outputChannel <- tuple
 		}
 	}
-	tracker.Next()
 }
 
 // GetJSON sérialise un tuple au format JSON.

--- a/lib/marshal/parser.go
+++ b/lib/marshal/parser.go
@@ -109,10 +109,11 @@ func parseTuplesFromLine(lineResult ParsedLineResult, filter *SirenFilter, track
 	for _, err := range lineResult.Errors {
 		tracker.AddParseError(err)
 	}
+	if filterError != nil {
+		return
+	}
 	for _, tuple := range lineResult.Tuples {
-		if filterError != nil {
-			continue // l'erreur de filtrage a déjà été rapportée => on se contente de passer au tuple suivant
-		} else if _, err := isValid(tuple); err != nil {
+		if _, err := isValid(tuple); err != nil {
 			// On rapporte une erreur de siret/siren invalide seulement si aucune autre error n'a été rapportée par le parseur
 			if len(lineResult.Errors) == 0 {
 				tracker.AddParseError(err)

--- a/parseFileHandler.go
+++ b/parseFileHandler.go
@@ -48,22 +48,16 @@ func (params parseFileHandler) Run() error {
 		return err
 	}
 
-	batch := base.AdminBatch{Files: base.BatchFiles{params.Parser: []base.BatchFile{base.BatchFile(params.File)}}}
+	file := base.BatchFile(params.File)
+	batch := base.AdminBatch{Files: base.BatchFiles{params.Parser: []base.BatchFile{file}}}
 	cache := marshal.NewCache()
 	parser := parsers[0]
 
 	// the following code is inspired from marshal.ParseFilesFromBatch()
 	outputChannel := make(chan marshal.Tuple)
 	eventChannel := make(chan marshal.Event)
-	filter := marshal.GetSirenFilterFromCache(cache)
 	go func() {
-		tracker := marshal.NewParsingTracker()
-		if err := parser.Init(&cache, &batch); err != nil {
-			tracker.AddFatalError(err)
-		} else {
-			marshal.RunParserWithSirenFilter(parser, &filter, params.File, &tracker, outputChannel)
-		}
-		eventChannel <- marshal.CreateReportEvent(params.Parser, tracker.Report(batch.ID.Key, params.File))
+		eventChannel <- marshal.ParseFile(file, parser, &batch, cache, outputChannel)
 		close(outputChannel)
 		close(eventChannel)
 	}()


### PR DESCRIPTION
## Objectifs

- rendre la logique d'extraction de tuples et d'erreurs plus lisible et maintenable, en cloisonnant les responsabilités de chaque fonction
- dé-dupliquer le code de `marshal.ParseFilesFromBatch()`, appelé dans `parseFileHandler.go` (commande `parseFile` de `sfdata`)