### PR TITLE
fix(Features): Correction du calcul des totaux par entreprise

### DIFF
--- a/js/reduce.algo2/finalize.ts
+++ b/js/reduce.algo2/finalize.ts
@@ -65,11 +65,12 @@ export function finalize(k: Clé, v: SortieMap): SortieFinalize {
   )
   const entr: DonnéesEntreprise = { ...v.entreprise } as DonnéesEntreprise // on suppose que v.entreprise est défini
 
-  const output: SortieEtabAvecEntreprise[] = Object.keys(établissements).map(
-    (siret) => {
+  const output: SortieEtabAvecEntreprise[] = Object.keys(établissements)
+    .map((siret) => {
       const etab: SortieMapEtablissement = établissements[siret] ?? {}
       if (etab.effectif) {
-        entr.effectif_entreprise = entr.effectif_entreprise || 0 + etab.effectif
+        entr.effectif_entreprise =
+          (entr.effectif_entreprise || 0) + etab.effectif
       }
       if (etab.apart_heures_consommees) {
         entr.apart_entreprise =
@@ -81,13 +82,13 @@ export function finalize(k: Clé, v: SortieMap): SortieFinalize {
           (etab.montant_part_patronale ?? 0) +
           (etab.montant_part_ouvriere ?? 0)
       }
-      return {
-        ...etab, // TODO: s'assurer que certains champs de données d'établissement ne sont pas écrasés par des données d'entreprise portant le même nom
-        ...entr,
-        nbr_etablissements_connus: Object.keys(établissements).length,
-      }
-    }
-  )
+      return etab
+    })
+    .map((etab) => ({
+      ...etab, // TODO: s'assurer que certains champs de données d'établissement ne sont pas écrasés par des données d'entreprise portant le même nom
+      ...entr,
+      nbr_etablissements_connus: Object.keys(établissements).length,
+    }))
 
   // NON: Pour l'instant, filtrage a posteriori
   // output = output.filter(siret_data => {

--- a/js/reduce.algo2/finalize_tests.ts
+++ b/js/reduce.algo2/finalize_tests.ts
@@ -2,83 +2,75 @@ import test from "ava"
 import { finalize } from "./finalize"
 import { CléSortieMap } from "./map"
 
+const siret1 = "12345678901234"
+const siret2 = "12345678901235"
+
+const clé = {
+  batch: "dummy",
+  siren: "012345678",
+  periode: new Date("2014-01-01"),
+  type: "other" as CléSortieMap["type"],
+}
+
 test(`finalize() fait la somme des effectifs des établissement rattachés à l'entreprise`, (t) => {
-  const clé = {
-    batch: "dummy",
-    siren: "012345678",
-    periode: new Date("2014-01-01"),
-    type: "other" as CléSortieMap["type"],
-  }
   const results = finalize(clé, {
-    "12345678901234": { siret: "12345678901234", effectif: 3 },
-    "12345678901235": { siret: "12345678901235", effectif: 4 },
+    siret1: { siret: siret1, effectif: 3 },
+    siret2: { siret: siret2, effectif: 4 },
   })
   t.deepEqual(results, [
     {
       effectif: 3,
       effectif_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: "12345678901234",
+      siret: siret1,
     },
     {
       effectif: 4,
       effectif_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: "12345678901235",
+      siret: siret2,
     },
   ] as unknown)
 })
 
 test(`finalize() fait la somme des heures d'activité partielle des établissement rattachés à l'entreprise`, (t) => {
-  const clé = {
-    batch: "dummy",
-    siren: "012345678",
-    periode: new Date("2014-01-01"),
-    type: "other" as CléSortieMap["type"],
-  }
   const results = finalize(clé, {
-    "12345678901234": { siret: "12345678901234", apart_heures_consommees: 3 },
-    "12345678901235": { siret: "12345678901235", apart_heures_consommees: 4 },
+    siret1: { siret: siret1, apart_heures_consommees: 3 },
+    siret2: { siret: siret2, apart_heures_consommees: 4 },
   })
   t.deepEqual(results, [
     {
       apart_heures_consommees: 3,
       apart_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: "12345678901234",
+      siret: siret1,
     },
     {
       apart_heures_consommees: 4,
       apart_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: "12345678901235",
+      siret: siret2,
     },
   ] as unknown)
 })
 
 test(`finalize() calcule la dette totale de l'entreprise à partir de celle des établissement`, (t) => {
-  const clé = {
-    batch: "dummy",
-    siren: "012345678",
-    periode: new Date("2014-01-01"),
-    type: "other" as CléSortieMap["type"],
-  }
   const results = finalize(clé, {
-    "12345678901234": { siret: "12345678901234", montant_part_patronale: 3 },
-    "12345678901235": { siret: "12345678901235", montant_part_ouvriere: 4 },
+    siret1: { siret: siret1, montant_part_patronale: 3 },
+    siret2: { siret: siret2, montant_part_ouvriere: 4 },
   })
   t.deepEqual(results, [
     {
       montant_part_patronale: 3,
       debit_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: "12345678901234",
+      siret: siret1,
     },
     {
       montant_part_ouvriere: 4,
       debit_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: "12345678901235",
+      siret: siret2,
     },
   ] as unknown)
 })

--- a/js/reduce.algo2/finalize_tests.ts
+++ b/js/reduce.algo2/finalize_tests.ts
@@ -1,0 +1,84 @@
+import test from "ava"
+import { finalize } from "./finalize"
+import { CléSortieMap } from "./map"
+
+test(`finalize() fait la somme des effectifs des établissement rattachés à l'entreprise`, (t) => {
+  const clé = {
+    batch: "dummy",
+    siren: "012345678",
+    periode: new Date("2014-01-01"),
+    type: "other" as CléSortieMap["type"],
+  }
+  const results = finalize(clé, {
+    "12345678901234": { siret: "12345678901234", effectif: 3 },
+    "12345678901235": { siret: "12345678901235", effectif: 4 },
+  })
+  t.deepEqual(results, [
+    {
+      effectif: 3,
+      effectif_entreprise: 7,
+      nbr_etablissements_connus: 2,
+      siret: "12345678901234",
+    },
+    {
+      effectif: 4,
+      effectif_entreprise: 7,
+      nbr_etablissements_connus: 2,
+      siret: "12345678901235",
+    },
+  ] as unknown)
+})
+
+test(`finalize() fait la somme des heures d'activité partielle des établissement rattachés à l'entreprise`, (t) => {
+  const clé = {
+    batch: "dummy",
+    siren: "012345678",
+    periode: new Date("2014-01-01"),
+    type: "other" as CléSortieMap["type"],
+  }
+  const results = finalize(clé, {
+    "12345678901234": { siret: "12345678901234", apart_heures_consommees: 3 },
+    "12345678901235": { siret: "12345678901235", apart_heures_consommees: 4 },
+  })
+  t.deepEqual(results, [
+    {
+      apart_heures_consommees: 3,
+      apart_entreprise: 7,
+      nbr_etablissements_connus: 2,
+      siret: "12345678901234",
+    },
+    {
+      apart_heures_consommees: 4,
+      apart_entreprise: 7,
+      nbr_etablissements_connus: 2,
+      siret: "12345678901235",
+    },
+  ] as unknown)
+})
+
+test(`finalize() calcule la dette totale de l'entreprise à partir de celle des établissement`, (t) => {
+  const clé = {
+    batch: "dummy",
+    siren: "012345678",
+    periode: new Date("2014-01-01"),
+    type: "other" as CléSortieMap["type"],
+  }
+  const results = finalize(clé, {
+    "12345678901234": { siret: "12345678901234", montant_part_patronale: 3 },
+    "12345678901235": { siret: "12345678901235", montant_part_ouvriere: 4 },
+  })
+  t.deepEqual(results, [
+    {
+      montant_part_patronale: 3,
+      debit_entreprise: 7,
+      nbr_etablissements_connus: 2,
+      siret: "12345678901234",
+    },
+    {
+      montant_part_ouvriere: 4,
+      debit_entreprise: 7,
+      nbr_etablissements_connus: 2,
+      siret: "12345678901235",
+    },
+  ] as unknown)
+})

--- a/js/reduce.algo2/finalize_tests.ts
+++ b/js/reduce.algo2/finalize_tests.ts
@@ -2,9 +2,6 @@ import test from "ava"
 import { finalize } from "./finalize"
 import { CléSortieMap } from "./map"
 
-const siret1 = "12345678901234"
-const siret2 = "12345678901235"
-
 const clé = {
   batch: "dummy",
   siren: "012345678",
@@ -14,63 +11,57 @@ const clé = {
 
 test(`finalize() fait la somme des effectifs des établissement rattachés à l'entreprise`, (t) => {
   const results = finalize(clé, {
-    siret1: { siret: siret1, effectif: 3 },
-    siret2: { siret: siret2, effectif: 4 },
+    siret1: { effectif: 3 },
+    siret2: { effectif: 4 },
   })
   t.deepEqual(results, [
     {
       effectif: 3,
       effectif_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: siret1,
     },
     {
       effectif: 4,
       effectif_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: siret2,
     },
   ] as unknown)
 })
 
 test(`finalize() fait la somme des heures d'activité partielle des établissement rattachés à l'entreprise`, (t) => {
   const results = finalize(clé, {
-    siret1: { siret: siret1, apart_heures_consommees: 3 },
-    siret2: { siret: siret2, apart_heures_consommees: 4 },
+    siret1: { apart_heures_consommees: 3 },
+    siret2: { apart_heures_consommees: 4 },
   })
   t.deepEqual(results, [
     {
       apart_heures_consommees: 3,
       apart_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: siret1,
     },
     {
       apart_heures_consommees: 4,
       apart_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: siret2,
     },
   ] as unknown)
 })
 
 test(`finalize() calcule la dette totale de l'entreprise à partir de celle des établissement`, (t) => {
   const results = finalize(clé, {
-    siret1: { siret: siret1, montant_part_patronale: 3 },
-    siret2: { siret: siret2, montant_part_ouvriere: 4 },
+    siret1: { montant_part_patronale: 3 },
+    siret2: { montant_part_ouvriere: 4 },
   })
   t.deepEqual(results, [
     {
       montant_part_patronale: 3,
       debit_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: siret1,
     },
     {
       montant_part_ouvriere: 4,
       debit_entreprise: 7,
       nbr_etablissements_connus: 2,
-      siret: siret2,
     },
   ] as unknown)
 })

--- a/lib/engine/jsFunctions.go
+++ b/lib/engine/jsFunctions.go
@@ -716,9 +716,6 @@ function reduce(key, values // chaque element contient plusieurs batches pour ce
 }`,
 		}, nil
 	},
-	"coverage": func(params bson.M) (functions, error) {
-		return functions{}, nil
-	},
 	"public": func(params bson.M) (functions, error) {
 		if _, ok := params["actual_batch"]; !ok {
 			return nil, errors.New("missing required parameter: actual_batch")

--- a/lib/engine/jsFunctions.go
+++ b/lib/engine/jsFunctions.go
@@ -716,6 +716,9 @@ function reduce(key, values // chaque element contient plusieurs batches pour ce
 }`,
 		}, nil
 	},
+	"coverage": func(params bson.M) (functions, error) {
+		return functions{}, nil
+	},
 	"public": func(params bson.M) (functions, error) {
 		if _, ok := params["actual_batch"]; !ok {
 			return nil, errors.New("missing required parameter: actual_batch")
@@ -1724,11 +1727,13 @@ function delais(vDelai, debitParPériode, intervalleTraitement) {
     // extraction de l'entreprise et des établissements depuis v
     const établissements = f.omit(v, "entreprise");
     const entr = Object.assign({}, v.entreprise); // on suppose que v.entreprise est défini
-    const output = Object.keys(établissements).map((siret) => {
+    const output = Object.keys(établissements)
+        .map((siret) => {
         var _a, _b, _c, _d;
         const etab = (_a = établissements[siret]) !== null && _a !== void 0 ? _a : {};
         if (etab.effectif) {
-            entr.effectif_entreprise = entr.effectif_entreprise || 0 + etab.effectif;
+            entr.effectif_entreprise =
+                (entr.effectif_entreprise || 0) + etab.effectif;
         }
         if (etab.apart_heures_consommees) {
             entr.apart_entreprise =
@@ -1740,8 +1745,9 @@ function delais(vDelai, debitParPériode, intervalleTraitement) {
                     ((_c = etab.montant_part_patronale) !== null && _c !== void 0 ? _c : 0) +
                     ((_d = etab.montant_part_ouvriere) !== null && _d !== void 0 ? _d : 0);
         }
-        return Object.assign(Object.assign(Object.assign({}, etab), entr), { nbr_etablissements_connus: Object.keys(établissements).length });
-    });
+        return etab;
+    })
+        .map((etab) => (Object.assign(Object.assign(Object.assign({}, etab), entr), { nbr_etablissements_connus: Object.keys(établissements).length })));
     // NON: Pour l'instant, filtrage a posteriori
     // output = output.filter(siret_data => {
     //   return(siret_data.effectif) // Only keep if there is known effectif


### PR DESCRIPTION
## Problèmes

Bugs découverts en augmentant la couverture de tests des traitements map-reduce, dans PR #348:

1. Les variables `effectif_entreprise`, `apart_entreprise` et `debit_entreprise` rattachées à chaque établissement de `Features` sont des valeurs intermédiaires au lieu de représenter le total calculé sur tous les établissements de l'entreprise. (cf 3 diffs ci-dessous)
2. La variable `effectif_entreprise` vaut systématiquement l'effectif du premier établissement de l'entreprise (cf 1er diff ci-dessous)

```
  reduce.algo2 › finalize_tests.ts › finalize() fait la somme des effectifs des établissement rattachés à l'entreprise

  Difference:

    [
      {
        effectif: 3,
  -     effectif_entreprise: 3,
  +     effectif_entreprise: 7,
        nbr_etablissements_connus: 2,
        siret: '12345678901234',
      },
      {
        effectif: 4,
  -     effectif_entreprise: 3,
  +     effectif_entreprise: 7,
        nbr_etablissements_connus: 2,
        siret: '12345678901235',
      },
    ]

  reduce.algo2 › finalize_tests.ts › finalize() fait la somme des heures d'activité partielle des établissement rattachés à l'entreprise

  Difference:

    [
      {
  -     apart_entreprise: 3,
  +     apart_entreprise: 7,
        apart_heures_consommees: 3,
        nbr_etablissements_connus: 2,
        siret: '12345678901234',
      },
      {
        apart_entreprise: 7,
        apart_heures_consommees: 4,
        nbr_etablissements_connus: 2,
        siret: '12345678901235',
      },
    ]

  reduce.algo2 › finalize_tests.ts › finalize() calcule la dette totale de l'entreprise à partir de celle des établissement

  Difference:

    [
      {
  -     debit_entreprise: 3,
  +     debit_entreprise: 7,
        montant_part_patronale: 3,
        nbr_etablissements_connus: 2,
        siret: '12345678901234',
      },
      {
        debit_entreprise: 7,
        montant_part_ouvriere: 4,
        nbr_etablissements_connus: 2,
        siret: '12345678901235',
      },
    ]

```

Source: https://github.com/signaux-faibles/opensignauxfaibles/pull/349/checks?check_run_id=2383084885#step:7:127