### PR TITLE
fix reduce job

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -59,7 +59,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
-github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -80,7 +79,6 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -161,7 +159,6 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -179,7 +176,6 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/lib/engine/public.go
+++ b/lib/engine/public.go
@@ -86,7 +86,7 @@ func Public(batch base.AdminBatch) error {
 		chunkJob.Out = bson.M{"replace": "TemporaryCollection", "db": dbTemp}
 		i++
 
-		go MRroutine(&chunkJob, query, dbTemp, "RawData", &w, pipeChannel)
+		go MRroutine(chunkJob, query, dbTemp, "RawData", &w, pipeChannel)
 
 	}
 

--- a/lib/engine/reduce.go
+++ b/lib/engine/reduce.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	// "github.com/davecgh/go-spew/spew"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/base"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/misc"
 	"github.com/signaux-faibles/opensignauxfaibles/lib/naf"
@@ -20,7 +21,6 @@ import (
 
 // ReduceOne lance le calcul de Features pour la clé passée en argument
 func ReduceOne(batch base.AdminBatch, key, from, to string, types []string) error {
-
 	if len(key) < 9 && (from == "" && to == "") {
 		return errors.New("key minimal length of 9")
 	}
@@ -104,7 +104,7 @@ func Reduce(batch base.AdminBatch, types []string) error {
 		// Injection des fonctions JavaScript pour exécution par MongoDB
 		job.Out = bson.M{"replace": "TemporaryCollection", "db": dbTemp}
 		i++
-		go MRroutine(job, query, dbTemp, "RawData", &w, tempDBChannel)
+		go MRroutine(*job, query, dbTemp, "RawData", &w, tempDBChannel)
 
 	}
 
@@ -138,7 +138,6 @@ func Reduce(batch base.AdminBatch, types []string) error {
 	}
 
 	for _, dbTemp := range tempDBs {
-
 		err = reduceFinalAggregation(
 			db.DB(dbTemp),
 			"TemporaryCollection",
@@ -282,6 +281,7 @@ func reduceFinalAggregation(tempDatabase *mgo.Database, tempCollection, outDatab
 
 	var result []interface{}
 	err = pipe.AllowDiskUse().All(&result)
+
 	return err
 }
 


### PR DESCRIPTION
Ce fix rétablit le fonctionnement des jobs reduce qui étaient impactés par un bug situé au niveau de la fabrication des jobs de mapReduce. La méthode propageait le même pointeur à tous les jobs qui étaient donc tous instanciés pour faire le traitement dans la même base de données de destination, écrasant au passage le résultat de la tranche précédente.