### PR TITLE
fix: rendre certaines valeurs nullables dans le format apdemande

### DIFF
--- a/lib/engine/validationSchemas.go
+++ b/lib/engine/validationSchemas.go
@@ -89,7 +89,7 @@ var validationSchemas = map[string]string{
     },
     "mta": {
       "description": "Montant total autorisé",
-      "bsonType": "number"
+      "bsonType": ["number", "null"]
     },
     "effectif_autorise": {
       "description": "Effectifs autorisés",
@@ -97,14 +97,15 @@ var validationSchemas = map[string]string{
     },
     "heure_consommee": {
       "description": "Nombre total d'heures consommées",
-      "bsonType": "number"
+      "bsonType": ["number", "null"]
     },
     "montant_consommee": {
       "description": "Montant total consommé",
-      "bsonType": "number"
+      "bsonType": ["number", "null"]
     },
     "effectif_consomme": {
-      "bsonType": "number"
+      "description": "Effectifs consommés",
+      "bsonType":  ["number", "null"]
     },
     "perimetre": {
       "bsonType": "number"

--- a/validation/apdemande.schema.json
+++ b/validation/apdemande.schema.json
@@ -54,7 +54,7 @@
     },
     "mta": {
       "description": "Montant total autorisé",
-      "bsonType": "number"
+      "bsonType": ["number", "null"]
     },
     "effectif_autorise": {
       "description": "Effectifs autorisés",
@@ -62,14 +62,15 @@
     },
     "heure_consommee": {
       "description": "Nombre total d'heures consommées",
-      "bsonType": "number"
+      "bsonType": ["number", "null"]
     },
     "montant_consommee": {
       "description": "Montant total consommé",
-      "bsonType": "number"
+      "bsonType": ["number", "null"]
     },
     "effectif_consomme": {
-      "bsonType": "number"
+      "description": "Effectifs consommés",
+      "bsonType":  ["number", "null"]
     },
     "perimetre": {
       "bsonType": "number"


### PR DESCRIPTION
Dans les fichiers fournis par la DARES, certains champs peuvent être vides:
- heure_consommee
- montant_consommee
- effectif_consomme
- mta

Cette PR ajoute le type "null" sur ces clés