### PR TITLE
fix(import): Support des fichiers comptes "admin_urssaf" compressés

### DIFF
--- a/lib/engine/adminBatch.go
+++ b/lib/engine/adminBatch.go
@@ -67,7 +67,7 @@ func CheckBatchPaths(batch *base.AdminBatch) error {
 	var ErrorString string
 	for _, filepaths := range batch.Files {
 		for _, batchFile := range filepaths {
-			filepath := viper.GetString("APP_DATA") + batchFile.FilePath()
+			filepath := viper.GetString("APP_DATA") + batchFile.FilePath() // TODO: don't forget to prepend with batchFile.Prefix(), to support files with the "gzip:" prefix
 			if _, err := os.Stat(filepath); err != nil {
 				ErrorString += filepath + " is missing (" + err.Error() + ").\n"
 			}

--- a/lib/marshal/mapping.go
+++ b/lib/marshal/mapping.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"log"
-	"path"
 
 	"github.com/signaux-faibles/opensignauxfaibles/lib/base"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/sfregexp"
@@ -90,7 +89,7 @@ func GetCompteSiretMapping(cache Cache, batch *base.AdminBatch, mr mappingReader
 		return nil, errors.New("no admin_urssaf mapping found")
 	}
 	for _, p := range path {
-		compteSiretMapping, err = mr(basePath, p.FilePath(), compteSiretMapping, cache, batch)
+		compteSiretMapping, err = mr(basePath, p, compteSiretMapping, cache, batch)
 		if err != nil {
 			return nil, err
 		}
@@ -99,18 +98,20 @@ func GetCompteSiretMapping(cache Cache, batch *base.AdminBatch, mr mappingReader
 	return compteSiretMapping, nil
 }
 
-type mappingReader func(string, string, Comptes, Cache, *base.AdminBatch) (Comptes, error)
+type mappingReader func(string, base.BatchFile, Comptes, Cache, *base.AdminBatch) (Comptes, error)
 
 // OpenAndReadSiretMapping opens files and reads their content
 func OpenAndReadSiretMapping(
 	basePath string,
-	endPath string,
+	batchFile base.BatchFile,
 	compteSiretMapping Comptes,
 	cache Cache,
 	batch *base.AdminBatch,
 ) (Comptes, error) {
 
-	file, fileReader, err := OpenFileReader(base.BatchFile(path.Join(basePath, endPath)))
+	filePath := base.BatchFile(batchFile.Prefix() + basePath + batchFile.FilePath()) // note: basePath is probably viper.GetString("APP_DATA")
+
+	file, fileReader, err := OpenFileReader(filePath)
 	if err != nil {
 		return nil, errors.New("Erreur à l'ouverture du fichier, " + err.Error())
 	}

--- a/lib/marshal/mapping_test.go
+++ b/lib/marshal/mapping_test.go
@@ -176,7 +176,7 @@ func TestGetCompteSiretMapping(t *testing.T) {
 		}
 
 		// When file is read, returnd stdExpected1
-		mockOpenFile := func(s1 string, s2 string, c Comptes, ca Cache, ba *base.AdminBatch) (Comptes, error) {
+		mockOpenFile := func(s1 string, s2 base.BatchFile, c Comptes, ca Cache, ba *base.AdminBatch) (Comptes, error) {
 			for key := range stdExpected1 {
 				c[key] = stdExpected1[key]
 			}


### PR DESCRIPTION
## Objectif

Vérifier que les fichiers `admin_urssaf` (comptes) gzippés sont supportés par `sfdata import`.

## Solution

Transmission de l'instance `BatchFile` (avec son préfixe `gzip:`) à jusqu'à la fonction `OpenFileReader()`, au lieu d'en extraire le chemin sans son préfixe, dans `OpenAndReadSiretMapping()`.