### PR TITLE
fix(import): Nombre négatif de lignes valides rapportées dans Journal

### DIFF
--- a/lib/marshal/parser_test.go
+++ b/lib/marshal/parser_test.go
@@ -39,10 +39,10 @@ func TestParseTuplesFromLine(t *testing.T) {
 		tracker.Next()
 
 		report := tracker.Report("", "")
-		assert.Equal(t, 1, report["linesParsed"])
-		assert.Equal(t, 1, report["linesRejected"])
-		assert.Equal(t, 0, report["linesSkipped"])
-		assert.Equal(t, 0, report["linesValid"])
+		assert.Equal(t, int64(1), report["linesParsed"])
+		assert.Equal(t, int64(1), report["linesRejected"])
+		assert.Equal(t, int64(0), report["linesSkipped"])
+		assert.Equal(t, int64(0), report["linesValid"])
 		assert.Equal(t, 2, len(report["headRejected"].([]string)))
 	})
 
@@ -57,10 +57,10 @@ func TestParseTuplesFromLine(t *testing.T) {
 		tracker.Next()
 
 		report := tracker.Report("", "")
-		assert.Equal(t, 1, report["linesParsed"])
-		assert.Equal(t, 0, report["linesRejected"])
-		assert.Equal(t, 1, report["linesSkipped"])
-		assert.Equal(t, 0, report["linesValid"])
+		assert.Equal(t, int64(1), report["linesParsed"])
+		assert.Equal(t, int64(0), report["linesRejected"])
+		assert.Equal(t, int64(1), report["linesSkipped"])
+		assert.Equal(t, int64(0), report["linesValid"])
 		assert.Equal(t, 0, len(report["headRejected"].([]string)))
 	})
 }

--- a/lib/marshal/parser_test.go
+++ b/lib/marshal/parser_test.go
@@ -26,6 +26,45 @@ func TestParseFilesFromBatch(t *testing.T) {
 	})
 }
 
+func TestParseTuplesFromLine(t *testing.T) {
+
+	t.Run("ne comptabilise pas plus d'une erreur par ligne", func(t *testing.T) {
+		var parsedLine ParsedLineResult
+		parsedLine.AddRegularError(errors.New("error 1"))
+		parsedLine.AddRegularError(errors.New("error 2"))
+		parsedLine.AddTuple(dummyTuple{})
+
+		outputChannel := make(chan Tuple)
+		tracker := NewParsingTracker()
+		parseTuplesFromLine(parsedLine, &SirenFilter{}, &tracker, outputChannel)
+		tracker.Next()
+
+		report := tracker.Report("", "")
+		assert.Equal(t, 1, report["linesParsed"])
+		assert.Equal(t, 1, report["linesRejected"])
+		assert.Equal(t, 0, report["linesSkipped"])
+		assert.Equal(t, 0, report["linesValid"])
+		assert.Equal(t, 2, len(report["headRejected"].([]string)))
+	})
+}
+
+type dummyTuple struct{}
+
+// Key id de l'objet",
+func (sirene dummyTuple) Key() string {
+	return ""
+}
+
+// Type de données
+func (sirene dummyTuple) Type() string {
+	return "dummy"
+}
+
+// Scope de l'objet
+func (sirene dummyTuple) Scope() string {
+	return "etablissement"
+}
+
 type dummyParser struct {
 	initError error
 }

--- a/lib/marshal/tracker.go
+++ b/lib/marshal/tracker.go
@@ -12,14 +12,14 @@ var MaxParsingErrors = 200
 // ParsingTracker permet de collecter puis rapporter des erreurs de parsing.
 type ParsingTracker struct {
 	// fields that are included in the report:
-	currentLine      int      // Note: line 1 is the first line of data (excluding the header) read from a file
-	nbSkippedLines   int      // lines skipped by the perimeter/filter or not found in "comptes" mapping
-	nbRejectedLines  int      // lines that have at least one parse error
+	currentLine      int64    // Note: line 1 is the first line of data (excluding the header) read from a file
+	nbSkippedLines   int64    // lines skipped by the perimeter/filter or not found in "comptes" mapping
+	nbRejectedLines  int64    // lines that have at least one parse error
 	firstParseErrors []string // capped by MaxParsingErrors, with line number rendered as string
 	fatalErrors      []string // with line number rendered as string
 	// private state vars:
-	lastSkippedLine        int // to avoid counting 2 lines if 2 "filter" errors are added on a same line
-	lastLineWithParseError int // to avoid counting 2 lines if 2 "parser" errors are added on a same line
+	lastSkippedLine        int64 // to avoid counting 2 lines if 2 "filter" errors are added on a same line
+	lastLineWithParseError int64 // to avoid counting 2 lines if 2 "parser" errors are added on a same line
 }
 
 // AddFatalError rapporte une erreur fatale liée au parsing d'un fichier

