### PR TITLE
refactor: retrait des "go generate"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,21 +5,6 @@ on:
     branches:
 
 jobs:
-  build:
-    name: Generate and lint
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: ./go.mod
-      - run: make build
-      - name: Check that generated files are up to date (variables.json)
-        run: |
-          go generate -x ./...
-          git diff
-          exit $(git diff | wc -l)
-
   go-tests:
     name: Go tests
     runs-on: ubuntu-22.04

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Prepare container sources & resources
         shell: bash
         run: |
-          go generate -x ./...
           CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o sfdata
           cp ./sfdata ./build-container
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .DEFAULT_GOAL := build
 
 build: ## Build the sfdata binary
-	# Note: don't forget to run `go generate ./...` before building.
 	go build -o "sfdata" -ldflags "-X main.GitCommit=$(shell git rev-parse HEAD)"
 
 build-prod: ## Build the sfdata binary for our production environment

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Contact: [contact@signaux-faibles.beta.gouv.fr](mailto:contact@signaux-faibles.b
 ```bash
 $ git clone https://github.com/signaux-faibles/opensignauxfaibles.git
 $ cd opensignauxfaibles
-$ go generate ./...
 $ make build
 $ go test ./...
 ```

--- a/test-all.sh
+++ b/test-all.sh
@@ -20,9 +20,6 @@ function indent {
 set -e # will stop the script if any command fails with a non-zero exit code
 set -o pipefail # ... even for tests which pipe their output to indent
 
-heading "go generate"
-(go generate ./...) 2>&1 | indent
-
 heading "make build"
 (killall sfdata 2>/dev/null || true; make build && echo "📦 sfdata") 2>&1 | indent
 


### PR DESCRIPTION
"go generate" était utilisé pour la génération de code. Les fonctionnalités pour lesquelles c'était requis ont disparu, on peut donc retirer tous les appels à "go generate" et la documentation associée.