--- a/lib/marshal/tracker_test.go
+++ b/lib/marshal/tracker_test.go
@@ -24,7 +24,7 @@ func TestTracker(t *testing.T) {
 			tracker.Next()
 		}
 		report := tracker.Report("", "")
-		assert.Equal(t, expectedLinesRejected, report["linesRejected"])
+		assert.Equal(t, int64(expectedLinesRejected), report["linesRejected"])
 	})
 
 	t.Run("should report just 1 rejected line, given 2 parse errors happened on that same line", func(t *testing.T) {
@@ -35,7 +35,7 @@ func TestTracker(t *testing.T) {
 			tracker.AddParseError(fmt.Errorf("parse error %d", i))
 		}
 		report := tracker.Report("", "")
-		assert.Equal(t, expectedLinesRejected, report["linesRejected"])
+		assert.Equal(t, int64(expectedLinesRejected), report["linesRejected"])
 	})
 
 	t.Run("should report just 1 skipped line, given 2 filter errors happened on that same line", func(t *testing.T) {
@@ -46,7 +46,7 @@ func TestTracker(t *testing.T) {
 			tracker.AddFilterError(fmt.Errorf("filter error %d", i))
 		}
 		report := tracker.Report("", "")
-		assert.Equal(t, expectedLinesSkipped, report["linesSkipped"])
+		assert.Equal(t, int64(expectedLinesSkipped), report["linesSkipped"])
 	})
 
 }

--- a/lib/urssaf/urssaf_test.go
+++ b/lib/urssaf/urssaf_test.go
@@ -158,7 +158,7 @@ func TestCotisation(t *testing.T) {
 		reportData, _ := output.Events[0].ParseReport()
 		assert.Equal(t, false, reportData["isFatal"], "aucune erreur fatale ne doit être rapportée")
 		assert.Equal(t, []interface{}{}, reportData["headRejected"], "aucune erreur de parsing ne doit être rapportée")
-		assert.Equal(t, 1.0, reportData["linesValid"], "seule la ligne de cotisation liée à un établissement du périmètre doit être incluse")
+		assert.Equal(t, map[string]interface{}{"$numberLong": 1.0}, reportData["linesValid"], "seule la ligne de cotisation liée à un établissement du périmètre doit être incluse")
 	})
 
 	t.Run("toute ligne de cotisation d'un établissement non inclus dans les comptes urssaf doit être sautée silencieusement", func(t *testing.T) {
@@ -175,7 +175,7 @@ func TestCotisation(t *testing.T) {
 		reportData, _ := output.Events[0].ParseReport()
 		assert.Equal(t, false, reportData["isFatal"], "aucune erreur fatale ne doit être rapportée")
 		assert.Equal(t, []interface{}{}, reportData["headRejected"], "aucune erreur de parsing ne doit être rapportée")
-		assert.Equal(t, 1.0, reportData["linesSkipped"], "seule la ligne de cotisation liée à un établissement hors mapping doit être sautée")
+		assert.Equal(t, map[string]interface{}{"$numberLong": 1.0}, reportData["linesSkipped"], "seule la ligne de cotisation liée à un établissement hors mapping doit être sautée")
 	})
 }
 

--- a/tests/output-snapshots/test-check.golden.txt
+++ b/tests/output-snapshots/test-check.golden.txt
@@ -95,7 +95,7 @@
 				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-01-01 00:00:00 +0000 UTC"
 			],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/urssaf/testData/comptesTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 1 lignes rejetées, 0 lignes filtrées, 2 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -111,7 +111,7 @@
 				"Line 4: parse error on line 5, column 1: bare \" in non-quoted-field"
 			],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/urssaf/testData/debitCorrompuTestData.csv: intégration terminée, 5 lignes traitées, 0 erreurs fatales, 2 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -127,7 +127,7 @@
 				"Line 4: parse error on line 5, column 1: bare \" in non-quoted-field"
 			],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/urssaf/testData/debitCorrompuTestData.csv: intégration terminée, 5 lignes traitées, 0 erreurs fatales, 2 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},

--- a/tests/output-snapshots/test-import.golden.txt
+++ b/tests/output-snapshots/test-import.golden.txt
@@ -4968,7 +4968,7 @@
 				"Line 2: Pas de siret associé au compte 450359886246036238 à la période 2019-01-01 00:00:00 +0000 UTC"
 			],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/urssaf/testData/comptesTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 1 lignes rejetées, 0 lignes filtrées, 2 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -4982,7 +4982,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/apconso/testData/apconsoTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -4996,7 +4996,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/apdemande/testData/apdemandeTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5010,7 +5010,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/bdf/testData/bdfTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5024,7 +5024,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/urssaf/testData/ccsfTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5038,7 +5038,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/urssaf/testData/cotisationTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5052,7 +5052,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/urssaf/testData/debitTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5066,7 +5066,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 1,
+			"linesSkipped" : NumberLong(1),
 			"summary" : "/../lib/urssaf/testData/delaiTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 1 lignes filtrées, 2 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5080,7 +5080,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/diane/testData/dianeTestData.txt: intégration terminée, 18 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 18 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5094,7 +5094,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/urssaf/testData/effectifTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5108,7 +5108,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/urssaf/testData/effectifEntTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5124,7 +5124,7 @@
 				"Line 1: strconv.ParseInt: parsing \"Niveau de détention\": invalid syntax"
 			],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/ellisphere/testData/ellisphereTestData.excel: intégration terminée, 7 lignes traitées, 0 erreurs fatales, 1 lignes rejetées, 0 lignes filtrées, 6 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5140,7 +5140,7 @@
 				"Line 3: invalid date: 01/15/2019"
 			],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/paydex/testData/paydexTestData.csv: intégration terminée, 6 lignes traitées, 0 erreurs fatales, 1 lignes rejetées, 0 lignes filtrées, 5 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5154,7 +5154,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/urssaf/testData/procolTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5168,7 +5168,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/sirene/testData/sireneTestData.csv: intégration terminée, 3 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 3 lignes valides",
 			"batchKey" : "1910"
 		},
@@ -5182,7 +5182,7 @@
 		"event" : {
 			"headRejected" : [ ],
 			"headFatal" : [ ],
-			"linesSkipped" : 0,
+			"linesSkipped" : NumberLong(0),
 			"summary" : "/../lib/sirene_ul/testData/sireneULTestData.csv: intégration terminée, 4 lignes traitées, 0 erreurs fatales, 0 lignes rejetées, 0 lignes filtrées, 4 lignes valides",
 			"batchKey" : "1910"
 		},


### PR DESCRIPTION
Fix #353.

## Problème

Cf `"linesValid" : -668053` dans l'extrait de document de la collection `Journal`, ci-dessous:

```
{
    "_id" : ObjectId("607ea0aaef6c0e5bec291a61"),
    "commitHash" : "396671ce2c716b494453bce942aaa76d981cd720",
    "event" : {
        "linesParsed" : 31058331,
        "linesRejected" : 2533049,
        "summary" : "/2104/StockEtablissement_utf8_geo.csv: intégration terminée, 31058331 lignes traitées, 0 erreurs fatales, 2533049 lignes rejetées, 29193335 lignes filtrées, -668053 lignes valides",
        "linesValid" : -668053,
        "linesSkipped" : 29193335,
    },
    "priority" : "info",
    "parserCode" : "sirene",
    "reportType" : "ImportBatch"
}
```

## Solution

Forcer l'usage du type `int64` au lieu de `int32` pour exprimer un nombre de lignes supérieur à 2 millions. (ce qui est le cas du fichier concerné)
